### PR TITLE
feat: add local indexer gating and improve Ethereum support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ generated
 .env
 .env.local
 .pnpm-store
+ponder.config.local.ts

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This package ships with multiple Ponder configs so you can index different netwo
 - `ponder.config.ts`: Multichain (Base, Unichain, Ink) + Zora listeners on Base.
 - `ponder.config.multichain.ts`: Multichain (same scope as above).
 - `ponder.config.multicurve.ts`: Multicurve indexing setup.
-- `ponder.confg.zora.ts`: Zora‑only on Base (limits chains/contracts to Zora needs).
+- `ponder.config.zora.ts`: Zora-only on Base (limits chains/contracts to Zora needs).
 
 ## Run
 
@@ -27,7 +27,53 @@ From this package directory:
 Swap the config path to target a different setup, for example:
 
 - Multichain: `ponder dev --config ./ponder.config.multichain.ts`
-- Zora‑only: `ponder dev --config ./ponder.config.zora.ts`
+- Zora-only: `ponder dev --config ./ponder.config.zora.ts`
+
+## Local Base/Ethereum Frontend Testing
+
+Use `ponder.config.local.ts` when testing the frontend against a small local indexer for the Ethereum rollout. This config is intentionally ignored by git and should stay local to your machine. Copy `ponder.config.local.ts.example` as a reference point.
+
+From this package directory:
+
+```bash
+docker compose up -d
+pnpm run dev --config ./ponder.config.local.ts
+```
+
+The local config expects the usual local database and RPC environment variables:
+
+- `DATABASE_URL`
+- `PONDER_RPC_URL_*` entry for each utilized chain ID
+
+If you need a clean local database, reset the Docker volume and let Ponder recreate the schema:
+
+```bash
+docker compose down -v
+docker compose up -d
+pnpm run dev --config ./ponder.config.local.ts
+```
+
+### Config-Driven Handler Registration
+
+The local config also controls which indexer handlers are registered. This was necessary because Ponder loads the indexer files and validates every registered `ponder.on(...)` source against the active config. When we were only trying to test limited frontend behavior, unrelated handlers for other chains still got loaded and caused Ponder to look for sources that were not part of the local config.
+
+To keep local runs focused, handlers now register through `onIndexerEvent(...)` from `src/indexer/entrypoint.ts` instead of calling `ponder.on(...)` directly. `ponder.config.local.ts` calls `configureIndexerEntrypoint(...)` with the source names from its own `blocks` and `contracts` objects. During local runs, only handlers whose event source appears in that configured source list are registered. Without that configuration, the default behavior is unchanged and all handlers register normally.
+
+In practice, this means the Ponder config now defines both what gets indexed and which handler sources are eligible to run. For local limited-chain testing, that keeps other unrelated paths out of the run unless the local config explicitly includes them.
+
+### Local SQL Compatibility View
+
+The frontend expects a production database relation named `mv_pool_day_agg_2` for Explore/search/trending-style SQL queries. A local Ponder run creates the underlying source tables, such as `pool`, `fifteen_minute_bucket_usd`, and `volume_bucket_24h`, but Ponder does not create that custom production relation from `ponder.schema.ts`.
+
+After the local indexer has created the schema, run:
+
+```bash
+pnpm run db:local-compat
+```
+
+This applies `scripts/create-local-compat-views.sql` to the Docker Compose Postgres service and creates or replaces `public.mv_pool_day_agg_2` as a normal Postgres view. The view exposes the frontend-required columns `pool`, `volume`, `percent_day_change`, `open`, and `close` using local indexed data.
+
+Run `pnpm run db:local-compat` again any time you reset the local database with `docker compose down -v`. You do not need to rerun it for every indexer restart unless the database volume was recreated or the view was dropped.
 
 ## Notes
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "ponder dev",
     "start": "ponder start",
     "db": "ponder db",
+    "db:local-compat": "docker compose exec -T doppler-indexer-database psql -U postgres -d default -v ON_ERROR_STOP=1 -f - < scripts/create-local-compat-views.sql",
     "codegen": "ponder codegen",
     "lint": "eslint .",
     "typecheck": "tsc",

--- a/ponder.config.local.ts.example
+++ b/ponder.config.local.ts.example
@@ -1,0 +1,387 @@
+import { createConfig, factory, mergeAbis } from "ponder";
+import { getAbiItem } from "viem";
+import {
+  UniswapV3InitializerABI,
+  UniswapV4InitializerABI,
+  UniswapV3PoolABI,
+  AirlockABI,
+  DERC20ABI,
+  DopplerABI,
+  PoolManagerABI,
+  UniswapV2PairABI,
+  ZoraFactoryABI,
+  ZoraV4HookABI,
+  ZoraCreatorCoinABI,
+  V4MigratorHookABI,
+  V4MigratorABI,
+  DopplerHookInitializerABI,
+  DopplerHookMigratorABI,
+  RehypeDopplerHookMigratorABI,
+} from "./src/abis";
+import { BLOCK_INTERVALS } from "./src/config/chains/constants";
+import { chainConfigs, CHAIN_IDS } from "./src/config/chains";
+import { LockableUniswapV3InitializerABI } from "@app/abis/v3-abis/LockableUniswapV3InitializerABI";
+import { UniswapV3MigratorAbi } from "@app/abis/v3-abis/UniswapV3Migrator";
+import { UniswapV4MulticurveInitializerHookABI } from "@app/abis/multicurve-abis/UniswapV4MulticurveInitializerHookABI";
+import { UniswapV4MulticurveInitializerABI } from "@app/abis/multicurve-abis/UniswapV4MulticurveInitializerABI";
+import { configureIndexerEntrypoint } from "./src/indexer/entrypointConfig";
+
+const { base, mainnet } = chainConfigs;
+
+// First blocks at or after 2026-05-05 12:00:00 UTC.
+const LOCAL_START_BLOCKS = {
+  mainnet: 25028663,
+  base: 45596527,
+} as const;
+
+const blocks = {
+    BaseChainlinkEthPriceFeed: {
+      chain: "base",
+      startBlock: LOCAL_START_BLOCKS.base,
+      interval: BLOCK_INTERVALS.FIVE_MINUTES,
+    },
+    MainnetChainlinkEthPriceFeed: {
+      chain: "mainnet",
+      startBlock: LOCAL_START_BLOCKS.mainnet,
+      interval: BLOCK_INTERVALS.FIFTY_BLOCKS,
+    },
+    ZoraUsdcPrice: {
+      chain: "base",
+      startBlock: LOCAL_START_BLOCKS.base,
+      interval: BLOCK_INTERVALS.FIVE_MINUTES,
+    },
+    FxhWethPrice: {
+      chain: "base",
+      startBlock: LOCAL_START_BLOCKS.base,
+      interval: BLOCK_INTERVALS.FIVE_MINUTES,
+    },
+    NoiceWethPrice: {
+      chain: "base",
+      startBlock: LOCAL_START_BLOCKS.base,
+      interval: BLOCK_INTERVALS.FIVE_MINUTES,
+    },
+    EurcUsdcPrice: {
+      chain: "base",
+      startBlock: LOCAL_START_BLOCKS.base,
+      interval: BLOCK_INTERVALS.FIVE_MINUTES,
+    },
+    BankrWethPrice: {
+      chain: "base",
+      startBlock: LOCAL_START_BLOCKS.base,
+      interval: BLOCK_INTERVALS.FIVE_MINUTES,
+    },
+
+} as const;
+
+const contracts = {
+    Airlock: {
+      abi: AirlockABI,
+      chain: {
+        base: {
+          startBlock: LOCAL_START_BLOCKS.base,
+          address: base.addresses.shared.airlock,
+        },
+        mainnet: {
+          startBlock: LOCAL_START_BLOCKS.mainnet,
+          address: mainnet.addresses.shared.airlock,
+        },
+      },
+    },
+    MigrationPool: {
+      abi: mergeAbis([UniswapV3PoolABI, UniswapV2PairABI]),
+      chain: {
+        base: {
+          startBlock: LOCAL_START_BLOCKS.base,
+          address: factory({
+            address: base.addresses.shared.airlock,
+            event: getAbiItem({ abi: AirlockABI, name: "Migrate" }),
+            parameter: "pool",
+          }),
+        },
+        mainnet: {
+          startBlock: LOCAL_START_BLOCKS.mainnet,
+          address: factory({
+            address: mainnet.addresses.shared.airlock,
+            event: getAbiItem({ abi: AirlockABI, name: "Migrate" }),
+            parameter: "pool",
+          }),
+        },
+      },
+    },
+    UniswapV3Initializer: {
+      abi: UniswapV3InitializerABI,
+      chain: {
+        base: {
+          startBlock: LOCAL_START_BLOCKS.base,
+          address: base.addresses.v3.v3Initializer,
+        },
+      },
+    },
+    DERC20: {
+      abi: DERC20ABI,
+      chain: {
+        base: {
+          startBlock: LOCAL_START_BLOCKS.base,
+          address: factory({
+            address: base.addresses.shared.airlock,
+            event: getAbiItem({ abi: AirlockABI, name: "Create" }),
+            parameter: "asset",
+          }),
+        },
+        mainnet: {
+          startBlock: LOCAL_START_BLOCKS.mainnet,
+          address: factory({
+            address: mainnet.addresses.shared.airlock,
+            event: getAbiItem({ abi: AirlockABI, name: "Create" }),
+            parameter: "asset",
+          }),
+        },
+      },
+    },
+    UniswapV3Migrator: {
+      abi: UniswapV3MigratorAbi,
+      chain: {
+        base: {
+          startBlock: LOCAL_START_BLOCKS.base,
+          address: base.addresses.v3.v3Migrator,
+        },
+      },
+    },
+    UniswapV3Pool: {
+      abi: UniswapV3PoolABI,
+      chain: {
+        base: {
+          startBlock: LOCAL_START_BLOCKS.base,
+          address: factory({
+            address: base.addresses.v3.v3Initializer,
+            event: getAbiItem({ abi: UniswapV3InitializerABI, name: "Create" }),
+            parameter: "poolOrHook",
+          }),
+        },
+      },
+    },
+    LockableUniswapV3Pool: {
+      abi: UniswapV3PoolABI,
+      chain: {
+        base: {
+          startBlock: LOCAL_START_BLOCKS.base,
+          address: factory({
+            address: base.addresses.v3.lockableV3Initializer,
+            event: getAbiItem({
+              abi: LockableUniswapV3InitializerABI,
+              name: "Create",
+            }),
+            parameter: "poolOrHook",
+          }),
+        },
+      },
+    },
+    PoolManager: {
+      abi: PoolManagerABI,
+      chain: {
+        base: {
+          startBlock: LOCAL_START_BLOCKS.base,
+          address: base.addresses.v4.poolManager,
+        },
+        mainnet: {
+          startBlock: LOCAL_START_BLOCKS.mainnet,
+          address: mainnet.addresses.v4.poolManager,
+        },
+      },
+    },
+    UniswapV4MigratorHook: {
+      abi: V4MigratorHookABI,
+      chain: {
+        base: {
+          startBlock: LOCAL_START_BLOCKS.base,
+          address: base.addresses.v4.v4MigratorHook,
+        },
+        mainnet: {
+          startBlock: LOCAL_START_BLOCKS.mainnet,
+          address: mainnet.addresses.v4.v4MigratorHook,
+        },
+      },
+    },
+    UniswapV4Migrator: {
+      abi: V4MigratorABI,
+      chain: {
+        base: {
+          startBlock: LOCAL_START_BLOCKS.base,
+          address: base.addresses.v4.v4Migrator,
+        },
+        mainnet: {
+          startBlock: LOCAL_START_BLOCKS.mainnet,
+          address: mainnet.addresses.v4.v4Migrator,
+        },
+      },
+    },
+    UniswapV4Pool: {
+      abi: DopplerABI,
+      chain: {
+        base: {
+          startBlock: LOCAL_START_BLOCKS.base,
+          address: factory({
+            address: base.addresses.v4.v4Initializer,
+            event: getAbiItem({ abi: UniswapV4InitializerABI, name: "Create" }),
+            parameter: "poolOrHook",
+          }),
+        },
+        mainnet: {
+          startBlock: LOCAL_START_BLOCKS.mainnet,
+          address: factory({
+            address: mainnet.addresses.v4.v4Initializer,
+            event: getAbiItem({ abi: UniswapV4InitializerABI, name: "Create" }),
+            parameter: "poolOrHook",
+          }),
+        },
+      },
+    },
+    UniswapV4Initializer: {
+      abi: UniswapV4InitializerABI,
+      chain: {
+        base: {
+          startBlock: LOCAL_START_BLOCKS.base,
+          address: base.addresses.v4.v4Initializer,
+        },
+        mainnet: {
+          startBlock: LOCAL_START_BLOCKS.mainnet,
+          address: mainnet.addresses.v4.v4Initializer,
+        },
+      },
+    },
+    LockableUniswapV3Initializer: {
+      abi: LockableUniswapV3InitializerABI,
+      chain: {
+        base: {
+          startBlock: LOCAL_START_BLOCKS.base,
+          address: base.addresses.v3.lockableV3Initializer,
+        },
+      },
+    },
+    ZoraFactory: {
+      abi: ZoraFactoryABI,
+      chain: {
+        base: {
+          startBlock: LOCAL_START_BLOCKS.base,
+          address: base.addresses.zora.zoraFactory,
+        },
+      },
+    },
+    ZoraCreatorCoinV4: {
+      abi: ZoraCreatorCoinABI,
+      chain: {
+        base: {
+          startBlock: LOCAL_START_BLOCKS.base,
+          address: factory({
+            address: base.addresses.zora.zoraFactory,
+            event: getAbiItem({
+              abi: ZoraFactoryABI,
+              name: "CreatorCoinCreated",
+            }),
+            parameter: "coin",
+          }),
+        },
+      },
+    },
+    ZoraV4CreatorCoinHook: {
+      abi: ZoraV4HookABI,
+      chain: {
+        base: {
+          startBlock: LOCAL_START_BLOCKS.base,
+          address: factory({
+            address: base.addresses.zora.zoraFactory,
+            event: getAbiItem({
+              abi: ZoraFactoryABI,
+              name: "CreatorCoinCreated",
+            }),
+            parameter: "poolKey.hooks",
+          }),
+        },
+      },
+    },
+    UniswapV4MulticurveInitializer: {
+      abi: UniswapV4MulticurveInitializerABI,
+      chain: {
+        base: {
+          startBlock: LOCAL_START_BLOCKS.base,
+          address: base.addresses.v4.v4MulticurveInitializer,
+        },
+      },
+    },
+    UniswapV4MulticurveInitializerHook: {
+      abi: UniswapV4MulticurveInitializerHookABI,
+      chain: {
+        base: {
+          startBlock: LOCAL_START_BLOCKS.base,
+          address: base.addresses.v4.v4MulticurveInitializerHook,
+        },
+      },
+    },
+    DecayMulticurveInitializer: {
+      abi: UniswapV4MulticurveInitializerABI,
+      chain: {
+        base: {
+          startBlock: LOCAL_START_BLOCKS.base,
+          address: base.addresses.v4.DecayMulticurveInitializer,
+        },
+      },
+    },
+    DecayMulticurveInitializerHook: {
+      abi: UniswapV4MulticurveInitializerHookABI,
+      chain: {
+        base: {
+          startBlock: LOCAL_START_BLOCKS.base,
+          address: base.addresses.v4.DecayMulticurveInitializerHook,
+        },
+      },
+    },
+    DopplerHookInitializer: {
+      abi: DopplerHookInitializerABI,
+      chain: {
+        base: {
+          startBlock: LOCAL_START_BLOCKS.base,
+          address: base.addresses.v4.DopplerHookInitializer,
+        },
+        mainnet: {
+          startBlock: LOCAL_START_BLOCKS.mainnet,
+          address: mainnet.addresses.v4.DopplerHookInitializer,
+        },
+      },
+    },
+    DopplerHookMigrator: {
+      abi: DopplerHookMigratorABI,
+      chain: {},
+    },
+    RehypeDopplerHookMigrator: {
+      abi: RehypeDopplerHookMigratorABI,
+      chain: {},
+    },
+
+} as const;
+
+configureIndexerEntrypoint({
+  sources: [...Object.keys(blocks), ...Object.keys(contracts)],
+});
+
+export default createConfig({
+  database: {
+    kind: "postgres",
+    connectionString: process.env.DATABASE_URL,
+    poolConfig: {
+      max: 100,
+    },
+  },
+  ordering: "multichain",
+  chains: {
+    mainnet: {
+      id: CHAIN_IDS.mainnet,
+      rpc: process.env.PONDER_RPC_URL_1,
+    },
+    base: {
+      id: CHAIN_IDS.base,
+      rpc: process.env.PONDER_RPC_URL_8453,
+    },
+  },
+  blocks,
+  contracts,
+});

--- a/ponder.config.ts
+++ b/ponder.config.ts
@@ -495,8 +495,8 @@ export default createConfig({
         monad: {
           startBlock: monad.startBlock,
           address: factory({
-            address: monad.addresses.v4.v4ScheduledMulticurveInitializer,
-            event: getAbiItem({ abi: UniswapV4ScheduledMulticurveInitializerABI, name: "Create"}),
+            address: monad.addresses.v4.v4Initializer,
+            event: getAbiItem({ abi: UniswapV4InitializerABI, name: "Create"}),
             parameter: "poolOrHook"
           }),
         },

--- a/ponder.config.ts
+++ b/ponder.config.ts
@@ -503,8 +503,8 @@ export default createConfig({
         mainnet: {
           startBlock: mainnet.v4StartBlock,
           address: factory({
-            address: mainnet.addresses.v4.v4ScheduledMulticurveInitializer,
-            event: getAbiItem({ abi: UniswapV4ScheduledMulticurveInitializerABI, name: "Create" }),
+            address: mainnet.addresses.v4.v4Initializer,
+            event: getAbiItem({ abi: UniswapV4InitializerABI, name: "Create" }),
             parameter: "poolOrHook",
           }),
         }

--- a/scripts/create-local-compat-views.sql
+++ b/scripts/create-local-compat-views.sql
@@ -1,0 +1,32 @@
+CREATE OR REPLACE VIEW public.mv_pool_day_agg_2 AS
+WITH latest_ohlc AS (
+  SELECT DISTINCT ON (pool, chain_id)
+    pool,
+    chain_id,
+    open,
+    close,
+    volume_usd
+  FROM public.fifteen_minute_bucket_usd
+  ORDER BY pool, chain_id, minute_id DESC
+), latest_volume AS (
+  SELECT DISTINCT ON (pool_address, chain_id)
+    pool_address,
+    chain_id,
+    volume_usd
+  FROM public.volume_bucket_24h
+  ORDER BY pool_address, chain_id, timestamp DESC
+)
+SELECT
+  p.address AS pool,
+  p.chain_id,
+  COALESCE(latest_volume.volume_usd, latest_ohlc.volume_usd, p.volume_usd) AS volume,
+  p.percent_day_change,
+  COALESCE(latest_ohlc.open, p.price) AS open,
+  COALESCE(latest_ohlc.close, p.price) AS close
+FROM public.pool AS p
+LEFT JOIN latest_ohlc
+  ON latest_ohlc.pool = p.address
+  AND latest_ohlc.chain_id = p.chain_id
+LEFT JOIN latest_volume
+  ON latest_volume.pool_address = p.address
+  AND latest_volume.chain_id = p.chain_id;

--- a/src/config/chains/mainnet.ts
+++ b/src/config/chains/mainnet.ts
@@ -13,6 +13,7 @@ export const mainnetConfig: ChainConfig = {
   id: CHAIN_IDS.mainnet,
   name: "mainnet",
   startBlock: START_BLOCKS.mainnet,
+  v4StartBlock: V4_START_BLOCKS.mainnet,
   oracleStartBlock: START_BLOCKS.mainnet,
   rpcEnvVar: RPC_ENV_VARS.mainnet,
   addresses: {

--- a/src/indexer/blockHandlers.ts
+++ b/src/indexer/blockHandlers.ts
@@ -1,4 +1,4 @@
-import { ponder } from "ponder:registry";
+import { onIndexerEvent } from "./entrypoint";
 import { ChainlinkOracleABI } from "@app/abis/ChainlinkOracleABI";
 import { ethPrice, zoraUsdcPrice, fxhWethPrice, noiceWethPrice, monadUsdcPrice, eurcUsdcPrice, bankrWethPrice, usdcPrice, usdtPrice } from "ponder.schema";
 import { UniswapV3PoolABI } from "@app/abis/v3-abis/UniswapV3PoolABI";
@@ -7,7 +7,7 @@ import { PriceService } from "@app/core";
 import { chainConfigs } from "@app/config";
 import { parseUnits, zeroAddress, createPublicClient, http, numberToHex } from "viem";
 
-ponder.on("BaseChainlinkEthPriceFeed:block", async ({ event, context }) => {
+onIndexerEvent("BaseChainlinkEthPriceFeed:block", async ({ event, context }) => {
   const { db, client, chain } = context;
   const { timestamp } = event.block;
 
@@ -32,7 +32,7 @@ ponder.on("BaseChainlinkEthPriceFeed:block", async ({ event, context }) => {
     .onConflictDoNothing();
 });
 
-ponder.on("MainnetChainlinkEthPriceFeed:block", async ({ event, context }) => {
+onIndexerEvent("MainnetChainlinkEthPriceFeed:block", async ({ event, context }) => {
   const { db, client, chain } = context;
   const { timestamp } = event.block;
 
@@ -57,7 +57,7 @@ ponder.on("MainnetChainlinkEthPriceFeed:block", async ({ event, context }) => {
     .onConflictDoNothing();
 });
 
-ponder.on("SepoliaChainlinkEthPriceFeed:block", async ({ event, context }) => {
+onIndexerEvent("SepoliaChainlinkEthPriceFeed:block", async ({ event, context }) => {
   const { db, client, chain } = context;
   const { timestamp } = event.block;
 
@@ -82,7 +82,7 @@ ponder.on("SepoliaChainlinkEthPriceFeed:block", async ({ event, context }) => {
     .onConflictDoNothing();
 });
 
-ponder.on("UnichainChainlinkEthPriceFeed:block", async ({ event, context }) => {
+onIndexerEvent("UnichainChainlinkEthPriceFeed:block", async ({ event, context }) => {
   const { db, client, chain } = context;
   const { timestamp } = event.block;
 
@@ -107,7 +107,7 @@ ponder.on("UnichainChainlinkEthPriceFeed:block", async ({ event, context }) => {
     .onConflictDoNothing();
 });
 
-ponder.on("InkChainlinkEthPriceFeed:block", async ({ event, context }) => {
+onIndexerEvent("InkChainlinkEthPriceFeed:block", async ({ event, context }) => {
   const { db, client, chain } = context;
   const { timestamp } = event.block;
 
@@ -132,7 +132,7 @@ ponder.on("InkChainlinkEthPriceFeed:block", async ({ event, context }) => {
     .onConflictDoNothing();
 });
 
-ponder.on("MonadChainlinkEthPriceFeed:block", async ({ event, context }) => {
+onIndexerEvent("MonadChainlinkEthPriceFeed:block", async ({ event, context }) => {
   const { db, client, chain } = context;
   const { timestamp } = event.block;
 
@@ -157,7 +157,7 @@ ponder.on("MonadChainlinkEthPriceFeed:block", async ({ event, context }) => {
     .onConflictDoNothing();
 });
 
-ponder.on("ZoraUsdcPrice:block", async ({ event, context }) => {
+onIndexerEvent("ZoraUsdcPrice:block", async ({ event, context }) => {
   const { db, client, chain } = context;
   const { timestamp, number: blockNumber } = event.block;
   const poolAddress = chainConfigs[chain.name].addresses.zora.zoraTokenPool;
@@ -231,7 +231,7 @@ ponder.on("ZoraUsdcPrice:block", async ({ event, context }) => {
   }
 });
 
-ponder.on(
+onIndexerEvent(
   "BaseSepoliaChainlinkEthPriceFeed:block",
   async ({ event, context }) => {
     const { db, client, chain } = context;
@@ -259,7 +259,7 @@ ponder.on(
   }
 );
 
-ponder.on("FxhWethPrice:block", async ({ event, context }) => {
+onIndexerEvent("FxhWethPrice:block", async ({ event, context }) => {
   const { db, client, chain } = context;
   const { timestamp } = event.block;
 
@@ -291,7 +291,7 @@ ponder.on("FxhWethPrice:block", async ({ event, context }) => {
     .onConflictDoNothing();
 });
 
-ponder.on("NoiceWethPrice:block", async ({ event, context }) => {
+onIndexerEvent("NoiceWethPrice:block", async ({ event, context }) => {
   const { db, client, chain } = context;
   const { timestamp } = event.block;
 
@@ -323,7 +323,7 @@ ponder.on("NoiceWethPrice:block", async ({ event, context }) => {
     .onConflictDoNothing();
 });
 
-ponder.on("MonadUsdcPrice:block", async ({ event, context }) => {
+onIndexerEvent("MonadUsdcPrice:block", async ({ event, context }) => {
   const { db, client, chain } = context;
   const { timestamp, number: blockNumber } = event.block;
   
@@ -383,7 +383,7 @@ ponder.on("MonadUsdcPrice:block", async ({ event, context }) => {
     .onConflictDoNothing();
 });
 
-ponder.on("EurcUsdcPrice:block", async ({ event, context }) => {
+onIndexerEvent("EurcUsdcPrice:block", async ({ event, context }) => {
   const { db, client, chain } = context;
   const { timestamp } = event.block;
   
@@ -424,7 +424,7 @@ ponder.on("EurcUsdcPrice:block", async ({ event, context }) => {
   }
 });
 
-ponder.on("BankrWethPrice:block", async ({ event, context }) => {
+onIndexerEvent("BankrWethPrice:block", async ({ event, context }) => {
   const { db, client, chain } = context;
   const { timestamp } = event.block;
 

--- a/src/indexer/entrypoint.ts
+++ b/src/indexer/entrypoint.ts
@@ -1,0 +1,28 @@
+import { ponder } from "ponder:registry";
+import { getConfiguredIndexerSources } from "./entrypointConfig";
+
+function getSourceName(eventName: string): string {
+  const separatorIndex = eventName.indexOf(":");
+
+  if (separatorIndex === -1) {
+    return eventName;
+  }
+
+  return eventName.slice(0, separatorIndex);
+}
+
+function shouldRegister(eventName: string): boolean {
+  const configuredSources = getConfiguredIndexerSources();
+
+  if (configuredSources === null) {
+    return true;
+  }
+
+  return configuredSources.has(getSourceName(eventName));
+}
+
+export const onIndexerEvent = ((eventName, handler) => {
+  if (shouldRegister(String(eventName))) {
+    return ponder.on(eventName as never, handler as never);
+  }
+}) as typeof ponder.on;

--- a/src/indexer/entrypointConfig.ts
+++ b/src/indexer/entrypointConfig.ts
@@ -1,0 +1,19 @@
+export interface IndexerEntrypointConfig {
+  sources: Iterable<string>;
+}
+
+const INDEXER_SOURCES_ENV = "DOPPLER_INDEXER_SOURCES";
+
+export function configureIndexerEntrypoint(config: IndexerEntrypointConfig): void {
+  process.env[INDEXER_SOURCES_ENV] = Array.from(config.sources).join(",");
+}
+
+export function getConfiguredIndexerSources(): Set<string> | null {
+  const configuredSources = process.env[INDEXER_SOURCES_ENV];
+
+  if (configuredSources === undefined) {
+    return null;
+  }
+
+  return new Set(configuredSources.split(",").filter(Boolean));
+}

--- a/src/indexer/indexer-dhook.ts
+++ b/src/indexer/indexer-dhook.ts
@@ -1,4 +1,4 @@
-import { ponder } from "ponder:registry";
+import { onIndexerEvent } from "./entrypoint";
 import { getPoolId } from "@app/utils/v4-utils";
 import { insertTokenIfNotExists } from "./shared/entities/token";
 import { insertPoolIfNotExistsDHook, updatePool } from "./shared/entities/pool";
@@ -72,7 +72,7 @@ async function fetchPositions({
   return getPositionsForPool({ poolId, context });
 }
 
-ponder.on("DopplerHookInitializer:Create", async ({ event, context }) => {
+onIndexerEvent("DopplerHookInitializer:Create", async ({ event, context }) => {
   const { poolOrHook, asset: assetId, numeraire } = event.args;
   const { block, transaction } = event;
   const timestamp = block.timestamp;
@@ -188,7 +188,7 @@ ponder.on("DopplerHookInitializer:Create", async ({ event, context }) => {
   });
 });
 
-ponder.on("DopplerHookInitializer:Collect", async ({ event, context }) => {
+onIndexerEvent("DopplerHookInitializer:Collect", async ({ event, context }) => {
   const { poolId } = event.args;
   const timestamp = event.block.timestamp;
   const { db, chain } = context;
@@ -224,7 +224,7 @@ ponder.on("DopplerHookInitializer:Collect", async ({ event, context }) => {
   });
 });
 
-ponder.on("DopplerHookInitializer:Swap", async ({ event, context }) => {
+onIndexerEvent("DopplerHookInitializer:Swap", async ({ event, context }) => {
   const { sender, poolKey: poolKeyTuple, poolId, params, amount0, amount1 } = event.args;
   const timestamp = event.block.timestamp;
   const { chain, client, db } = context;
@@ -405,7 +405,7 @@ ponder.on("DopplerHookInitializer:Swap", async ({ event, context }) => {
   ]);
 });
 
-ponder.on("DopplerHookInitializer:ModifyLiquidity", async ({ event, context }) => {
+onIndexerEvent("DopplerHookInitializer:ModifyLiquidity", async ({ event, context }) => {
   const { key: poolKeyTuple } = event.args;
   const timestamp = event.block.timestamp;
   const { chain, client, db } = context;

--- a/src/indexer/indexer-shared.ts
+++ b/src/indexer/indexer-shared.ts
@@ -1,4 +1,4 @@
-import { ponder } from "ponder:registry";
+import { onIndexerEvent } from "./entrypoint";
 import { pool, tokenVestingAllocation, tokenVestingRelease, tokenVestingSchedule } from "ponder:schema";
 import { insertV3MigrationPoolIfNotExists } from "./shared/entities/migrationPool";
 import { insertAssetIfNotExists, updateAsset } from "./shared/entities/asset";
@@ -13,7 +13,7 @@ import { zeroAddress } from "viem";
 import { getV4MigratorForAsset, getDHookMigratorForAsset } from "@app/utils/v4-utils";
 import { isPrecompileAddress } from "@app/utils/validation";
 
-ponder.on("Airlock:Migrate", async ({ event, context }) => {
+onIndexerEvent("Airlock:Migrate", async ({ event, context }) => {
   const { timestamp } = event.block;
   const assetId = event.args.asset.toLowerCase() as `0x${string}`;
   const migrationPoolAddress = event.args.pool.toLowerCase() as `0x${string}`;
@@ -184,7 +184,7 @@ ponder.on("Airlock:Migrate", async ({ event, context }) => {
   }
 });
 
-ponder.on("DERC20:Transfer", async ({ event, context }) => {
+onIndexerEvent("DERC20:Transfer", async ({ event, context }) => {
   const { address } = event.log;
   const { timestamp } = event.block;
   const { from, to, value } = event.args;
@@ -304,7 +304,7 @@ ponder.on("DERC20:Transfer", async ({ event, context }) => {
   await Promise.all(updatePromises);
 });
 
-ponder.on("DERC20:VestingScheduleCreated", async ({ event, context }) => {
+onIndexerEvent("DERC20:VestingScheduleCreated", async ({ event, context }) => {
   const tokenAddress = event.log.address.toLowerCase() as `0x${string}`;
   const { scheduleId, cliff, duration } = event.args;
 
@@ -324,7 +324,7 @@ ponder.on("DERC20:VestingScheduleCreated", async ({ event, context }) => {
     }));
 });
 
-ponder.on("DERC20:VestingAllocated", async ({ event, context }) => {
+onIndexerEvent("DERC20:VestingAllocated", async ({ event, context }) => {
   const tokenAddress = event.log.address.toLowerCase() as `0x${string}`;
   const beneficiary = event.args.beneficiary.toLowerCase() as `0x${string}`;
   const { scheduleId, amount } = event.args;
@@ -345,7 +345,7 @@ ponder.on("DERC20:VestingAllocated", async ({ event, context }) => {
     }));
 });
 
-ponder.on("DERC20:TokensReleased", async ({ event, context }) => {
+onIndexerEvent("DERC20:TokensReleased", async ({ event, context }) => {
   const tokenAddress = event.log.address.toLowerCase() as `0x${string}`;
   const beneficiary = event.args.beneficiary.toLowerCase() as `0x${string}`;
   const { scheduleId, amount } = event.args;
@@ -383,7 +383,7 @@ ponder.on("DERC20:TokensReleased", async ({ event, context }) => {
   ]);
 });
 
-ponder.on("DERC20:BalanceLimitDisabled", async ({ event, context }) => {
+onIndexerEvent("DERC20:BalanceLimitDisabled", async ({ event, context }) => {
   await updateToken({
     tokenAddress: event.log.address,
     context,

--- a/src/indexer/indexer-v2.ts
+++ b/src/indexer/indexer-v2.ts
@@ -1,4 +1,4 @@
-import { ponder } from "ponder:registry";
+import { onIndexerEvent } from "./entrypoint";
 import { v2Pool } from "ponder.schema";
 import { getPairData } from "@app/utils/v2-utils/getPairData";
 import { fetchEthPrice } from "./shared/oracle";
@@ -15,7 +15,7 @@ import { chainConfigs } from "@app/config";
 import { SwapService, SwapOrchestrator, PriceService, MarketDataService } from "@app/core";
 import { updateFifteenMinuteBucketUsd } from "@app/utils/time-buckets";
 
-ponder.on("MigrationPool:Swap(address indexed sender, uint256 amount0In, uint256 amount1In, uint256 amount0Out, uint256 amount1Out, address indexed to)", async ({ event, context }) => {
+onIndexerEvent("MigrationPool:Swap(address indexed sender, uint256 amount0In, uint256 amount1In, uint256 amount0Out, uint256 amount1Out, address indexed to)", async ({ event, context }) => {
   const { db, chain } = context;
   const { timestamp } = event.block;
   const { amount0In, amount1In, amount0Out, amount1Out } = event.args;

--- a/src/indexer/indexer-v3.ts
+++ b/src/indexer/indexer-v3.ts
@@ -2,7 +2,7 @@ import { PriceService, SwapOrchestrator, SwapService, MarketDataService } from "
 import { CHAINLINK_ETH_DECIMALS, WAD } from "@app/utils/constants";
 import { computeGraduationThresholdDelta } from "@app/utils/v3-utils/computeGraduationThreshold";
 import { isPrecompileAddress } from "@app/utils/validation";
-import { ponder } from "ponder:registry";
+import { onIndexerEvent } from "./entrypoint";
 import {
   insertLockableV3PoolIfNotExists,
   insertPoolIfNotExists,
@@ -19,7 +19,7 @@ import { fetchV3MigrationPool, updateMigrationPool } from "./shared/entities/mig
 import { insertAssetIfNotExists, updateAsset } from "./shared/entities";
 import { LockableUniswapV3InitializerABI, UniswapV3PoolABI } from "@app/abis";
 
-ponder.on("UniswapV3Initializer:Create", async ({ event, context }) => {
+onIndexerEvent("UniswapV3Initializer:Create", async ({ event, context }) => {
   const { poolOrHook, asset, numeraire } = event.args;
   const timestamp = event.block.timestamp;
 
@@ -68,7 +68,7 @@ ponder.on("UniswapV3Initializer:Create", async ({ event, context }) => {
   });
 });
 
-ponder.on("LockableUniswapV3Initializer:Create", async ({ event, context }) => {
+onIndexerEvent("LockableUniswapV3Initializer:Create", async ({ event, context }) => {
   const { poolOrHook, asset, numeraire } = event.args;
   const timestamp = event.block.timestamp;
 
@@ -123,7 +123,7 @@ ponder.on("LockableUniswapV3Initializer:Create", async ({ event, context }) => {
   });
 });
 
-ponder.on("LockableUniswapV3Initializer:Lock", async ({ event, context }) => {
+onIndexerEvent("LockableUniswapV3Initializer:Lock", async ({ event, context }) => {
   const { pool } = event.args;
 
   await updatePool({
@@ -135,7 +135,7 @@ ponder.on("LockableUniswapV3Initializer:Lock", async ({ event, context }) => {
   });
 });
 
-ponder.on("LockableUniswapV3Pool:Mint", async ({ event, context }) => {
+onIndexerEvent("LockableUniswapV3Pool:Mint", async ({ event, context }) => {
   const address = event.log.address.toLowerCase() as `0x${string}`;
   const { tickLower, tickUpper, amount, owner, amount0, amount1 } = event.args;
   const timestamp = event.block.timestamp;  
@@ -214,7 +214,7 @@ ponder.on("LockableUniswapV3Pool:Mint", async ({ event, context }) => {
   }
 });
 
-ponder.on("LockableUniswapV3Pool:Burn", async ({ event, context }) => {
+onIndexerEvent("LockableUniswapV3Pool:Burn", async ({ event, context }) => {
   const address = event.log.address.toLowerCase() as `0x${string}`;
   const timestamp = event.block.timestamp;
   const { tickLower, tickUpper, owner, amount, amount0, amount1 } = event.args;
@@ -289,7 +289,7 @@ ponder.on("LockableUniswapV3Pool:Burn", async ({ event, context }) => {
   ]);
 });
 
-ponder.on("LockableUniswapV3Pool:Swap", async ({ event, context }) => {
+onIndexerEvent("LockableUniswapV3Pool:Swap", async ({ event, context }) => {
   const address = event.log.address.toLowerCase() as `0x${string}`;
   const timestamp = event.block.timestamp;
   const { amount0, amount1, sqrtPriceX96 } = event.args;
@@ -471,7 +471,7 @@ ponder.on("LockableUniswapV3Pool:Swap", async ({ event, context }) => {
   ]);
 });
 
-ponder.on("UniswapV3Pool:Mint", async ({ event, context }) => {
+onIndexerEvent("UniswapV3Pool:Mint", async ({ event, context }) => {
   const address = event.log.address.toLowerCase() as `0x${string}`;
   const { tickLower, tickUpper, amount, owner, amount0, amount1 } = event.args;
   const timestamp = event.block.timestamp;  
@@ -561,7 +561,7 @@ ponder.on("UniswapV3Pool:Mint", async ({ event, context }) => {
   }
 });
 
-ponder.on("UniswapV3Pool:Burn", async ({ event, context }) => {
+onIndexerEvent("UniswapV3Pool:Burn", async ({ event, context }) => {
   const address = event.log.address.toLowerCase() as `0x${string}`;
   const timestamp = event.block.timestamp;
   const { tickLower, tickUpper, owner, amount, amount0, amount1 } = event.args;  
@@ -647,7 +647,7 @@ ponder.on("UniswapV3Pool:Burn", async ({ event, context }) => {
   ]);
 });
 
-ponder.on("UniswapV3Pool:Swap", async ({ event, context }) => {
+onIndexerEvent("UniswapV3Pool:Swap", async ({ event, context }) => {
   const { chain } = context;
   const address = event.log.address.toLowerCase() as `0x${string}`;
   const timestamp = event.block.timestamp;
@@ -836,7 +836,7 @@ ponder.on("UniswapV3Pool:Swap", async ({ event, context }) => {
   ]);
 });
 
-ponder.on("MigrationPool:Swap(address indexed sender, address indexed recipient, int256 amount0, int256 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick)", async ({ event, context }) => {
+onIndexerEvent("MigrationPool:Swap(address indexed sender, address indexed recipient, int256 amount0, int256 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick)", async ({ event, context }) => {
   const { timestamp } = event.block;
   const { amount0, amount1, sqrtPriceX96 } = event.args;
   

--- a/src/indexer/indexer-v4-decay.ts
+++ b/src/indexer/indexer-v4-decay.ts
@@ -1,4 +1,4 @@
-import { ponder } from "ponder:registry";
+import { onIndexerEvent } from "./entrypoint";
 import { getPoolId, getV4PoolData } from "@app/utils/v4-utils";
 import { isPrecompileAddress } from "@app/utils/validation";
 import { insertTokenIfNotExists } from "./shared/entities/token";
@@ -30,7 +30,7 @@ import { getQuoteInfo } from "@app/utils/getQuoteInfo";
 import { readContractWithZeroDataPadding } from "@app/utils/readContractWithZeroDataPadding";
 import { updateCumulatedFees, handleCollect } from "./shared/cumulatedFees";
 
-ponder.on(
+onIndexerEvent(
   "DecayMulticurveInitializer:Create",
   async ({ event, context }) => {
     const { asset: assetId } = event.args;
@@ -114,7 +114,7 @@ ponder.on(
   }
 );
 
-ponder.on(
+onIndexerEvent(
   "DecayMulticurveInitializer:Collect",
   async ({ event, context }) => {
     const { poolId, beneficiary, fees0, fees1 } = event.args;
@@ -156,7 +156,7 @@ ponder.on(
   }
 );
 
-ponder.on(
+onIndexerEvent(
   "DecayMulticurveInitializerHook:ModifyLiquidity",
   async ({ event, context }) => {
     const { key, params } = event.args;
@@ -256,7 +256,7 @@ ponder.on(
   }
 );
 
-ponder.on(
+onIndexerEvent(
   "DecayMulticurveInitializerHook:Swap",
   async ({ event, context }) => {
     const { poolId, sender, amount0, amount1 } = event.args;

--- a/src/indexer/indexer-v4-scheduled.ts
+++ b/src/indexer/indexer-v4-scheduled.ts
@@ -1,4 +1,4 @@
-import { ponder } from "ponder:registry";
+import { onIndexerEvent } from "./entrypoint";
 import { getPoolId, getV4PoolData } from "@app/utils/v4-utils";
 import { isPrecompileAddress } from "@app/utils/validation";
 import { insertTokenIfNotExists } from "./shared/entities/token";
@@ -30,7 +30,7 @@ import { getQuoteInfo } from "@app/utils/getQuoteInfo";
 import { readContractWithZeroDataPadding } from "@app/utils/readContractWithZeroDataPadding";
 import { updateCumulatedFees, handleCollect } from "./shared/cumulatedFees";
 
-ponder.on(
+onIndexerEvent(
   "UniswapV4ScheduledMulticurveInitializer:Create",
   async ({ event, context }) => {
     const { asset: assetId } = event.args;
@@ -113,7 +113,7 @@ ponder.on(
   }
 );
 
-ponder.on(
+onIndexerEvent(
   "UniswapV4ScheduledMulticurveInitializer:Collect",
   async ({ event, context }) => {
     const { poolId, beneficiary, fees0, fees1 } = event.args;
@@ -155,7 +155,7 @@ ponder.on(
   }
 );
 
-ponder.on(
+onIndexerEvent(
   "UniswapV4ScheduledMulticurveInitializerHook:ModifyLiquidity",
   async ({ event, context }) => {
     const { key, params } = event.args;
@@ -254,7 +254,7 @@ ponder.on(
   }
 );
 
-ponder.on(
+onIndexerEvent(
   "UniswapV4ScheduledMulticurveInitializerHook:Swap",
   async ({ event, context }) => {
     const { poolId, sender, amount0, amount1 } = event.args;

--- a/src/indexer/indexer-v4.ts
+++ b/src/indexer/indexer-v4.ts
@@ -1,4 +1,4 @@
-import { ponder } from "ponder:registry";
+import { onIndexerEvent } from "./entrypoint";
 import { getPoolId, getV4PoolData, isV4MigratorHook } from "@app/utils/v4-utils";
 import { computeV4Price } from "@app/utils/v4-utils/computeV4Price";
 import { isPrecompileAddress } from "@app/utils/validation";
@@ -33,7 +33,7 @@ import { updateCumulatedFees, handleCollect } from "./shared/cumulatedFees";
 import { computeReservesFromPositions } from "@app/utils/v4-utils/computeReservesFromPositions";
 import { upsertPositionLedger, getPositionsForPool } from "./shared/entities/positionLedger";
 
-ponder.on("UniswapV4Initializer:Create", async ({ event, context }) => {
+onIndexerEvent("UniswapV4Initializer:Create", async ({ event, context }) => {
   const { poolOrHook, asset: assetId, numeraire } = event.args;
   const { block } = event;
   const timestamp = block.timestamp;
@@ -113,7 +113,7 @@ ponder.on("UniswapV4Initializer:Create", async ({ event, context }) => {
   ]);
 });
 
-ponder.on("UniswapV4Pool:Swap", async ({ event, context }) => {
+onIndexerEvent("UniswapV4Pool:Swap", async ({ event, context }) => {
   const address = event.log.address.toLowerCase() as `0x${string}`;
   const { chain } = context;
   const { currentTick, totalProceeds, totalTokensSold } = event.args;
@@ -294,7 +294,7 @@ ponder.on("UniswapV4Pool:Swap", async ({ event, context }) => {
   ]);
 });
 
-ponder.on(
+onIndexerEvent(
   "UniswapV4MulticurveInitializer:Create",
   async ({ event, context }) => {
     const { asset: assetId } = event.args;
@@ -378,7 +378,7 @@ ponder.on(
   }
 );
 
-ponder.on(
+onIndexerEvent(
   "UniswapV4MulticurveInitializer:Collect",
   async ({ event, context }) => {
     const { poolId, beneficiary, fees0, fees1 } = event.args;
@@ -420,7 +420,7 @@ ponder.on(
   }
 );
 
-ponder.on(
+onIndexerEvent(
   "UniswapV4MulticurveInitializerHook:ModifyLiquidity",
   async ({ event, context }) => {
     const { key, params } = event.args;
@@ -505,7 +505,7 @@ ponder.on(
   }
 );
 
-ponder.on(
+onIndexerEvent(
   "UniswapV4MulticurveInitializerHook:Swap",
   async ({ event, context }) => {
     const { poolId, sender, amount0, amount1 } = event.args;
@@ -595,7 +595,7 @@ ponder.on(
   },
 );
 
-ponder.on("PoolManager:Swap", async ({ event, context }) => {
+onIndexerEvent("PoolManager:Swap", async ({ event, context }) => {
   const { id: poolId, sender, amount0, amount1, sqrtPriceX96, liquidity, tick, fee } = event.args;
   const { timestamp } = event.block;
   const { hash: txHash, from: txFrom } = event.transaction;
@@ -800,7 +800,7 @@ ponder.on("PoolManager:Swap", async ({ event, context }) => {
   ]);
 });
 
-ponder.on("UniswapV4MigratorHook:ModifyLiquidity", async ({ event, context }) => {
+onIndexerEvent("UniswapV4MigratorHook:ModifyLiquidity", async ({ event, context }) => {
   const { key } = event.args;
   const { timestamp } = event.block;
 
@@ -890,7 +890,7 @@ ponder.on("UniswapV4MigratorHook:ModifyLiquidity", async ({ event, context }) =>
   });
 });
 
-ponder.on("PoolManager:Donate", async ({ event, context }) => {
+onIndexerEvent("PoolManager:Donate", async ({ event, context }) => {
   const { id: poolId, amount0, amount1 } = event.args;
   const { timestamp } = event.block;
   const { chain } = context;
@@ -941,7 +941,7 @@ ponder.on("PoolManager:Donate", async ({ event, context }) => {
   });
 });
 
-ponder.on("PoolManager:Initialize", async ({ event, context }) => {
+onIndexerEvent("PoolManager:Initialize", async ({ event, context }) => {
   const { id: poolId, currency0, currency1, fee, tickSpacing, hooks, sqrtPriceX96, tick } = event.args;
   const { timestamp } = event.block;
   const { chain } = context;
@@ -1001,7 +1001,7 @@ ponder.on("PoolManager:Initialize", async ({ event, context }) => {
   });
 });
 
-ponder.on("PoolManager:ModifyLiquidity", async ({ event, context }) => {
+onIndexerEvent("PoolManager:ModifyLiquidity", async ({ event, context }) => {
   const { id, tickLower, tickUpper, liquidityDelta } = event.args;
   await upsertPositionLedger({
     poolId: (id as string).toLowerCase() as `0x${string}`,
@@ -1012,7 +1012,7 @@ ponder.on("PoolManager:ModifyLiquidity", async ({ event, context }) => {
   });
 });
 
-ponder.on("UniswapV4Migrator:Migrate", async ({ event, context }) => {
+onIndexerEvent("UniswapV4Migrator:Migrate", async ({ event, context }) => {
   const { poolId, sqrtPriceX96, liquidity, reserves0, reserves1 } = event.args;
   const { timestamp } = event.block;
   const { chain } = context;

--- a/src/indexer/indexer-zora.ts
+++ b/src/indexer/indexer-zora.ts
@@ -1,4 +1,4 @@
-import { ponder } from "ponder:registry";
+import { onIndexerEvent } from "./entrypoint";
 import { updateToken } from "./shared/entities/token";
 import { upsertTokenWithPool } from "./shared/entities/token-optimized";
 import {
@@ -127,7 +127,7 @@ import { computeReservesFromPositions } from "@app/utils/v4-utils";
 //   });
 // });
 
-ponder.on("ZoraFactory:CreatorCoinCreated", async ({ event, context }) => {
+onIndexerEvent("ZoraFactory:CreatorCoinCreated", async ({ event, context }) => {
   const { coin, currency, poolKey, poolKeyHash, caller } = event.args;
 
   if (isPrecompileAddress(coin) || isPrecompileAddress(currency)) {
@@ -207,7 +207,7 @@ ponder.on("ZoraFactory:CreatorCoinCreated", async ({ event, context }) => {
 //   );
 // });
 
-ponder.on("ZoraV4CreatorCoinHook:Swapped", async ({ event, context }) => {
+onIndexerEvent("ZoraV4CreatorCoinHook:Swapped", async ({ event, context }) => {
   const { db, chain } = context;
   const { poolKeyHash, swapSender, amount0, amount1, sqrtPriceX96, isCoinBuy, key } = event.args;
   const timestamp = event.block.timestamp;
@@ -264,7 +264,7 @@ ponder.on("ZoraV4CreatorCoinHook:Swapped", async ({ event, context }) => {
   );
 });
 
-ponder.on("ZoraCreatorCoinV4:LiquidityMigrated", async ({ event, context }) => {
+onIndexerEvent("ZoraCreatorCoinV4:LiquidityMigrated", async ({ event, context }) => {
   const { chain, db } = context;
   const { fromPoolKeyHash, toPoolKey, toPoolKeyHash } = event.args;
   const timestamp = event.block.timestamp;
@@ -342,7 +342,7 @@ ponder.on("ZoraCreatorCoinV4:LiquidityMigrated", async ({ event, context }) => {
   });
 });
 
-ponder.on("ZoraCreatorCoinV4:CoinTransfer", async ({ event, context }) => {
+onIndexerEvent("ZoraCreatorCoinV4:CoinTransfer", async ({ event, context }) => {
   const { address } = event.log;
   const { timestamp } = event.block;
   const { sender, recipient, senderBalance, recipientBalance } = event.args;


### PR DESCRIPTION
This branch adds the plumbing needed to run a narrowed local Ponder indexer for Base/Ethereum frontend testing, while keeping normal production handler registration unchanged by default. It also fixes mainnet V4 configuration so Ethereum and Monad indexing uses the correct initializers and start blocks where applicable.

What changed:
- Added config-driven handler registration through `onIndexerEvent(...)`, so local configs can register only sources present in the active Ponder config.
- Added a `ponder.config.local.ts.example` template for local Base/Ethereum indexing.
- Added a local SQL compatibility view for frontend queries that expect `mv_pool_day_agg_2`.
- Documented the local workflow and added a package script to apply the compatibility view.
- Fixed mainnet and monad V4 initializer wiring and added v4StartBlock to mainnet config.

File changes:
- `.gitignore`: Ignores machine-local `ponder.config.local.ts`.
- `README.md`: Documents local testing, config-gated handler registration, and the local compatibility view flow.
- `package.json`: Adds `db:local-compat` for applying the SQL view to Docker Postgres.
- `ponder.config.local.ts.example`: Adds a local Ponder config template with narrowed Base/Mainnet sources.
- `ponder.config.ts`: Updates mainnet and monad V4 pool discovery to use `v4Initializer` and `UniswapV4InitializerABI`.
- `scripts/create-local-compat-views.sql`: Creates `public.mv_pool_day_agg_2` from local indexed pool/volume/OHLC tables.
- `src/config/chains/mainnet.ts`: Adds `v4StartBlock` for mainnet.
- `src/indexer/entrypoint.ts`: Adds `onIndexerEvent(...)`, a wrapper that conditionally registers handlers.
- `src/indexer/entrypointConfig.ts`: Adds env-backed source allowlist configuration.
- `src/indexer/blockHandlers.ts`: Routes block handlers through `onIndexerEvent(...)`.
- `src/indexer/indexer-dhook.ts`: Routes Doppler hook handlers through `onIndexerEvent(...)`.
- `src/indexer/indexer-shared.ts`: Routes shared Airlock/DERC20 handlers through `onIndexerEvent(...)`.
- `src/indexer/indexer-v2.ts`: Routes V2 swap handler registration through `onIndexerEvent(...)`.
- `src/indexer/indexer-v3.ts`: Routes V3 handlers through `onIndexerEvent(...)`.
- `src/indexer/indexer-v4.ts`: Routes core V4 handlers through `onIndexerEvent(...)`.
- `src/indexer/indexer-v4-decay.ts`: Routes decay multicurve handlers through `onIndexerEvent(...)`.
- `src/indexer/indexer-v4-scheduled.ts`: Routes scheduled multicurve handlers through `onIndexerEvent(...)`.
- `src/indexer/indexer-zora.ts`: Routes Zora handlers through `onIndexerEvent(...)`.