### PR TITLE
fix: serialize CIC builds and sweep invalid indexes

### DIFF
--- a/patches/ponder@0.16.3.patch
+++ b/patches/ponder@0.16.3.patch
@@ -60,7 +60,7 @@ diff --git a/dist/esm/database/actions.js b/dist/esm/database/actions.js
 index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..d1c03a848aed7d8755920590a1f095a8df078473 100644
 --- a/dist/esm/database/actions.js
 +++ b/dist/esm/database/actions.js
-@@ -6,13 +6,59 @@ import { and, eq, getTableColumns, getTableName, getViewName, lte, sql, } from "
+@@ -6,13 +6,82 @@ import { and, eq, getTableColumns, getTableName, getViewName, lte, sql, } from "
  import { getTableConfig } from "drizzle-orm/pg-core";
  import { PONDER_CHECKPOINT_TABLE_NAME, PONDER_META_TABLE_NAME, getPonderCheckpointTable, } from "./index.js";
  export const createIndexes = async (qb, { statements }, context) => {
@@ -74,19 +74,42 @@ index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..d1c03a848aed7d8755920590a1f095a8
 +    // Parallelize index creation. On Postgres we use CREATE INDEX CONCURRENTLY
 +    // so the build does not block writes — this lets live indexing run
 +    // concurrently with the index build (see runtime/{multichain,omnichain}.js
-+    // where this is invoked without await). CONCURRENTLY cannot run inside a
-+    // transaction block, so each statement runs via qb.wrap. The statement
-+    // timeout is sent in the same simple-query batch so it applies to the
-+    // same backend session.
++    // where this is invoked without await).
 +    //
-+    // Concurrency cap is lower than the non-CONCURRENTLY path because the
-+    // user pool is shared with live indexing during the background build.
-+    const CONCURRENCY = 4;
++    // Postgres path is serialized (CONCURRENCY=1) because parallel
++    // CREATE INDEX CONCURRENTLY workers can form deadlock cycles waiting on
++    // each other's (and the live indexer's) virtual transactions. The build
++    // is already non-blocking, so the wall-clock win from parallelism is
++    // marginal compared to the risk of a deadlock killing a build mid-flight
++    // and leaving an INVALID index behind.
 +    const isPostgres = qb.$dialect === "postgres";
++    const CONCURRENCY = isPostgres ? 1 : 4;
 +    const queue = statements.indexes.sql.map((statement) => {
 +        if (!isPostgres) return statement;
 +        return statement.replace(/^\s*CREATE(\s+UNIQUE)?\s+INDEX\s+IF\s+NOT\s+EXISTS/i, (_m, unique) => `CREATE${unique ?? ""} INDEX CONCURRENTLY IF NOT EXISTS`);
 +    });
++    // Sweep any INVALID indexes left behind by a previously-killed
++    // CREATE INDEX CONCURRENTLY (e.g. from a deadlock or process crash).
++    // IF NOT EXISTS would otherwise skip recreating them, so they'd stay
++    // invalid forever and queries wouldn't use them.
++    if (isPostgres && queue.length > 0) {
++        const sweepClient = await qb.$client.connect();
++        try {
++            const { rows } = await sweepClient.query(`
++                SELECT n.nspname AS schema, c.relname AS index
++                FROM pg_index i
++                JOIN pg_class c ON c.oid = i.indexrelid
++                JOIN pg_namespace n ON n.oid = c.relnamespace
++                WHERE NOT i.indisvalid
++            `);
++            for (const row of rows) {
++                await sweepClient.query(`DROP INDEX IF EXISTS "${row.schema}"."${row.index}"`);
++            }
++        }
++        finally {
++            sweepClient.release();
++        }
++    }
 +    const runWorker = async () => {
 +        while (queue.length > 0) {
 +            const statement = queue.shift();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   ponder@0.16.3:
-    hash: 686ad81ada4f7dfbc11896b57fcc9f296f5f58a2d48a3d444038e011a9d74ed3
+    hash: 07d5e98449f207b60b160c3f193fd2df2ba7342393d121e92124f0e4d6624bf9
     path: patches/ponder@0.16.3.patch
 
 importers:
@@ -24,7 +24,7 @@ importers:
         version: 4.3.2
       ponder:
         specifier: 0.16.3
-        version: 0.16.3(patch_hash=686ad81ada4f7dfbc11896b57fcc9f296f5f58a2d48a3d444038e011a9d74ed3)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3))
+        version: 0.16.3(patch_hash=07d5e98449f207b60b160c3f193fd2df2ba7342393d121e92124f0e4d6624bf9)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3))
       viem:
         specifier: 2.30.1
         version: 2.30.1(typescript@5.9.3)
@@ -4920,7 +4920,7 @@ snapshots:
       sonic-boom: 3.8.1
       thread-stream: 2.7.0
 
-  ponder@0.16.3(patch_hash=686ad81ada4f7dfbc11896b57fcc9f296f5f58a2d48a3d444038e011a9d74ed3)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3)):
+  ponder@0.16.3(patch_hash=07d5e98449f207b60b160c3f193fd2df2ba7342393d121e92124f0e4d6624bf9)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3)):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@commander-js/extra-typings': 12.1.0(commander@12.1.0)


### PR DESCRIPTION
Follow-up to #64 — `CREATE INDEX CONCURRENTLY` now runs, but staging is hitting:

```
error: deadlock detected
  at runWorker (.../ponder/dist/esm/database/actions.js:41:17)
  at async Promise.all (index 0)
  at createIndexes (.../ponder/dist/esm/database/actions.js:61:5)
```

## Two problems

1. **Worker-vs-worker deadlock.** Four parallel `CREATE INDEX CONCURRENTLY` workers each wait on virtual transactions held by other backends (peer workers + the live indexer). This forms wait-cycles that Postgres breaks by aborting a victim — repeatedly enough to blow through ponder's 9 retries.
2. **Orphaned INVALID indexes.** When `CREATE INDEX CONCURRENTLY` is aborted mid-build, the partial index is left with `pg_index.indisvalid = false`. On the next run, `IF NOT EXISTS` sees the name and **skips** — leaving the invalid index in place forever, unused by the planner.

## Fix

- **Serialize the Postgres path (`CONCURRENCY = 1`).** CIC is already non-blocking to live indexing, so the wall-clock win from parallelism is marginal against the cost of one bad build leaving an INVALID index behind. PGlite path keeps `CONCURRENCY = 4`.
- **Sweep INVALID indexes at the start of `createIndexes`.** Single pre-pass query against `pg_index` to find any `NOT indisvalid` indexes and `DROP INDEX IF EXISTS` each. Makes re-runs self-healing after this kind of failure (including the staging incident that prompted this PR).

```js
const isPostgres = qb.$dialect === "postgres";
const CONCURRENCY = isPostgres ? 1 : 4;
// ...
if (isPostgres && queue.length > 0) {
  const sweepClient = await qb.$client.connect();
  try {
    const { rows } = await sweepClient.query(`
      SELECT n.nspname AS schema, c.relname AS index
      FROM pg_index i
      JOIN pg_class c ON c.oid = i.indexrelid
      JOIN pg_namespace n ON n.oid = c.relnamespace
      WHERE NOT i.indisvalid
    `);
    for (const row of rows) {
      await sweepClient.query(`DROP INDEX IF EXISTS "${row.schema}"."${row.index}"`);
    }
  } finally {
    sweepClient.release();
  }
}
```

## Changes

- `patches/ponder@0.16.3.patch` — serialize Postgres path; add invalid-index sweep before the worker pool starts.
- `pnpm-lock.yaml` — new patch hash recorded.