### PR TITLE
perf: atomic upsert for positionLedger

### DIFF
--- a/src/indexer/shared/entities/positionLedger.ts
+++ b/src/indexer/shared/entities/positionLedger.ts
@@ -18,41 +18,32 @@ export async function upsertPositionLedger({
   const { db, chain } = context;
   const poolIdLower = poolId.toLowerCase() as `0x${string}`;
 
-  const existing = await db.find(positionLedger, {
-    poolId: poolIdLower,
-    tickLower,
-    tickUpper,
-    chainId: chain.id,
-  });
-
-  if (existing) {
-    const newLiquidity = existing.liquidity + liquidityDelta;
-    if (newLiquidity < 0n) {
-      console.error(
-        `positionLedger: negative aggregate liquidity for pool=${poolIdLower} range=[${tickLower},${tickUpper}] chain=${chain.id}: ${newLiquidity}. Possible missed event.`
-      );
-    }
-    await db
-      .update(positionLedger, {
-        poolId: poolIdLower,
-        tickLower,
-        tickUpper,
-        chainId: chain.id,
-      })
-      .set({ liquidity: newLiquidity });
-  } else {
-    if (liquidityDelta < 0n) {
-      console.error(
-        `positionLedger: inserting negative liquidity for pool=${poolIdLower} range=[${tickLower},${tickUpper}] chain=${chain.id}: ${liquidityDelta}. Possible missed event.`
-      );
-    }
-    await db.insert(positionLedger).values({
+  await db
+    .insert(positionLedger)
+    .values({
       poolId: poolIdLower,
       tickLower,
       tickUpper,
       liquidity: liquidityDelta,
       chainId: chain.id,
+    })
+    .onConflictDoUpdate((row) => {
+      const newLiquidity = row.liquidity + liquidityDelta;
+      if (newLiquidity < 0n) {
+        console.error(
+          `positionLedger: negative aggregate liquidity for pool=${poolIdLower} range=[${tickLower},${tickUpper}] chain=${chain.id}: ${newLiquidity}. Possible missed event.`
+        );
+      }
+      return { liquidity: newLiquidity };
     });
+
+  // The callback only runs on conflict, so a first-time insert with a negative
+  // delta won't be flagged from there. Mirror the original insert-path warning
+  // by checking the delta sign here.
+  if (liquidityDelta < 0n) {
+    console.error(
+      `positionLedger: negative liquidity delta for pool=${poolIdLower} range=[${tickLower},${tickUpper}] chain=${chain.id}: ${liquidityDelta}. Possible missed event.`
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

Replaces the `find` → `update`-or-`insert` pattern in `upsertPositionLedger` with a single `db.insert(...).values(...).onConflictDoUpdate(...)`.

## Why

`PoolManager:ModifyLiquidity` calls `upsertPositionLedger` unconditionally for every event (~1.96M completed events in current prod). The old read-modify-write path was doing two sequential DB roundtrips per call — a `db.find` plus a follow-up `update` or `insert` — and `position_ledger / find` is by far the largest entry in `ponder_indexing_cache_query_duration` (~2.8M ms cumulative, more than every other cache entry combined). It's also a meaningful contributor to ongoing realtime indexing lag, particularly on monad.

The atomic upsert:
- halves DB roundtrips on the ModifyLiquidity hot path
- closes the read-modify-write race window between concurrent updates against the same `(poolId, tickLower, tickUpper, chainId)`

## Behavior notes

- Negative-aggregate-after-update warning is preserved (now logged from inside the `onConflictDoUpdate` callback).
- Original "inserting negative liquidity" warning is mirrored with a post-call delta-sign check, since the conflict callback doesn't run on first inserts. As a side effect this also fires on the update branch for any negative delta — strictly noisier than before, but the cases overlap. Happy to drop it if you'd rather rely solely on the sum-negative signal.