### PR TITLE
perf: add pool and token indexes for feed sort and lookups

### DIFF
--- a/ponder.schema.ts
+++ b/ponder.schema.ts
@@ -1,4 +1,4 @@
-import { index, onchainTable, primaryKey, relations } from "ponder";
+import { index, onchainTable, primaryKey, relations, sql } from "ponder";
 
 /* TABLES */
 export const user = onchainTable(
@@ -65,6 +65,8 @@ export const token = onchainTable(
     chainIdIdx: index().on(table.chainId),
     poolIdx: index().on(table.pool),
     symbolIdx: index().on(table.symbol),
+    tokenChainFirstSeenIdx: index("token_chain_first_seen_idx").on(table.chainId, table.firstSeenAt.desc()),
+    tokenChainCreatorAddressIdx: index("token_chain_creator_address_idx").on(table.chainId, table.creatorAddress.desc()),
   })
 );
 
@@ -490,6 +492,7 @@ export const pool = onchainTable(
     pk: primaryKey({
       columns: [table.address, table.chainId],
     }),
+    assetIdx: index().on(table.asset),
     baseTokenIdx: index().on(table.baseToken),
     quoteTokenIdx: index().on(table.quoteToken),
     lastRefreshedIdx: index().on(table.lastRefreshed),
@@ -507,7 +510,13 @@ export const pool = onchainTable(
     chainQuoteLastSwapIdx: index().on(table.chainId, table.hasValidQuote, table.lastSwapTimestamp),
     chainQuoteMcapIdx: index().on(table.chainId, table.hasValidQuote, table.marketCapUsd),
     chainQuoteHoldersIdx: index().on(table.chainId, table.hasValidQuote, table.holderCount),
-    chainQuoteLiquidityIdx: index().on(table.chainId, table.hasValidQuote, table.dollarLiquidity)
+    chainQuoteLiquidityIdx: index().on(table.chainId, table.hasValidQuote, table.dollarLiquidity),
+    // Ordered index for paginated feed sorted by created_at DESC, address DESC
+    poolCreatedIdx: index("pool_created_idx").on(table.createdAt.desc(), table.address.desc()),
+    // Partial ordered index for paginated feed sorted by last_swap_timestamp DESC, created_at DESC
+    poolFeedIdx: index("pool_feed_idx")
+      .on(table.lastSwapTimestamp.desc(), table.createdAt.desc())
+      .where(sql`${table.lastSwapTimestamp} IS NOT NULL`),
   })
 );
 


### PR DESCRIPTION
## Summary

Adds five indexes to `ponder.schema.ts`:

**`pool` table**
- `assetIdx` — `pool (asset)` for asset-based lookups.
- `pool_created_idx` — `pool (created_at DESC, address DESC)` for the feed sorted by `created_at`.
- `pool_feed_idx` — partial `pool (last_swap_timestamp DESC, created_at DESC) WHERE last_swap_timestamp IS NOT NULL` for the feed sorted by last swap.

**`token` table**
- `token_chain_first_seen_idx` — `token (chain_id, first_seen_at DESC)`.
- `token_chain_creator_address_idx` — `token (chain_id, creator_address DESC)`.

The patched Ponder (`patches/ponder@0.16.3.patch`) automatically rewrites `CREATE INDEX` to `CREATE INDEX CONCURRENTLY`, so no explicit `.concurrently()` call is needed.

The two `pool_*` indexes match the manual SQL captured in `indices.md` (slow-query investigation 2026-05-27) — defining them in the schema lets fresh deployments pick them up without manual psql.

`pool_feed_idx` uses default DESC null-ordering (NULLS FIRST) to match the planner's behavior on `ORDER BY ... DESC`; the partial `WHERE last_swap_timestamp IS NOT NULL` is what excludes the null bucket. (See `indices.md` gotcha #1.)