### PR TITLE
fix: use simple query protocol for CREATE INDEX CONCURRENTLY

### DIFF
--- a/patches/ponder@0.16.3.patch
+++ b/patches/ponder@0.16.3.patch
@@ -60,7 +60,7 @@ diff --git a/dist/esm/database/actions.js b/dist/esm/database/actions.js
 index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..d1c03a848aed7d8755920590a1f095a8df078473 100644
 --- a/dist/esm/database/actions.js
 +++ b/dist/esm/database/actions.js
-@@ -6,13 +6,41 @@ import { and, eq, getTableColumns, getTableName, getViewName, lte, sql, } from "
+@@ -6,13 +6,45 @@ import { and, eq, getTableColumns, getTableName, getViewName, lte, sql, } from "
  import { getTableConfig } from "drizzle-orm/pg-core";
  import { PONDER_CHECKPOINT_TABLE_NAME, PONDER_META_TABLE_NAME, getPonderCheckpointTable, } from "./index.js";
  export const createIndexes = async (qb, { statements }, context) => {
@@ -92,9 +92,13 @@ index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..d1c03a848aed7d8755920590a1f095a8
 +            const statement = queue.shift();
 +            if (statement === undefined) return;
 +            if (isPostgres) {
-+                // Single simple-query batch keeps SET on the same backend session
-+                // as the CREATE INDEX CONCURRENTLY that follows it.
-+                await qb.wrap({ label: "create_indexes" }, (db) => db.execute(`SET statement_timeout = 3600000; ${statement}`), context);
++                // CREATE INDEX CONCURRENTLY cannot run inside a transaction
++                // block, and drizzle's db.execute() uses the pg extended query
++                // protocol which forces an implicit transaction. Go through
++                // the raw pg Pool (qb.$client.query(text)) so the simple query
++                // protocol is used: it auto-commits and allows the SET +
++                // CREATE INDEX CONCURRENTLY to ride in one message.
++                await qb.wrap({ label: "create_indexes" }, () => qb.$client.query(`SET statement_timeout = 3600000; ${statement}`), context);
 +            }
 +            else {
 +                await qb.transaction({ label: "create_indexes" }, async (tx) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   ponder@0.16.3:
-    hash: 3f5e9b05e87c71cfee5cbb23a6568defea8aab5016b54c9c786ff7bec83409f1
+    hash: 0197e3896665bb8e57eccf84180dcdb04c1c1051a532e8610c36ab5b76d67e0f
     path: patches/ponder@0.16.3.patch
 
 importers:
@@ -24,7 +24,7 @@ importers:
         version: 4.3.2
       ponder:
         specifier: 0.16.3
-        version: 0.16.3(patch_hash=3f5e9b05e87c71cfee5cbb23a6568defea8aab5016b54c9c786ff7bec83409f1)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3))
+        version: 0.16.3(patch_hash=0197e3896665bb8e57eccf84180dcdb04c1c1051a532e8610c36ab5b76d67e0f)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3))
       viem:
         specifier: 2.30.1
         version: 2.30.1(typescript@5.9.3)
@@ -4920,7 +4920,7 @@ snapshots:
       sonic-boom: 3.8.1
       thread-stream: 2.7.0
 
-  ponder@0.16.3(patch_hash=3f5e9b05e87c71cfee5cbb23a6568defea8aab5016b54c9c786ff7bec83409f1)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3)):
+  ponder@0.16.3(patch_hash=0197e3896665bb8e57eccf84180dcdb04c1c1051a532e8610c36ab5b76d67e0f)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3)):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@commander-js/extra-typings': 12.1.0(commander@12.1.0)


### PR DESCRIPTION
The patched `createIndexes()` runs `db.execute(\`SET statement_timeout = 3600000; ${statement}\`)` against drizzle. Drizzle's `db.execute()` builds a `rawQueryConfig` and routes through pg's **extended query protocol**, which implicitly wraps statements in a transaction — so Postgres rejects `CREATE INDEX CONCURRENTLY` with:

```
error: CREATE INDEX CONCURRENTLY cannot run inside a transaction block
```

This was hit on `ponder-staging` after the concurrent-index-build patch shipped (#62).

## Fix

In the postgres branch of `createIndexes()`, call the underlying pg Pool directly instead of going through drizzle:

```js
await qb.wrap({ label: "create_indexes" }, () =>
  qb.$client.query(`SET statement_timeout = 3600000; ${statement}`),
  context);
```

`pool.query(text)` with text-only (no params, no config object) uses the **simple query protocol**, which auto-commits, allows multi-statement batches, and lets `CREATE INDEX CONCURRENTLY` run. `qb.wrap` still wraps for retry/logging.

## Changes

- `patches/ponder@0.16.3.patch` — swap drizzle `db.execute` for `qb.$client.query` in the postgres path; hunk count adjusted (`+6,41` → `+6,45`).
- `pnpm-lock.yaml` — new patch hash recorded.