### PR TITLE
feat: gate PoolManager:ModifyLiquidity on dhook/migration pool caches

### DIFF
--- a/src/indexer/indexer-v4.ts
+++ b/src/indexer/indexer-v4.ts
@@ -12,6 +12,11 @@ import {
   isKnownV4MigrationPool,
   addToV4MigrationPoolCache,
 } from "./shared/v4MigrationPoolCache";
+import {
+  initializeDHookPoolCache,
+  isDHookPoolCacheInitialized,
+  isKnownDHookPool,
+} from "./shared/dhookPoolCache";
 
 import { insertV4ConfigIfNotExists } from "./shared/entities/v4Config";
 import { getReservesV4, getReservesMulticurve } from "@app/utils/v4-utils/getV4PoolData";
@@ -1003,8 +1008,25 @@ onIndexerEvent("PoolManager:Initialize", async ({ event, context }) => {
 
 onIndexerEvent("PoolManager:ModifyLiquidity", async ({ event, context }) => {
   const { id, tickLower, tickUpper, liquidityDelta } = event.args;
+  const { chain } = context;
+  const poolId = (id as string).toLowerCase() as `0x${string}`;
+
+  if (!isDHookPoolCacheInitialized()) {
+    await initializeDHookPoolCache(context);
+  }
+  if (!isV4MigrationPoolCacheInitialized()) {
+    await initializeV4MigrationPoolCache(context);
+  }
+
+  if (
+    !isKnownDHookPool(chain.id, poolId) &&
+    !isKnownV4MigrationPool(chain.id, poolId)
+  ) {
+    return;
+  }
+
   await upsertPositionLedger({
-    poolId: (id as string).toLowerCase() as `0x${string}`,
+    poolId,
     tickLower: Number(tickLower),
     tickUpper: Number(tickUpper),
     liquidityDelta,

--- a/src/indexer/shared/dhookPoolCache.ts
+++ b/src/indexer/shared/dhookPoolCache.ts
@@ -1,0 +1,60 @@
+import { Context } from "ponder:registry";
+import { pool } from "ponder:schema";
+import { or, eq } from "ponder";
+
+const knownDHookPoolIds = new Set<string>();
+let cacheInitialized = false;
+let cacheInitializing = false;
+
+function getCacheKey(chainId: number, poolId: string): string {
+  return `${chainId}:${poolId.toLowerCase()}`;
+}
+
+export async function initializeDHookPoolCache(context: Context): Promise<void> {
+  if (cacheInitialized || cacheInitializing) {
+    return;
+  }
+
+  cacheInitializing = true;
+
+  try {
+    const { db } = context;
+
+    const dhookPools = await db.sql
+      .select({
+        address: pool.address,
+        chainId: pool.chainId,
+      })
+      .from(pool)
+      .where(or(eq(pool.type, "dhook"), eq(pool.type, "rehype")));
+
+    for (const p of dhookPools) {
+      knownDHookPoolIds.add(getCacheKey(p.chainId, p.address));
+    }
+
+    cacheInitialized = true;
+    console.log(
+      `[DHookPoolCache] Initialized with ${dhookPools.length} existing dhook/rehype pools`
+    );
+  } catch (error) {
+    console.error(`[DHookPoolCache] Failed to initialize cache:`, error);
+    cacheInitializing = false;
+    throw error;
+  }
+}
+
+export function isDHookPoolCacheInitialized(): boolean {
+  return cacheInitialized;
+}
+
+export function addToDHookPoolCache(chainId: number, poolId: string): void {
+  knownDHookPoolIds.add(getCacheKey(chainId, poolId));
+}
+
+export function isKnownDHookPool(chainId: number, poolId: string): boolean {
+  return knownDHookPoolIds.has(getCacheKey(chainId, poolId));
+}
+
+export function getDHookPoolCacheSize(): number {
+  return knownDHookPoolIds.size;
+}

--- a/src/indexer/shared/entities/pool.ts
+++ b/src/indexer/shared/entities/pool.ts
@@ -16,6 +16,7 @@ import { AssetData } from "@app/types";
 import { Network } from "@app/types/config-types";
 import { eq, and } from "ponder";
 import { isPrecompileAddress } from "@app/utils/validation";
+import { addToDHookPoolCache } from "../dhookPoolCache";
 
 export const fetchExistingPool = async ({
   poolAddress,
@@ -554,7 +555,7 @@ export const insertPoolIfNotExistsDHook = async ({
   let migrationType = getMigrationType(assetData, chain.name);
   
   const isQuoteEth = quoteInfo.quoteToken === QuoteToken.Eth;
-  return await db.insert(pool).values({
+  const inserted = await db.insert(pool).values({
     address,
     chainId: chain.id,
     tick: slot0Data.tick,
@@ -597,6 +598,10 @@ export const insertPoolIfNotExistsDHook = async ({
       : null,
     initializer: initializerAddress ? initializerAddress.toLowerCase() as `0x${string}` : null,
   });
+
+  addToDHookPoolCache(chain.id, address);
+
+  return inserted;
 };
 
 export const insertLockableV3PoolIfNotExists = async ({


### PR DESCRIPTION
## What

Adds an in-memory `dhookPoolCache` (mirroring `v4MigrationPoolCache`) and gates the `PoolManager:ModifyLiquidity` handler to only call `upsertPositionLedger` when the event's pool is either a dhook/rehype pool or a known v4 migration pool.

## Why

`PoolManager:ModifyLiquidity` was firing for every Uniswap V4 pool's liquidity change across all chains and unconditionally doing a `find` + `update`/`insert` against `position_ledger`. Prod metrics showed `position_ledger / find` accounting for ~2.8M ms of cache time — by far the largest cache cost — driven by ~1.96M completed `PoolManager:ModifyLiquidity` events.

Only dhook/rehype pools and v4 migration pools actually read from `position_ledger` (via `getPositionsForPool` in `indexer-dhook.ts` and `indexer-v4.ts`), so writes for any other v4 pool are pure overhead. The migration pool cache is included in the gate because the existing comment at `indexer-v4.ts` (`Position ledger is upserted by the PoolManager:ModifyLiquidity handler.`) confirms migration-pool reserve recomputation depends on this same upsert path.

## Changes

- `src/indexer/shared/dhookPoolCache.ts` — new module mirroring `v4MigrationPoolCache.ts`. Initialized from `pool` rows where `type IN ('dhook','rehype')`.
- `src/indexer/shared/entities/pool.ts` — `insertPoolIfNotExistsDHook` calls `addToDHookPoolCache` after insert so newly-created pools are immediately gate-eligible.
- `src/indexer/indexer-v4.ts` — `PoolManager:ModifyLiquidity` lazy-inits both caches and returns early unless the pool is in one of them.