### PR TITLE
perf(dhook): parallelize awaits in DopplerHookInitializer Swap handler

### DIFF
--- a/src/indexer/indexer-dhook.ts
+++ b/src/indexer/indexer-dhook.ts
@@ -254,7 +254,7 @@ onIndexerEvent("DopplerHookInitializer:Swap", async ({ event, context }) => {
   const { stateView } = chainConfigs[chain.name].addresses.v4;
   const initializerAddress = (poolEntity.initializer ?? event.log.address) as `0x${string}`;
 
-  const [slot0, onChainPositions] = await Promise.all([
+  const [slot0, onChainPositions, quoteInfo, tokenEntity] = await Promise.all([
     client.readContract({
       abi: StateViewABI,
       address: stateView,
@@ -268,11 +268,19 @@ onIndexerEvent("DopplerHookInitializer:Swap", async ({ event, context }) => {
       poolType: poolEntity.type,
       context,
     }),
+    getQuoteInfo(poolEntity.quoteToken, timestamp, context),
+    db.find(token, {
+      address: poolEntity.baseToken,
+      chainId: chain.id,
+    }),
   ]);
 
-  const [sqrtPriceX96, currentTick] = slot0;
+  if (!tokenEntity) {
+    console.warn(`Token not found for DHook swap: ${poolEntity.baseToken}`);
+    return;
+  }
 
-  const quoteInfo = await getQuoteInfo(poolEntity.quoteToken, timestamp, context);
+  const [sqrtPriceX96, currentTick] = slot0;
 
   const price = PriceService.computePriceFromSqrtPriceX96({
     sqrtPriceX96,
@@ -286,16 +294,6 @@ onIndexerEvent("DopplerHookInitializer:Swap", async ({ event, context }) => {
 
   const amountIn = amount0 > 0n ? BigInt(amount0) : BigInt(amount1);
   const amountOut = amount0 < 0n ? BigInt(-amount0) : BigInt(-amount1);
-
-  const tokenEntity = await db.find(token, {
-    address: poolEntity.baseToken,
-    chainId: chain.id,
-  });
-
-  if (!tokenEntity) {
-    console.warn(`Token not found for DHook swap: ${poolEntity.baseToken}`);
-    return;
-  }
 
   const marketCapUsd = MarketDataService.calculateMarketCap({
     price,
@@ -357,28 +355,27 @@ onIndexerEvent("DopplerHookInitializer:Swap", async ({ event, context }) => {
     updateAsset,
   };
 
-  await SwapOrchestrator.performSwapUpdates(
-    {
-      swapData,
-      swapType: type,
-      metrics: marketMetrics,
-      poolData: {
-        parentPoolAddress: poolAddress,
-        price,
-        quotePriceDecimals: quoteInfo.quotePriceDecimals,
-        tickLower: 0,
-        currentTick,
-        graduationTick: poolEntity.graduationTick ?? 0,
-        type: "dhook",
-        baseToken: poolEntity.baseToken,
-      },
-      chainId: chain.id,
-      context,
-    },
-    entityUpdaters
-  );
-
   await Promise.all([
+    SwapOrchestrator.performSwapUpdates(
+      {
+        swapData,
+        swapType: type,
+        metrics: marketMetrics,
+        poolData: {
+          parentPoolAddress: poolAddress,
+          price,
+          quotePriceDecimals: quoteInfo.quotePriceDecimals,
+          tickLower: 0,
+          currentTick,
+          graduationTick: poolEntity.graduationTick ?? 0,
+          type: "dhook",
+          baseToken: poolEntity.baseToken,
+        },
+        chainId: chain.id,
+        context,
+      },
+      entityUpdaters
+    ),
     updatePool({
       poolAddress,
       context,


### PR DESCRIPTION
## Summary

Removes needless sequential awaits in the `DopplerHookInitializer:Swap` handler (`src/indexer/indexer-dhook.ts`).

- Folds `getQuoteInfo` and `db.find(token, ...)` into the existing `Promise.all` alongside `slot0` and `fetchPositions`. All four only depend on `poolEntity` and can run concurrently.
- Runs `SwapOrchestrator.performSwapUpdates`, the post-swap `updatePool` (pool-level reserve/price snapshot), and `updateCumulatedFees` in a single `Promise.all`. The two `updatePool` calls overlap on `price`, `tick`, `marketCapUsd`, `dollarLiquidity`, and `lastSwapTimestamp`, and both write identical values for those fields, so concurrent execution is safe.
- `db.find(pool, ...)` stays sequential because the early-return on missing pool and the subsequent `poolKey` / precompile checks gate everything downstream.

## Why

These were the only awaits in the handler still serialized despite having no data dependency on each other. Parallelizing them reduces handler latency by roughly the cost of two RPC round trips plus two DB lookups per swap.