### PR TITLE
feat: support new data in DopplerERC20V1

### DIFF
--- a/ponder.schema.ts
+++ b/ponder.schema.ts
@@ -36,6 +36,12 @@ export const token = onchainTable(
     vestingStart: t.bigint(),
     vestingDuration: t.bigint(),
     vestedTotalAmount: t.bigint(),
+    isBalanceLimitActive: t.boolean(),
+    balanceLimitEnd: t.bigint(),
+    maxBalanceLimit: t.bigint(),
+    balanceLimitController: t.hex(),
+    balanceLimitDisabledAt: t.bigint(),
+    balanceLimitDisabledExpired: t.boolean(),
     firstSeenAt: t.bigint().notNull(),
     lastSeenAt: t.bigint().notNull(),
     pool: t.hex(),
@@ -53,6 +59,69 @@ export const token = onchainTable(
     chainIdIdx: index().on(table.chainId),
     poolIdx: index().on(table.pool),
     symbolIdx: index().on(table.symbol),
+  })
+);
+
+export const tokenVestingSchedule = onchainTable(
+  "token_vesting_schedule",
+  (t) => ({
+    token: t.hex().notNull(),
+    chainId: t.integer().notNull(),
+    scheduleId: t.bigint().notNull(),
+    cliff: t.bigint().notNull(),
+    duration: t.bigint().notNull(),
+    createdAt: t.bigint().notNull(),
+  }),
+  (table) => ({
+    pk: primaryKey({
+      columns: [table.token, table.chainId, table.scheduleId],
+    }),
+    tokenIdx: index().on(table.token),
+    chainIdIdx: index().on(table.chainId),
+  })
+);
+
+export const tokenVestingAllocation = onchainTable(
+  "token_vesting_allocation",
+  (t) => ({
+    token: t.hex().notNull(),
+    chainId: t.integer().notNull(),
+    beneficiary: t.hex().notNull(),
+    scheduleId: t.bigint().notNull(),
+    allocatedAmount: t.bigint().notNull(),
+    releasedAmount: t.bigint().notNull().default(0n),
+    createdAt: t.bigint().notNull(),
+    lastReleasedAt: t.bigint(),
+  }),
+  (table) => ({
+    pk: primaryKey({
+      columns: [table.token, table.chainId, table.beneficiary, table.scheduleId],
+    }),
+    tokenIdx: index().on(table.token),
+    beneficiaryIdx: index().on(table.beneficiary),
+    scheduleIdx: index().on(table.token, table.chainId, table.scheduleId),
+  })
+);
+
+export const tokenVestingRelease = onchainTable(
+  "token_vesting_release",
+  (t) => ({
+    txHash: t.hex().notNull(),
+    logIndex: t.integer().notNull(),
+    token: t.hex().notNull(),
+    chainId: t.integer().notNull(),
+    beneficiary: t.hex().notNull(),
+    scheduleId: t.bigint().notNull(),
+    amount: t.bigint().notNull(),
+    timestamp: t.bigint().notNull(),
+  }),
+  (table) => ({
+    pk: primaryKey({
+      columns: [table.txHash, table.logIndex, table.chainId],
+    }),
+    tokenIdx: index().on(table.token),
+    beneficiaryIdx: index().on(table.beneficiary),
+    scheduleIdx: index().on(table.token, table.chainId, table.scheduleId),
   })
 );
 
@@ -733,6 +802,42 @@ export const tokenRelations = relations(token, ({ one }) => ({
   derc20Data: one(asset, {
     fields: [token.derc20Data],
     references: [asset.address],
+  }),
+}));
+
+export const tokenVestingScheduleRelations = relations(tokenVestingSchedule, ({ one, many }) => ({
+  token: one(token, {
+    fields: [tokenVestingSchedule.token, tokenVestingSchedule.chainId],
+    references: [token.address, token.chainId],
+  }),
+  allocations: many(tokenVestingAllocation),
+  releases: many(tokenVestingRelease),
+}));
+
+export const tokenVestingAllocationRelations = relations(tokenVestingAllocation, ({ one, many }) => ({
+  token: one(token, {
+    fields: [tokenVestingAllocation.token, tokenVestingAllocation.chainId],
+    references: [token.address, token.chainId],
+  }),
+  schedule: one(tokenVestingSchedule, {
+    fields: [tokenVestingAllocation.token, tokenVestingAllocation.chainId, tokenVestingAllocation.scheduleId],
+    references: [tokenVestingSchedule.token, tokenVestingSchedule.chainId, tokenVestingSchedule.scheduleId],
+  }),
+  releases: many(tokenVestingRelease),
+}));
+
+export const tokenVestingReleaseRelations = relations(tokenVestingRelease, ({ one }) => ({
+  token: one(token, {
+    fields: [tokenVestingRelease.token, tokenVestingRelease.chainId],
+    references: [token.address, token.chainId],
+  }),
+  schedule: one(tokenVestingSchedule, {
+    fields: [tokenVestingRelease.token, tokenVestingRelease.chainId, tokenVestingRelease.scheduleId],
+    references: [tokenVestingSchedule.token, tokenVestingSchedule.chainId, tokenVestingSchedule.scheduleId],
+  }),
+  allocation: one(tokenVestingAllocation, {
+    fields: [tokenVestingRelease.token, tokenVestingRelease.chainId, tokenVestingRelease.beneficiary, tokenVestingRelease.scheduleId],
+    references: [tokenVestingAllocation.token, tokenVestingAllocation.chainId, tokenVestingAllocation.beneficiary, tokenVestingAllocation.scheduleId],
   }),
 }));
 

--- a/src/abis/DERC20ABI.ts
+++ b/src/abis/DERC20ABI.ts
@@ -65,6 +65,13 @@ export const DERC20ABI = [
   },
   {
     type: "function",
+    name: "balanceLimitEnd",
+    inputs: [],
+    outputs: [{ name: "", type: "uint48", internalType: "uint48" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
     name: "checkpoints",
     inputs: [
       { name: "account", type: "address", internalType: "address" },
@@ -95,6 +102,13 @@ export const DERC20ABI = [
     name: "currentYearStart",
     inputs: [],
     outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "controller",
+    inputs: [],
+    outputs: [{ name: "", type: "address", internalType: "address" }],
     stateMutability: "view",
   },
   {
@@ -190,6 +204,20 @@ export const DERC20ABI = [
   },
   {
     type: "function",
+    name: "isBalanceLimitActive",
+    inputs: [],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "isExcludedFromBalanceLimit",
+    inputs: [{ name: "account", type: "address", internalType: "address" }],
+    outputs: [{ name: "excluded", type: "bool", internalType: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
     name: "lastMintTimestamp",
     inputs: [],
     outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
@@ -208,6 +236,13 @@ export const DERC20ABI = [
     inputs: [],
     outputs: [],
     stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "maxBalanceLimit",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
+    stateMutability: "view",
   },
   {
     type: "function",
@@ -263,6 +298,37 @@ export const DERC20ABI = [
     type: "function",
     name: "release",
     inputs: [{ name: "amount", type: "uint256", internalType: "uint256" }],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "release",
+    inputs: [
+      { name: "scheduleId", type: "uint256", internalType: "uint256" },
+      { name: "amount", type: "uint256", internalType: "uint256" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "releaseFor",
+    inputs: [
+      { name: "beneficiary", type: "address", internalType: "address" },
+      { name: "amount", type: "uint256", internalType: "uint256" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "releaseFor",
+    inputs: [
+      { name: "beneficiary", type: "address", internalType: "address" },
+      { name: "scheduleId", type: "uint256", internalType: "uint256" },
+      { name: "amount", type: "uint256", internalType: "uint256" },
+    ],
     outputs: [],
     stateMutability: "nonpayable",
   },
@@ -345,6 +411,36 @@ export const DERC20ABI = [
   },
   {
     type: "function",
+    name: "vestingOf",
+    inputs: [
+      { name: "beneficiary", type: "address", internalType: "address" },
+      { name: "scheduleId", type: "uint256", internalType: "uint256" },
+    ],
+    outputs: [
+      { name: "totalAmount", type: "uint256", internalType: "uint256" },
+      { name: "releasedAmount", type: "uint256", internalType: "uint256" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "vestingScheduleCount",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "vestingSchedules",
+    inputs: [{ name: "", type: "uint256", internalType: "uint256" }],
+    outputs: [
+      { name: "cliff", type: "uint64", internalType: "uint64" },
+      { name: "duration", type: "uint64", internalType: "uint64" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
     name: "vestingDuration",
     inputs: [],
     outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
@@ -386,6 +482,14 @@ export const DERC20ABI = [
         indexed: false,
         internalType: "uint256",
       },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "BalanceLimitDisabled",
+    inputs: [
+      { name: "expired", type: "bool", indexed: false, internalType: "bool" },
     ],
     anonymous: false,
   },
@@ -471,6 +575,44 @@ export const DERC20ABI = [
         indexed: false,
         internalType: "uint256",
       },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "TokensReleased",
+    inputs: [
+      { name: "beneficiary", type: "address", indexed: true, internalType: "address" },
+      { name: "scheduleId", type: "uint256", indexed: true, internalType: "uint256" },
+      { name: "amount", type: "uint256", indexed: false, internalType: "uint256" },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "UpdateTokenURI",
+    inputs: [
+      { name: "tokenURI", type: "string", indexed: false, internalType: "string" },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "VestingAllocated",
+    inputs: [
+      { name: "beneficiary", type: "address", indexed: true, internalType: "address" },
+      { name: "scheduleId", type: "uint256", indexed: true, internalType: "uint256" },
+      { name: "amount", type: "uint256", indexed: false, internalType: "uint256" },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "VestingScheduleCreated",
+    inputs: [
+      { name: "scheduleId", type: "uint256", indexed: true, internalType: "uint256" },
+      { name: "cliff", type: "uint64", indexed: false, internalType: "uint64" },
+      { name: "duration", type: "uint64", indexed: false, internalType: "uint64" },
     ],
     anonymous: false,
   },

--- a/src/indexer/indexer-shared.ts
+++ b/src/indexer/indexer-shared.ts
@@ -1,5 +1,5 @@
 import { ponder } from "ponder:registry";
-import { pool } from "ponder:schema";
+import { pool, tokenVestingAllocation, tokenVestingRelease, tokenVestingSchedule } from "ponder:schema";
 import { insertV3MigrationPoolIfNotExists } from "./shared/entities/migrationPool";
 import { insertAssetIfNotExists, updateAsset } from "./shared/entities/asset";
 import { insertTokenIfNotExists, updateToken } from "./shared/entities/token";
@@ -302,4 +302,95 @@ ponder.on("DERC20:Transfer", async ({ event, context }) => {
   }
 
   await Promise.all(updatePromises);
+});
+
+ponder.on("DERC20:VestingScheduleCreated", async ({ event, context }) => {
+  const tokenAddress = event.log.address.toLowerCase() as `0x${string}`;
+  const { scheduleId, cliff, duration } = event.args;
+
+  await context.db
+    .insert(tokenVestingSchedule)
+    .values({
+      token: tokenAddress,
+      chainId: context.chain.id,
+      scheduleId,
+      cliff: BigInt(cliff),
+      duration: BigInt(duration),
+      createdAt: event.block.timestamp,
+    })
+    .onConflictDoUpdate(() => ({
+      cliff: BigInt(cliff),
+      duration: BigInt(duration),
+    }));
+});
+
+ponder.on("DERC20:VestingAllocated", async ({ event, context }) => {
+  const tokenAddress = event.log.address.toLowerCase() as `0x${string}`;
+  const beneficiary = event.args.beneficiary.toLowerCase() as `0x${string}`;
+  const { scheduleId, amount } = event.args;
+
+  await context.db
+    .insert(tokenVestingAllocation)
+    .values({
+      token: tokenAddress,
+      chainId: context.chain.id,
+      beneficiary,
+      scheduleId,
+      allocatedAmount: amount,
+      releasedAmount: 0n,
+      createdAt: event.block.timestamp,
+    })
+    .onConflictDoUpdate((existing) => ({
+      allocatedAmount: existing.allocatedAmount + amount,
+    }));
+});
+
+ponder.on("DERC20:TokensReleased", async ({ event, context }) => {
+  const tokenAddress = event.log.address.toLowerCase() as `0x${string}`;
+  const beneficiary = event.args.beneficiary.toLowerCase() as `0x${string}`;
+  const { scheduleId, amount } = event.args;
+
+  await Promise.all([
+    context.db
+      .insert(tokenVestingRelease)
+      .values({
+        txHash: event.transaction.hash,
+        logIndex: event.log.logIndex,
+        token: tokenAddress,
+        chainId: context.chain.id,
+        beneficiary,
+        scheduleId,
+        amount,
+        timestamp: event.block.timestamp,
+      })
+      .onConflictDoNothing(),
+    context.db
+      .insert(tokenVestingAllocation)
+      .values({
+        token: tokenAddress,
+        chainId: context.chain.id,
+        beneficiary,
+        scheduleId,
+        allocatedAmount: 0n,
+        releasedAmount: amount,
+        createdAt: event.block.timestamp,
+        lastReleasedAt: event.block.timestamp,
+      })
+      .onConflictDoUpdate((existing) => ({
+        releasedAmount: existing.releasedAmount + amount,
+        lastReleasedAt: event.block.timestamp,
+      })),
+  ]);
+});
+
+ponder.on("DERC20:BalanceLimitDisabled", async ({ event, context }) => {
+  await updateToken({
+    tokenAddress: event.log.address,
+    context,
+    update: {
+      isBalanceLimitActive: false,
+      balanceLimitDisabledAt: event.block.timestamp,
+      balanceLimitDisabledExpired: event.args.expired,
+    },
+  });
 });

--- a/src/indexer/shared/entities/token-optimized.ts
+++ b/src/indexer/shared/entities/token-optimized.ts
@@ -96,6 +96,42 @@ export const upsertTokenWithPool = async ({
       derc20Data: isDerc20 ? address : undefined,
       tokenUri: tokenURIResult?.result ?? "",
     };
+
+    if (isDerc20) {
+      const [
+        vestingStartResult,
+        vestingDurationResult,
+        vestedTotalAmountResult,
+        isBalanceLimitActiveResult,
+        balanceLimitEndResult,
+        maxBalanceLimitResult,
+        balanceLimitControllerResult,
+      ] = await client.multicall({
+        contracts: [
+          { abi: DERC20ABI, address, functionName: "vestingStart" },
+          { abi: DERC20ABI, address, functionName: "vestingDuration" },
+          { abi: DERC20ABI, address, functionName: "vestedTotalAmount" },
+          { abi: DERC20ABI, address, functionName: "isBalanceLimitActive" },
+          { abi: DERC20ABI, address, functionName: "balanceLimitEnd" },
+          { abi: DERC20ABI, address, functionName: "maxBalanceLimit" },
+          { abi: DERC20ABI, address, functionName: "controller" },
+        ],
+        ...multicallOptions,
+      });
+
+      tokenData = {
+        ...tokenData,
+        vestingStart: vestingStartResult.status === "success" ? vestingStartResult.result : undefined,
+        vestingDuration: vestingDurationResult.status === "success" ? vestingDurationResult.result : undefined,
+        vestedTotalAmount: vestedTotalAmountResult.status === "success" ? vestedTotalAmountResult.result : undefined,
+        isBalanceLimitActive: isBalanceLimitActiveResult.status === "success" ? isBalanceLimitActiveResult.result : undefined,
+        balanceLimitEnd: balanceLimitEndResult.status === "success" ? BigInt(balanceLimitEndResult.result) : undefined,
+        maxBalanceLimit: maxBalanceLimitResult.status === "success" ? maxBalanceLimitResult.result : undefined,
+        balanceLimitController: balanceLimitControllerResult.status === "success"
+          ? balanceLimitControllerResult.result.toLowerCase() as `0x${string}`
+          : undefined,
+      };
+    }
   }
 
   if (poolAddress) {
@@ -111,6 +147,10 @@ export const upsertTokenWithPool = async ({
         lastSeenAt: timestamp,
         // Keep existing totalSupply if it's already set
         totalSupply: existing.totalSupply || tokenData.totalSupply,
+        isBalanceLimitActive: tokenData.isBalanceLimitActive,
+        balanceLimitEnd: tokenData.balanceLimitEnd,
+        maxBalanceLimit: tokenData.maxBalanceLimit,
+        balanceLimitController: tokenData.balanceLimitController,
       }));
   } else {
     return await db

--- a/src/indexer/shared/entities/token.ts
+++ b/src/indexer/shared/entities/token.ts
@@ -162,9 +162,21 @@ export const insertTokenIfNotExists = async ({
     let vestingStart: bigint | undefined;
     let vestingDuration: bigint | undefined;
     let vestedTotalAmount: bigint | undefined;
+    let isBalanceLimitActive: boolean | undefined;
+    let balanceLimitEnd: bigint | undefined;
+    let maxBalanceLimit: bigint | undefined;
+    let balanceLimitController: Address | undefined;
 
     if (isDerc20) {
-      const [vestingStartResult, vestingDurationResult, vestedTotalAmountResult] =
+      const [
+        vestingStartResult,
+        vestingDurationResult,
+        vestedTotalAmountResult,
+        isBalanceLimitActiveResult,
+        balanceLimitEndResult,
+        maxBalanceLimitResult,
+        balanceLimitControllerResult,
+      ] =
         await context.client.multicall({
           contracts: [
             {
@@ -182,6 +194,26 @@ export const insertTokenIfNotExists = async ({
               address,
               functionName: "vestedTotalAmount",
             },
+            {
+              abi: DERC20ABI,
+              address,
+              functionName: "isBalanceLimitActive",
+            },
+            {
+              abi: DERC20ABI,
+              address,
+              functionName: "balanceLimitEnd",
+            },
+            {
+              abi: DERC20ABI,
+              address,
+              functionName: "maxBalanceLimit",
+            },
+            {
+              abi: DERC20ABI,
+              address,
+              functionName: "controller",
+            },
           ],
           ...multicallOptions,
         });
@@ -194,6 +226,18 @@ export const insertTokenIfNotExists = async ({
       }
       if (vestedTotalAmountResult?.status === "success") {
         vestedTotalAmount = vestedTotalAmountResult.result;
+      }
+      if (isBalanceLimitActiveResult?.status === "success") {
+        isBalanceLimitActive = isBalanceLimitActiveResult.result;
+      }
+      if (balanceLimitEndResult?.status === "success") {
+        balanceLimitEnd = BigInt(balanceLimitEndResult.result);
+      }
+      if (maxBalanceLimitResult?.status === "success") {
+        maxBalanceLimit = maxBalanceLimitResult.result;
+      }
+      if (balanceLimitControllerResult?.status === "success") {
+        balanceLimitController = balanceLimitControllerResult.result.toLowerCase() as Address;
       }
     }
 
@@ -261,6 +305,10 @@ export const insertTokenIfNotExists = async ({
         vestingStart,
         vestingDuration,
         vestedTotalAmount,
+        isBalanceLimitActive,
+        balanceLimitEnd,
+        maxBalanceLimit,
+        balanceLimitController,
         tokenUri: tokenURIResult?.result ?? "",
         image: image ?? "",
       })


### PR DESCRIPTION
`DopplerERC20V1` introduces new functionality like partial vesting claims and a max balance cap. ABI was expanded to support this, as well as new vesting schedule/allocation/release events and balance-limit state. New token schema fields and tables with relations were added too.

- `ponder.schema.ts`: Adds balance-limit fields to tokens and new tables/relations for vesting schedules, allocations, and releases.
- `src/abis/DERC20ABI.ts`: Expands the `DERC20` ABI for partial vesting releases, schedule reads, balance-limit reads, and new events.
- `src/indexer/indexer-shared.ts`: Indexes new vesting and balance-limit events into the added schema tables/fields.
- `src/indexer/shared/entities/token.ts`: Fetches and stores new DERC20 balance-limit metadata during token insertion.
- `src/indexer/shared/entities/token-optimized.ts`: Adds the same balance-limit metadata support to the optimized token upsert path.