### PR TITLE
perf: gate ponder live_query triggers on PONDER_DISABLE_LIVE_QUERY

### DIFF
--- a/patches/ponder@0.16.3.patch
+++ b/patches/ponder@0.16.3.patch
@@ -39,6 +39,51 @@ index cd8df0b2352161ca01104b4b3e4882fe6ff25a03..6cc76d99b4219ce890b085121db9ba38
                          stream.abort();
                      }
                  }
+diff --git a/dist/esm/database/actions.js b/dist/esm/database/actions.js
+index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..6fc08eb4c2b025de1a74e5280c54cd3e74d037ce 100644
+--- a/dist/esm/database/actions.js
++++ b/dist/esm/database/actions.js
+@@ -54,6 +54,14 @@ export const dropTriggers = async (qb, { tables, chainId }, context) => {
+     }, undefined, context);
+ };
+ export const createLiveQueryTriggers = async (qb, { namespaceBuild, tables, chainId, }, context) => {
++    // Gate: when PONDER_DISABLE_LIVE_QUERY=1, drop any pre-existing triggers
++    // instead of creating new ones. This avoids the per-row trigger overhead
++    // on onchain tables for projects that do not consume @ponder/client live
++    // queries.
++    if (process.env.PONDER_DISABLE_LIVE_QUERY === "1") {
++        await dropLiveQueryTriggers(qb, { namespaceBuild, tables, chainId }, context);
++        return;
++    }
+     await qb.transaction(async (tx) => {
+         const notifyProcedure = getLiveQueryNotifyProcedureName();
+         const notifyTrigger = getLiveQueryNotifyTriggerName();
+@@ -86,6 +94,11 @@ export const dropLiveQueryTriggers = async (qb, { namespaceBuild, tables, chainI
+     }, undefined, context);
+ };
+ export const createLiveQueryProcedures = async (qb, { namespaceBuild }, context) => {
++    // Gate: when PONDER_DISABLE_LIVE_QUERY=1, skip creating the unused procedures.
++    // The triggers that would call them are also skipped (see createLiveQueryTriggers).
++    if (process.env.PONDER_DISABLE_LIVE_QUERY === "1") {
++        return;
++    }
+     await qb.transaction(async (tx) => {
+         const schema = namespaceBuild.schema;
+         const procedure = getLiveQueryProcedureName();
+@@ -147,6 +160,13 @@ export const createViews = async (qb, { tables, views, namespaceBuild, }, contex
+         await tx.wrap((tx) => tx.execute(`DROP VIEW IF EXISTS "${namespaceBuild.viewsSchema}"."${PONDER_CHECKPOINT_TABLE_NAME}"`));
+         await tx.wrap((tx) => tx.execute(`CREATE VIEW "${namespaceBuild.viewsSchema}"."${PONDER_META_TABLE_NAME}" AS SELECT * FROM "${namespaceBuild.schema}"."${PONDER_META_TABLE_NAME}"`));
+         await tx.wrap((tx) => tx.execute(`CREATE VIEW "${namespaceBuild.viewsSchema}"."${PONDER_CHECKPOINT_TABLE_NAME}" AS SELECT * FROM "${namespaceBuild.schema}"."${PONDER_CHECKPOINT_TABLE_NAME}"`));
++        // Gate: when PONDER_DISABLE_LIVE_QUERY=1, also skip the views-schema notify
++        // trigger/procedure and drop any prior one so re-runs converge.
++        if (process.env.PONDER_DISABLE_LIVE_QUERY === "1") {
++            const trigger = getViewsLiveQueryNotifyTriggerName(namespaceBuild.viewsSchema);
++            await tx.wrap((tx) => tx.execute(`DROP TRIGGER IF EXISTS "${trigger}" ON "${namespaceBuild.schema}"."${PONDER_CHECKPOINT_TABLE_NAME}";`));
++            return;
++        }
+         const notifyProcedure = getLiveQueryNotifyProcedureName();
+         const channel = getLiveQueryChannelName(namespaceBuild.viewsSchema);
+         await tx.wrap((tx) => tx.execute(`
 diff --git a/dist/esm/database/queryBuilder.js b/dist/esm/database/queryBuilder.js
 index dddf085491df24a37bb1da1dcb43f76c31d0e0bb..8fefde11e9766cb645853733360bd582dba0f56c 100644
 --- a/dist/esm/database/queryBuilder.js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   ponder@0.16.3:
-    hash: d0f71b7748a907b99cdc4f4d26566d82e41fb0f96498b6c26861a076f4540073
+    hash: d0466ab6209810f1d8154df88a60e5386ddac2584140ae259a79cb0f49142f9f
     path: patches/ponder@0.16.3.patch
 
 importers:
@@ -24,7 +24,7 @@ importers:
         version: 4.3.2
       ponder:
         specifier: 0.16.3
-        version: 0.16.3(patch_hash=d0f71b7748a907b99cdc4f4d26566d82e41fb0f96498b6c26861a076f4540073)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3))
+        version: 0.16.3(patch_hash=d0466ab6209810f1d8154df88a60e5386ddac2584140ae259a79cb0f49142f9f)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3))
       viem:
         specifier: 2.30.1
         version: 2.30.1(typescript@5.9.3)
@@ -2589,6 +2589,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   viem@2.30.1:
@@ -4913,7 +4914,7 @@ snapshots:
       sonic-boom: 3.8.1
       thread-stream: 2.7.0
 
-  ponder@0.16.3(patch_hash=d0f71b7748a907b99cdc4f4d26566d82e41fb0f96498b6c26861a076f4540073)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3)):
+  ponder@0.16.3(patch_hash=d0466ab6209810f1d8154df88a60e5386ddac2584140ae259a79cb0f49142f9f)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3)):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@commander-js/extra-typings': 12.1.0(commander@12.1.0)


### PR DESCRIPTION
## Summary

Ponder installs two triggers on every onchain table to power `@ponder/client`'s `/sql/live` SSE endpoint:

- `live_query` — **per-row** trigger that `INSERT … ON CONFLICT DO NOTHING`s into a temp table for every INSERT/UPDATE/DELETE.
- `live_query_notify` — per-statement trigger on `_ponder_checkpoint` that `pg_notify`s subscribed clients at commit.

This indexer's only known downstream consumer (`pure-markets-interface`) hits `/sql/db` exclusively — no `useLiveQuery`, no `.live(` calls, no `EventSource`, no `@ponder/react` imports. The per-row trigger cost is pure overhead for our deployment.

## What changes

Extends `patches/ponder@0.16.3.patch` with three gates in `dist/esm/database/actions.js`. When `PONDER_DISABLE_LIVE_QUERY=1`:

- `createLiveQueryTriggers` delegates to `dropLiveQueryTriggers` instead of creating — idempotent cleanup for DBs that already have the triggers from prior runs.
- `createLiveQueryProcedures` no-ops. Orphan PL/pgSQL functions left over from prior runs are harmless; nothing invokes them.
- `createViews` drops any pre-existing views-schema notify trigger and skips re-creating the views-schema notify procedure/trigger.

`dropLiveQueryTriggers` is untouched so cleanup paths still work. Reorg triggers (`createTriggers`) are unrelated and untouched. The runtime's per-tx `live_query_tables` temp-table maintenance is left in place — negligible cost without the triggers writing to it, and skipping it would widen the patch surface.

## Rollout

- **Default behavior unchanged** when the env var is unset.
- To disable: set `PONDER_DISABLE_LIVE_QUERY=1` in the indexer's env. First boot cleans up existing triggers; subsequent boots are no-ops.
- To re-enable: unset the var. Next boot recreates triggers and procedures.

## Reverting

Unset `PONDER_DISABLE_LIVE_QUERY`. The next startup recreates triggers via the unchanged create paths. No DB migration required.

## Caveats

If a future consumer wants live queries, set the env var to anything other than `"1"` (or unset it) before starting that consumer's indexer environment. The `/sql/live` route in `client()` middleware will return data correctly — it just won't be pushed updates without the triggers, so live subscriptions will hang waiting for notifies. Worth a follow-up note in deploy docs if any downstream service starts depending on `/sql/live`.