### PR TITLE
fix: stop tagging Zora creator coins as DERC20

### DIFF
--- a/src/indexer/indexer-zora.ts
+++ b/src/indexer/indexer-zora.ts
@@ -148,7 +148,7 @@ onIndexerEvent("ZoraFactory:CreatorCoinCreated", async ({ event, context }) => {
   const [assetTokenEntity] = await Promise.all([
     upsertTokenWithPool({
       tokenAddress: coinAddress,
-      isDerc20: true,
+      isDerc20: false,
       isCreatorCoin: true,
       isContentCoin: false,
       poolAddress,
@@ -364,7 +364,7 @@ onIndexerEvent("ZoraCreatorCoinV4:CoinTransfer", async ({ event, context }) => {
   // Ensure token exists (upsert if needed)
   const finalTokenData = tokenData || await upsertTokenWithPool({
     tokenAddress,
-    isDerc20: true,
+    isDerc20: false,
     isCreatorCoin: true,
     isContentCoin: false,
     poolAddress: null,


### PR DESCRIPTION
## What

The Zora indexer was passing `isDerc20: true` to `upsertTokenWithPool` for both `ZoraFactory:CreatorCoinCreated` and `ZoraCreatorCoinV4:CoinTransfer`. Zora `CreatorCoin` contracts do not implement the DERC20-specific surface, so the gated multicall in `src/indexer/shared/entities/token.ts` (and the optimized variant) issued seven `eth_call`s per new coin that always reverted:

| Selector | Function |
|---|---|
| `0x17fc70ee` | `isBalanceLimitActive()` |
| `0x04dfe79d` | `maxBalanceLimit()` |
| `0x1514617e` | `vestingDuration()` |
| `0x254800d4` | `vestingStart()` |
| `0xcd6106f8` | `balanceLimitEnd()` |
| `0xf68d90d8` | `vestedTotalAmount()` |
| `0xf77c4791` | `controller()` |

`multicall({ allowFailure: true })` masked the throws downstream, but each failed sub-call still surfaced as `execution reverted` in RPC logs and consumed RPC budget for no benefit.

## Why

Cuts seven reverting eth_calls per new Zora creator coin and per `CoinTransfer` upsert path, removes spurious "execution reverted" noise from RPC logs.

## Notes

- `isCreatorCoin: true` is preserved on both callsites, so creator-coin classification is unchanged.
- `derc20Data` and the re-pool branch (`token.ts:86`) will now correctly skip Zora creator coins.
- Existing rows in the DB with `isDerc20: true` for Zora coins are not migrated; only new inserts/transfers are affected.