### PR TITLE
perf: persist zora pool cache, derive tick from event, collapse swap writes

### DIFF
--- a/src/indexer/indexer-v4.ts
+++ b/src/indexer/indexer-v4.ts
@@ -17,6 +17,7 @@ import {
   isDHookPoolCacheInitialized,
   isKnownDHookPool,
 } from "./shared/dhookPoolCache";
+import { invalidatePoolCoinCache } from "./indexer-zora";
 
 import { insertV4ConfigIfNotExists } from "./shared/entities/v4Config";
 import { getReservesV4, getReservesMulticurve } from "@app/utils/v4-utils/getV4PoolData";
@@ -1010,6 +1011,10 @@ onIndexerEvent("PoolManager:ModifyLiquidity", async ({ event, context }) => {
   const { id, tickLower, tickUpper, liquidityDelta } = event.args;
   const { chain } = context;
   const poolId = (id as string).toLowerCase() as `0x${string}`;
+
+  // Any liquidity change on this pool invalidates the Zora hook's cached positions.
+  // No-op when the pool isn't a Zora creator-coin pool (cache miss is free).
+  invalidatePoolCoinCache(chain.id, poolId);
 
   if (!isDHookPoolCacheInitialized()) {
     await initializeDHookPoolCache(context);

--- a/src/indexer/indexer-zora.ts
+++ b/src/indexer/indexer-zora.ts
@@ -7,7 +7,7 @@ import {
 import { fetchEthPrice, fetchZoraPrice } from "./shared/oracle";
 import { batchUpsertUsersAndAssets, batchUpdateHolderCounts } from "./shared/entities/user-optimized";
 import { handleOptimizedSwap } from "./shared/swap-optimizer";
-import { StateViewABI, ZoraV4HookABI } from "@app/abis";
+import { ZoraV4HookABI } from "@app/abis";
 import { zeroAddress } from "viem";
 import { PriceService } from "@app/core";
 import { chainConfigs } from "@app/config";
@@ -16,25 +16,41 @@ import { insertZoraPoolV4Optimized } from "./shared/entities/zora/pool";
 import { getQuoteInfo, QuoteToken } from "@app/utils/getQuoteInfo";
 import { isPrecompileAddress } from "@app/utils/validation";
 import { computeReservesFromPositions } from "@app/utils/v4-utils";
+import { TickMath } from "@uniswap/v3-sdk";
+import JSBI from "jsbi";
 
-const READ_CACHE_TTL_MS = 5 * 60_000;
+// Persistent cache for ZoraV4 hook getPoolCoin reads. Positions only change when
+// PoolManager:ModifyLiquidity fires (the hook has afterAdd/RemoveLiquidity perms) or
+// when ZoraCreatorCoinV4:LiquidityMigrated moves liquidity away. Those handlers call
+// invalidatePoolCoinCache; everything else can safely reuse the cached read across blocks.
+const POOL_COIN_CACHE_MAX_SIZE = 10_000;
+const poolCoinByPool = new Map<string, Promise<unknown>>();
 
-function makeBlockCache() {
-  const cache = new Map<string, Promise<unknown>>();
-  return <T>(key: string, loader: () => Promise<T>): Promise<T> => {
-    const existing = cache.get(key) as Promise<T> | undefined;
-    if (existing) return existing;
-    const promise = loader();
-    cache.set(key, promise);
-    promise.catch(() => cache.delete(key));
-    const timer = setTimeout(() => cache.delete(key), READ_CACHE_TTL_MS);
-    timer.unref?.();
-    return promise;
-  };
+function poolCoinCacheKey(chainId: number, poolAddress: string): string {
+  return `${chainId}:${poolAddress.toLowerCase()}`;
 }
 
-const slot0Cache = makeBlockCache();
-const poolCoinCache = makeBlockCache();
+function cachedGetPoolCoin<T>(key: string, loader: () => Promise<T>): Promise<T> {
+  const existing = poolCoinByPool.get(key) as Promise<T> | undefined;
+  if (existing) {
+    // LRU touch: move to most-recently-used position.
+    poolCoinByPool.delete(key);
+    poolCoinByPool.set(key, existing);
+    return existing;
+  }
+  if (poolCoinByPool.size >= POOL_COIN_CACHE_MAX_SIZE) {
+    const oldest = poolCoinByPool.keys().next().value;
+    if (oldest !== undefined) poolCoinByPool.delete(oldest);
+  }
+  const promise = loader();
+  poolCoinByPool.set(key, promise);
+  promise.catch(() => poolCoinByPool.delete(key));
+  return promise;
+}
+
+export function invalidatePoolCoinCache(chainId: number, poolAddress: string): void {
+  poolCoinByPool.delete(poolCoinCacheKey(chainId, poolAddress));
+}
 
 // ponder.on("ZoraFactory:CoinCreatedV4", async ({ event, context }) => {
 //   const { db, chain } = context;
@@ -231,21 +247,18 @@ onIndexerEvent("ZoraV4CreatorCoinHook:Swapped", async ({ event, context }) => {
   const { poolKeyHash, swapSender, amount0, amount1, sqrtPriceX96, isCoinBuy, key } = event.args;
   const timestamp = event.block.timestamp;
   const poolAddress = poolKeyHash.toLowerCase() as `0x${string}`;
-  const cacheKey = `${context.chain.id}:${poolAddress}:${event.block.number}`;
+  const poolCoinKey = poolCoinCacheKey(context.chain.id, poolAddress);
 
   const zoraAddress = chainConfigs[context.chain.name].addresses.zora.zoraToken;
 
-  // Parallelize RPC calls (cached per (pool, block) for 5m), quote info lookup, and pool fetch.
-  const [slot0, poolCoin, quoteInfo, poolEntity] = await Promise.all([
-    slot0Cache(cacheKey, () =>
-      context.client.readContract({
-        abi: StateViewABI,
-        address: chainConfigs[context.chain.name].addresses.v4.stateView,
-        functionName: "getSlot0",
-        args: [poolAddress],
-      }),
-    ),
-    poolCoinCache(cacheKey, () =>
+  // Derive tick from the event's sqrtPriceX96 — avoids a per-swap StateView.getSlot0 RPC read.
+  const tick = TickMath.getTickAtSqrtRatio(JSBI.BigInt(sqrtPriceX96.toString()));
+
+  // Parallelize the remaining RPC call (persistently cached per pool, invalidated by
+  // PoolManager:ModifyLiquidity / ZoraCreatorCoinV4:LiquidityMigrated), quote info lookup,
+  // and pool fetch.
+  const [poolCoin, quoteInfo, poolEntity] = await Promise.all([
+    cachedGetPoolCoin(poolCoinKey, () =>
       context.client.readContract({
         abi: ZoraV4HookABI,
         address: key.hooks,
@@ -261,7 +274,6 @@ onIndexerEvent("ZoraV4CreatorCoinHook:Swapped", async ({ event, context }) => {
     return;
   }
 
-  const tick = slot0[1];
   const reserves = computeReservesFromPositions(poolCoin.positions, tick);
 
   await handleOptimizedSwap(
@@ -295,6 +307,9 @@ onIndexerEvent("ZoraCreatorCoinV4:LiquidityMigrated", async ({ event, context })
 
   const fromPoolAddress = fromPoolKeyHash.toLowerCase() as `0x${string}`;
   const toPoolAddress = toPoolKeyHash.toLowerCase() as `0x${string}`;
+
+  // Liquidity has moved off the source pool; drop any cached positions.
+  invalidatePoolCoinCache(chain.id, fromPoolAddress);
 
   const fromPoolEntity = await db.find(pool, {
     address: fromPoolAddress,

--- a/src/indexer/shared/swap-optimizer.ts
+++ b/src/indexer/shared/swap-optimizer.ts
@@ -1,10 +1,10 @@
 import { Context } from "ponder:registry";
 import { pool, token } from "ponder:schema";
 import { Address, zeroAddress } from "viem";
-import { SwapOrchestrator } from "@app/core";
 import { SwapService, MarketDataService, PriceService } from "@app/core";
 import { QuoteToken, QuoteInfo, getQuoteInfo } from "@app/utils/getQuoteInfo";
-import { updateAsset, updatePool, updatePoolDirect } from "./entities";
+import { updateAsset, updatePoolDirect } from "./entities";
+import { insertAssetIfNotExists } from "./entities/asset";
 import { chainConfigs } from "@app/config";
 import { updateFifteenMinuteBucketUsd } from "@app/utils/time-buckets";
 import { SwapType } from "@app/types";
@@ -182,83 +182,85 @@ export async function handleOptimizedSwap(
 
 
   
-  // Create swap data for orchestrator
-  const orchestratorSwapData = SwapOrchestrator.createSwapData({
-    poolAddress,
-    sender: params.transactionFrom,
-    transactionHash: params.transactionHash,
-    transactionFrom: params.transactionFrom,
-    blockNumber: params.blockNumber,
-    timestamp,
-    assetAddress: poolEntity.baseToken,
-    quoteAddress: poolEntity.quoteToken,
-    isToken0: poolEntity.isToken0,
-    amountIn: swapData.amountIn,
-    amountOut: swapData.amountOut,
-    price: swapData.price,
-    usdPrice: quoteInfo.quotePrice!,
-  });
+  const isQuoteEth = quoteInfo.quoteToken === QuoteToken.Eth;
 
-  // Create metrics
-  const metrics = {
+  // Merge the pool-level swap fields and the reserves/sqrtPrice into a single update.
+  // Previously this was two parallel writes to the same `pool` row (one via updatePool,
+  // which also did a redundant db.find, and one via updatePoolDirect); collapsing them
+  // saves one find + one update per swap.
+  const formattedPoolUpdate = SwapService.formatPoolUpdate({
+    price: swapData.price,
     liquidityUsd: swapData.dollarLiquidity,
     marketCapUsd,
-    swapValueUsd: swapData.swapValueUsd,
-  };
-  
-  // Define entity updaters
-  const entityUpdaters = {
-    updatePool,
-    updateFifteenMinuteBucketUsd,
-    updateAsset
+    timestamp,
+    tickLower: poolEntity.tickLower,
+    currentTick: params.tick,
+    graduationTick: poolEntity.graduationTick,
+    type: poolEntity.type,
+  });
+  const combinedPoolUpdate = {
+    ...formattedPoolUpdate,
+    reserves0: swapData.nextReserves0,
+    reserves1: swapData.nextReserves1,
+    sqrtPrice: params.sqrtPriceX96,
   };
 
-  const isQuoteEth = (quoteInfo.quoteToken === QuoteToken.Eth) ? true : false
-  // Execute all updates in parallel (including reserve update)
-  await Promise.all([
-    SwapOrchestrator.performSwapUpdates(
-      {
-        swapData: orchestratorSwapData,
-        swapType: swapData.swapType,
-        metrics,
-        poolData: {
-          parentPoolAddress: poolAddress,
-          price: swapData.price,
-          isQuoteEth,
-          quotePriceDecimals: quoteInfo.quotePriceDecimals,
-          tickLower: poolEntity.tickLower,
-          currentTick: params.tick,
-          graduationTick: poolEntity.graduationTick,
-          type: poolEntity.type,
-          baseToken: poolEntity.baseToken
-        },
-        chainId: chain.id,
+  const priceDivisor = quoteInfo.quotePriceDecimals !== undefined
+    ? BigInt(10) ** BigInt(quoteInfo.quotePriceDecimals)
+    : (isQuoteEth ? CHAINLINK_ETH_DECIMALS : WAD);
+
+  const assetUpdate: Record<string, unknown> = {
+    marketCapUsd,
+    liquidityUsd: swapData.dollarLiquidity,
+  };
+  if ("migrated" in formattedPoolUpdate) {
+    assetUpdate.migrated = formattedPoolUpdate.migrated;
+  }
+
+  const handleAssetUpdate = async () => {
+    try {
+      await updateAsset({
+        assetAddress: poolEntity.baseToken,
         context,
-      },
-      entityUpdaters
-    ),
+        update: assetUpdate,
+      });
+    } catch {
+      await insertAssetIfNotExists({
+        assetAddress: poolEntity.baseToken,
+        timestamp,
+        context,
+        marketCapUsd,
+        poolAddress,
+      });
+    }
+  };
+
+  await Promise.all([
+    updatePoolDirect({
+      poolAddress,
+      context,
+      update: combinedPoolUpdate,
+    }),
+    updateFifteenMinuteBucketUsd(context, {
+      poolAddress,
+      chainId: chain.id,
+      timestamp,
+      priceUsd: swapData.price * quoteInfo.quotePrice! / priceDivisor,
+      volumeUsd: swapData.swapValueUsd,
+    }),
+    handleAssetUpdate(),
     insertSwapIfNotExists({
       txHash: params.transactionHash,
       timestamp,
       context,
       pool: poolAddress,
       asset: poolEntity.baseToken,
-      chainId: context.chain.id,
+      chainId: chain.id,
       type: swapData.swapType,
       user: params.transactionFrom,
       amountIn: swapData.amountIn,
       amountOut: swapData.amountOut,
       swapValueUsd: swapData.swapValueUsd,
-    }),
-    // Update reserves directly (pool existence already verified)
-    updatePoolDirect({
-      poolAddress: poolAddress,
-      context,
-      update: {
-        reserves0: swapData.nextReserves0,
-        reserves1: swapData.nextReserves1,
-        sqrtPrice: params.sqrtPriceX96,
-      },
     }),
   ]);
 }


### PR DESCRIPTION
## Summary
- **Persistent Zora `getPoolCoin` cache** (`indexer-zora.ts`): replaces the 5-min per-block cache with an LRU keyed by `(chainId, poolAddress)`. Positions only change on `PoolManager:ModifyLiquidity` (Zora hook has `afterAdd/RemoveLiquidity` perms) or `ZoraCreatorCoinV4:LiquidityMigrated`; both call `invalidatePoolCoinCache`. Everything else reuses the read across blocks instead of re-issuing it every 5 min.
- **Derive tick from event** (`indexer-zora.ts`): `ZoraV4CreatorCoinHook:Swapped` already carries `sqrtPriceX96`, so we compute the tick via `TickMath.getTickAtSqrtRatio` and drop the per-swap `StateView.getSlot0` RPC read entirely.
- **Collapse swap writes** (`shared/swap-optimizer.ts`): the swap path was doing two writes to the same `pool` row in parallel (one via `SwapOrchestrator`/`updatePool` with a redundant `db.find`, one via `updatePoolDirect` for reserves/sqrtPrice). Merged into a single `updatePoolDirect` and inlined the asset/bucket updates so the orchestrator indirection is gone. Saves one find + one update per swap.

## Notes
- Branched off `origin/main`; the local `parallel index creation` commit on `main` is unrelated and left out of this PR.