### PR TITLE
fix: run SET and CREATE INDEX CONCURRENTLY as separate queries

### DIFF
--- a/patches/ponder@0.16.3.patch
+++ b/patches/ponder@0.16.3.patch
@@ -60,7 +60,7 @@ diff --git a/dist/esm/database/actions.js b/dist/esm/database/actions.js
 index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..d1c03a848aed7d8755920590a1f095a8df078473 100644
 --- a/dist/esm/database/actions.js
 +++ b/dist/esm/database/actions.js
-@@ -6,13 +6,45 @@ import { and, eq, getTableColumns, getTableName, getViewName, lte, sql, } from "
+@@ -6,13 +6,59 @@ import { and, eq, getTableColumns, getTableName, getViewName, lte, sql, } from "
  import { getTableConfig } from "drizzle-orm/pg-core";
  import { PONDER_CHECKPOINT_TABLE_NAME, PONDER_META_TABLE_NAME, getPonderCheckpointTable, } from "./index.js";
  export const createIndexes = async (qb, { statements }, context) => {
@@ -93,12 +93,26 @@ index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..d1c03a848aed7d8755920590a1f095a8
 +            if (statement === undefined) return;
 +            if (isPostgres) {
 +                // CREATE INDEX CONCURRENTLY cannot run inside a transaction
-+                // block, and drizzle's db.execute() uses the pg extended query
-+                // protocol which forces an implicit transaction. Go through
-+                // the raw pg Pool (qb.$client.query(text)) so the simple query
-+                // protocol is used: it auto-commits and allows the SET +
-+                // CREATE INDEX CONCURRENTLY to ride in one message.
-+                await qb.wrap({ label: "create_indexes" }, () => qb.$client.query(`SET statement_timeout = 3600000; ${statement}`), context);
++                // block. Two pitfalls to avoid:
++                //   1. drizzle's db.execute() uses the pg extended query
++                //      protocol, which wraps single statements in an implicit
++                //      transaction.
++                //   2. Sending `SET ...; CREATE INDEX CONCURRENTLY ...` as a
++                //      single simple-query message also forms an implicit
++                //      transaction block (multi-statement simple queries do).
++                // So: check out one pg client and issue the two statements
++                // as separate simple-query messages. Each is its own
++                // autocommit statement, and the SET persists on the session.
++                await qb.wrap({ label: "create_indexes" }, async () => {
++                    const client = await qb.$client.connect();
++                    try {
++                        await client.query("SET statement_timeout = 3600000");
++                        await client.query(statement);
++                    }
++                    finally {
++                        client.release();
++                    }
++                }, context);
 +            }
 +            else {
 +                await qb.transaction({ label: "create_indexes" }, async (tx) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   ponder@0.16.3:
-    hash: 0197e3896665bb8e57eccf84180dcdb04c1c1051a532e8610c36ab5b76d67e0f
+    hash: 686ad81ada4f7dfbc11896b57fcc9f296f5f58a2d48a3d444038e011a9d74ed3
     path: patches/ponder@0.16.3.patch
 
 importers:
@@ -24,7 +24,7 @@ importers:
         version: 4.3.2
       ponder:
         specifier: 0.16.3
-        version: 0.16.3(patch_hash=0197e3896665bb8e57eccf84180dcdb04c1c1051a532e8610c36ab5b76d67e0f)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3))
+        version: 0.16.3(patch_hash=686ad81ada4f7dfbc11896b57fcc9f296f5f58a2d48a3d444038e011a9d74ed3)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3))
       viem:
         specifier: 2.30.1
         version: 2.30.1(typescript@5.9.3)
@@ -4920,7 +4920,7 @@ snapshots:
       sonic-boom: 3.8.1
       thread-stream: 2.7.0
 
-  ponder@0.16.3(patch_hash=0197e3896665bb8e57eccf84180dcdb04c1c1051a532e8610c36ab5b76d67e0f)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3)):
+  ponder@0.16.3(patch_hash=686ad81ada4f7dfbc11896b57fcc9f296f5f58a2d48a3d444038e011a9d74ed3)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3)):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@commander-js/extra-typings': 12.1.0(commander@12.1.0)


### PR DESCRIPTION
Follow-up to #63 — the previous fix routed the SET + CREATE INDEX CONCURRENTLY through pg's simple query protocol via `pool.query(\`SET ...; CREATE INDEX CONCURRENTLY ...\`)`, but staging is still hitting:

```
error: CREATE INDEX CONCURRENTLY cannot run inside a transaction block
```

## Why the previous fix was incomplete

PostgreSQL treats **multi-statement simple-query messages as a single implicit transaction block**, so `SET ...; CREATE INDEX CONCURRENTLY ...` in one `pool.query()` is still rejected. Two failure modes had to be dodged, not one:

1. drizzle's `db.execute()` uses the **extended** protocol, which wraps single statements in an implicit transaction.
2. A multi-statement payload over the **simple** protocol also forms an implicit transaction.

## Fix

Check out a single client from the pool and issue the two statements as **separate** simple-query messages. Each becomes its own autocommit statement, and the SET persists for the duration of the CREATE INDEX CONCURRENTLY because both run on the same session.

```js
await qb.wrap({ label: "create_indexes" }, async () => {
  const client = await qb.$client.connect();
  try {
    await client.query("SET statement_timeout = 3600000");
    await client.query(statement);
  } finally {
    client.release();
  }
}, context);
```

## Changes

- `patches/ponder@0.16.3.patch` — replace `pool.query(combined)` with checked-out-client + two `client.query(text)` calls; hunk count adjusted.
- `pnpm-lock.yaml` — new patch hash recorded.