### PR TITLE
feat: add monitoring stack (prometheus + grafana)

### DIFF
--- a/monitoring/.env.example
+++ b/monitoring/.env.example
@@ -1,0 +1,20 @@
+DATABASE_URL=postgresql://user:pass@private-db-...-do-user-...-0.k.db.ondigitalocean.com:25060/defaultdb?sslmode=require
+
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=change-me
+
+# DigitalOcean managed Postgres Prometheus integration (from DO console → Metrics → Prometheus)
+DO_PG_USER=your-do-metrics-user
+DO_PG_PASSWORD=your-do-metrics-password
+DO_PG_HOST=db-postgresql-...-do-user-...-0.k.db.ondigitalocean.com:9273
+# Same DO metrics user/password reused for the replica; only the host differs
+DO_PG_REPLICA_HOST=db-postgresql-...-do-user-...-1.k.db.ondigitalocean.com:9273
+
+# Ponder indexer scrape targets (host:port). Use host.docker.internal to reach
+# the host machine from inside the prometheus container.
+PONDER_PROD_API_HOST=134.199.245.81:8080
+PONDER_PROD_INDEXER_HOST=host.docker.internal:8080
+PONDER_STAGING_HOST=host.docker.internal:8081
+PONDER_TESTNET_API_HOST=134.199.245.81:8082
+PONDER_TESTNET_INDEXER_HOST=host.docker.internal:8082
+PONDER_BANKR_HOST=bankr.indexer.doppler.lol

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,0 +1,75 @@
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml.tmpl:/etc/prometheus/prometheus.yml.tmpl:ro
+      - prometheus-data:/prometheus
+    environment:
+      DO_PG_USER: ${DO_PG_USER}
+      DO_PG_PASSWORD: ${DO_PG_PASSWORD}
+      DO_PG_HOST: ${DO_PG_HOST}
+      DO_PG_REPLICA_HOST: ${DO_PG_REPLICA_HOST}
+      PONDER_PROD_API_HOST: ${PONDER_PROD_API_HOST}
+      PONDER_PROD_INDEXER_HOST: ${PONDER_PROD_INDEXER_HOST}
+      PONDER_STAGING_HOST: ${PONDER_STAGING_HOST}
+      PONDER_TESTNET_API_HOST: ${PONDER_TESTNET_API_HOST}
+      PONDER_TESTNET_INDEXER_HOST: ${PONDER_TESTNET_INDEXER_HOST}
+      PONDER_BANKR_HOST: ${PONDER_BANKR_HOST}
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -e
+        sed -e "s|__DO_PG_USER__|$$DO_PG_USER|g" \
+            -e "s|__DO_PG_PASSWORD__|$$DO_PG_PASSWORD|g" \
+            -e "s|__DO_PG_HOST__|$$DO_PG_HOST|g" \
+            -e "s|__DO_PG_REPLICA_HOST__|$$DO_PG_REPLICA_HOST|g" \
+            -e "s|__PONDER_PROD_API_HOST__|$$PONDER_PROD_API_HOST|g" \
+            -e "s|__PONDER_PROD_INDEXER_HOST__|$$PONDER_PROD_INDEXER_HOST|g" \
+            -e "s|__PONDER_STAGING_HOST__|$$PONDER_STAGING_HOST|g" \
+            -e "s|__PONDER_TESTNET_API_HOST__|$$PONDER_TESTNET_API_HOST|g" \
+            -e "s|__PONDER_TESTNET_INDEXER_HOST__|$$PONDER_TESTNET_INDEXER_HOST|g" \
+            -e "s|__PONDER_BANKR_HOST__|$$PONDER_BANKR_HOST|g" \
+            /etc/prometheus/prometheus.yml.tmpl > /tmp/prometheus.yml
+        exec /bin/prometheus \
+          --config.file=/tmp/prometheus.yml \
+          --storage.tsdb.path=/prometheus \
+          --storage.tsdb.retention.time=14d \
+          --web.enable-lifecycle
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: unless-stopped
+
+  postgres-exporter:
+    image: quay.io/prometheuscommunity/postgres-exporter:latest
+    container_name: postgres-exporter
+    environment:
+      DATA_SOURCE_NAME: "${DATABASE_URL}"
+      PG_EXPORTER_AUTO_DISCOVER_DATABASES: "false"
+      PG_EXPORTER_EXCLUDE_DATABASES: "template0,template1"
+    ports:
+      - "9187:9187"
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: "${GRAFANA_ADMIN_USER:-admin}"
+      GF_SECURITY_ADMIN_PASSWORD: "${GRAFANA_ADMIN_PASSWORD:-admin}"
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_INSTALL_PLUGINS: ""
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana-data:/var/lib/grafana
+    restart: unless-stopped
+
+volumes:
+  prometheus-data:
+  grafana-data:

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: default
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/monitoring/grafana/provisioning/dashboards/db-replica.json
+++ b/monitoring/grafana/provisioning/dashboards/db-replica.json
@@ -1,0 +1,256 @@
+{
+  "title": "Postgres (Read Replica)",
+  "uid": "db-replica",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "timezone": "browser",
+  "tags": ["postgres", "infra", "replica"],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": { "text": "Prometheus", "value": "Prometheus" }
+      },
+      {
+        "name": "schema",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "query": "label_values(postgresql_pg_statio_user_tables_cache_hit_ratio{role=\"replica\"}, schema_name)",
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": "All", "value": "$__all" },
+        "refresh": 2
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1, "type": "row", "title": "Disk IO",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
+    },
+    {
+      "id": 2, "type": "timeseries", "title": "Avg disk queue depth (avgqu-sz) — vda5 / dm-5",
+      "description": "Mean number of I/Os in flight, averaged over the rate window. The real saturation signal for parallel devices — virtio/NVMe/device-mapper handle many requests at once, so the Linux util% pins at 100% with plenty of headroom left. Healthy: <2. Working hard: 2–8. Bottlenecked: >8 sustained. Derived from diskio_weighted_io_time (ms-of-queue-time per second ÷ 1000 = unitless mean concurrency).",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "targets": [{
+        "expr": "rate(diskio_weighted_io_time{role=\"replica\",name=~\"vda5|dm-5\"}[1m]) / 1000",
+        "legendFormat": "{{name}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "short", "min": 0, "thresholds": { "mode": "absolute", "steps": [
+        { "color": "green", "value": null }, { "color": "yellow", "value": 2 }, { "color": "orange", "value": 4 }, { "color": "red", "value": 8 }
+      ]}}}
+    },
+    {
+      "id": 3, "type": "timeseries", "title": "IO await (ms) — read vs write",
+      "description": "Average wait + service time per I/O. The primary latency signal — what Postgres backends actually feel when reading from / fsyncing to disk. Healthy: <25ms. Concerning: >50ms sustained (start checking checkpoint pressure, autovacuum, and DO volume IOPS cap). Read/write split derived from diskio_{read,write}_time ÷ diskio_{reads,writes}; dm-5 combined comes from the precomputed diskio_io_await.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "targets": [
+        { "expr": "rate(diskio_read_time{role=\"replica\",name=\"vda5\"}[1m]) / rate(diskio_reads{role=\"replica\",name=\"vda5\"}[1m])", "legendFormat": "vda5 read", "refId": "A" },
+        { "expr": "rate(diskio_write_time{role=\"replica\",name=\"vda5\"}[1m]) / rate(diskio_writes{role=\"replica\",name=\"vda5\"}[1m])", "legendFormat": "vda5 write", "refId": "B" },
+        { "expr": "diskio_io_await{role=\"replica\",name=\"dm-5\"}", "legendFormat": "dm-5 combined", "refId": "C" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ms", "min": 0, "thresholds": { "mode": "absolute", "steps": [
+        { "color": "green", "value": null }, { "color": "yellow", "value": 25 }, { "color": "red", "value": 50 }
+      ]}}}
+    },
+    {
+      "id": 4, "type": "timeseries", "title": "IOPS (reads + writes / s) — data disk",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 9 },
+      "targets": [
+        { "expr": "rate(diskio_reads{role=\"replica\",name=\"vda5\"}[1m])", "legendFormat": "reads", "refId": "A" },
+        { "expr": "rate(diskio_writes{role=\"replica\",name=\"vda5\"}[1m])", "legendFormat": "writes", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "iops" } }
+    },
+    {
+      "id": 5, "type": "timeseries", "title": "Throughput (B/s) — data disk",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 9 },
+      "targets": [
+        { "expr": "rate(diskio_read_bytes{role=\"replica\",name=\"vda5\"}[1m])", "legendFormat": "read", "refId": "A" },
+        { "expr": "rate(diskio_write_bytes{role=\"replica\",name=\"vda5\"}[1m])", "legendFormat": "write", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "Bps" } }
+    },
+    {
+      "id": 6, "type": "row", "title": "CPU / memory",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 16 }
+    },
+    {
+      "id": 7, "type": "timeseries", "title": "CPU usage (cpu-total)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 17 },
+      "targets": [
+        { "expr": "cpu_usage_user{role=\"replica\",cpu=\"cpu-total\"}", "legendFormat": "user", "refId": "A" },
+        { "expr": "cpu_usage_system{role=\"replica\",cpu=\"cpu-total\"}", "legendFormat": "system", "refId": "B" },
+        { "expr": "cpu_usage_iowait{role=\"replica\",cpu=\"cpu-total\"}", "legendFormat": "iowait", "refId": "C" },
+        { "expr": "100 - cpu_usage_idle{role=\"replica\",cpu=\"cpu-total\"}", "legendFormat": "used (100-idle)", "refId": "D" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "percent", "max": 100, "min": 0 } }
+    },
+    {
+      "id": 8, "type": "timeseries", "title": "Max per-CPU usage (find a pegged core)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 17 },
+      "targets": [{
+        "expr": "max by (host) (100 - cpu_usage_idle{role=\"replica\",cpu!=\"cpu-total\"})",
+        "legendFormat": "max core %",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "percent", "max": 100, "min": 0 } }
+    },
+    {
+      "id": 9, "type": "timeseries", "title": "System load (1/5/15) vs n_cpus",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 17 },
+      "targets": [
+        { "expr": "system_load1{role=\"replica\"}", "legendFormat": "load1", "refId": "A" },
+        { "expr": "system_load5{role=\"replica\"}", "legendFormat": "load5", "refId": "B" },
+        { "expr": "system_load15{role=\"replica\"}", "legendFormat": "load15", "refId": "C" },
+        { "expr": "system_n_cpus{role=\"replica\"}", "legendFormat": "n_cpus", "refId": "D" }
+      ]
+    },
+    {
+      "id": 10, "type": "timeseries", "title": "Memory used / available / cached",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 24 },
+      "targets": [
+        { "expr": "mem_used{role=\"replica\"}", "legendFormat": "used", "refId": "A" },
+        { "expr": "mem_available{role=\"replica\"}", "legendFormat": "available", "refId": "B" },
+        { "expr": "mem_cached{role=\"replica\"}", "legendFormat": "cached", "refId": "C" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes" } }
+    },
+    {
+      "id": 11, "type": "timeseries", "title": "Swap activity (rate)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 24 },
+      "targets": [
+        { "expr": "rate(swap_in{role=\"replica\"}[5m])", "legendFormat": "swap in B/s", "refId": "A" },
+        { "expr": "rate(swap_out{role=\"replica\"}[5m])", "legendFormat": "swap out B/s", "refId": "B" },
+        { "expr": "swap_used{role=\"replica\"}", "legendFormat": "swap used (current)", "refId": "C" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "Bps" } }
+    },
+    {
+      "id": 12, "type": "row", "title": "Postgres internals",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 31 }
+    },
+    {
+      "id": 13, "type": "timeseries", "title": "Connections by state",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 32 },
+      "targets": [
+        { "expr": "postgresql_pg_stat_activity_conn_count{role=\"replica\"}", "legendFormat": "total", "refId": "A" },
+        { "expr": "postgresql_pg_stat_activity_active_conn_count{role=\"replica\"}", "legendFormat": "active", "refId": "B" },
+        { "expr": "postgresql_pg_stat_activity_idle_conn_count{role=\"replica\"}", "legendFormat": "idle", "refId": "C" }
+      ]
+    },
+    {
+      "id": 14, "type": "timeseries", "title": "Cache hit ratio (db-wide)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 32 },
+      "targets": [{
+        "expr": "rate(postgresql_pg_stat_database_blks_hit{role=\"replica\",datname=\"defaultdb\"}[5m]) / (rate(postgresql_pg_stat_database_blks_hit{role=\"replica\",datname=\"defaultdb\"}[5m]) + rate(postgresql_pg_stat_database_blks_read{role=\"replica\",datname=\"defaultdb\"}[5m]))",
+        "legendFormat": "hit ratio",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "percentunit", "max": 1, "min": 0 } }
+    },
+    {
+      "id": 15, "type": "timeseries", "title": "TPS (commits + rollbacks)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 32 },
+      "targets": [
+        { "expr": "rate(postgresql_pg_stat_database_xact_commit{role=\"replica\",datname=\"defaultdb\"}[1m])", "legendFormat": "commits/s", "refId": "A" },
+        { "expr": "rate(postgresql_pg_stat_database_xact_rollback{role=\"replica\",datname=\"defaultdb\"}[1m])", "legendFormat": "rollbacks/s", "refId": "B" }
+      ]
+    },
+    {
+      "id": 16, "type": "timeseries", "title": "Checkpoints (timed vs forced) per minute",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 39 },
+      "targets": [
+        { "expr": "rate(postgresql_pg_stat_bgwriter_checkpoints_timed{role=\"replica\"}[5m]) * 60", "legendFormat": "timed/min", "refId": "A" },
+        { "expr": "rate(postgresql_pg_stat_bgwriter_checkpoints_req{role=\"replica\"}[5m]) * 60", "legendFormat": "forced/min", "refId": "B" }
+      ]
+    },
+    {
+      "id": 17, "type": "timeseries", "title": "Bgwriter buffers / s",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 39 },
+      "targets": [
+        { "expr": "rate(postgresql_pg_stat_bgwriter_buffers_checkpoint{role=\"replica\"}[1m])", "legendFormat": "checkpoint", "refId": "A" },
+        { "expr": "rate(postgresql_pg_stat_bgwriter_buffers_clean{role=\"replica\"}[1m])", "legendFormat": "clean", "refId": "B" },
+        { "expr": "rate(postgresql_pg_stat_bgwriter_buffers_backend{role=\"replica\"}[1m])", "legendFormat": "backend", "refId": "C" }
+      ]
+    },
+    {
+      "id": 18, "type": "timeseries", "title": "Temp file bytes / s",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 39 },
+      "targets": [
+        { "expr": "rate(postgresql_pg_stat_database_temp_bytes{role=\"replica\",datname=\"defaultdb\"}[1m])", "legendFormat": "temp bytes/s", "refId": "A" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "Bps" } }
+    },
+    {
+      "id": 19, "type": "row", "title": "Per-table hotspots",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 46 }
+    },
+    {
+      "id": 20, "type": "bargauge", "title": "Worst cache hit ratio (by schema/table)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 47 },
+      "options": { "orientation": "horizontal", "displayMode": "gradient" },
+      "targets": [{
+        "expr": "bottomk(15, postgresql_pg_statio_user_tables_cache_hit_ratio{role=\"replica\",schema_name=~\"$schema\"})",
+        "legendFormat": "{{schema_name}}.{{table_name}}",
+        "refId": "A",
+        "instant": true
+      }],
+      "fieldConfig": { "defaults": { "unit": "percentunit", "max": 1, "min": 0 } }
+    },
+    {
+      "id": 21, "type": "bargauge", "title": "Largest tables (current size)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 47 },
+      "options": { "orientation": "horizontal", "displayMode": "gradient" },
+      "targets": [{
+        "expr": "topk(15, postgresql_pg_class_table_size{role=\"replica\"})",
+        "legendFormat": "{{table_name}}",
+        "refId": "A",
+        "instant": true
+      }],
+      "fieldConfig": { "defaults": { "unit": "bytes" } }
+    },
+    {
+      "id": 22, "type": "timeseries", "title": "Dead tuples",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 57 },
+      "targets": [{
+        "expr": "postgresql_pg_stat_user_tables_n_dead_tup{role=\"replica\"}",
+        "legendFormat": "dead tuples",
+        "refId": "A"
+      }]
+    },
+    {
+      "id": 23, "type": "timeseries", "title": "Max table XID age (wraparound risk)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 57 },
+      "targets": [{
+        "expr": "max by (table_name) (postgresql_pg_class_xid_age{role=\"replica\"})",
+        "legendFormat": "{{table_name}}",
+        "refId": "A"
+      }]
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/db.json
+++ b/monitoring/grafana/provisioning/dashboards/db.json
@@ -1,0 +1,257 @@
+{
+  "title": "Postgres (DB host)",
+  "uid": "db",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "timezone": "browser",
+  "tags": ["postgres", "infra", "primary"],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": { "text": "Prometheus", "value": "Prometheus" }
+      },
+      {
+        "name": "schema",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "query": "label_values(postgresql_pg_statio_user_tables_cache_hit_ratio{role=\"primary\"}, schema_name)",
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": "All", "value": "$__all" },
+        "refresh": 2
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1, "type": "row", "title": "Disk IO",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
+    },
+    {
+      "id": 2, "type": "timeseries", "title": "Avg disk queue depth (avgqu-sz) — vda5 / dm-5",
+      "description": "Mean number of I/Os in flight, averaged over the rate window. The real saturation signal for parallel devices — virtio/NVMe/device-mapper handle many requests at once, so the Linux util% pins at 100% with plenty of headroom left. Healthy: <2. Working hard: 2–8. Bottlenecked: >8 sustained. Derived from diskio_weighted_io_time (ms-of-queue-time per second ÷ 1000 = unitless mean concurrency).",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "targets": [{
+        "expr": "rate(diskio_weighted_io_time{role=\"primary\",name=~\"vda5|dm-5\"}[1m]) / 1000",
+        "legendFormat": "{{name}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "short", "min": 0, "thresholds": { "mode": "absolute", "steps": [
+        { "color": "green", "value": null }, { "color": "yellow", "value": 2 }, { "color": "orange", "value": 4 }, { "color": "red", "value": 8 }
+      ]}}}
+    },
+    {
+      "id": 3, "type": "timeseries", "title": "IO await (ms) — read vs write",
+      "description": "Average wait + service time per I/O. The primary latency signal — what Postgres backends actually feel when reading from / fsyncing to disk. Healthy: <25ms. Concerning: >50ms sustained (start checking checkpoint pressure, autovacuum, and DO volume IOPS cap). Read/write split derived from diskio_{read,write}_time ÷ diskio_{reads,writes}; dm-5 combined comes from the precomputed diskio_io_await.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "targets": [
+        { "expr": "rate(diskio_read_time{role=\"primary\",name=\"vda5\"}[1m]) / rate(diskio_reads{role=\"primary\",name=\"vda5\"}[1m])", "legendFormat": "vda5 read", "refId": "A" },
+        { "expr": "rate(diskio_write_time{role=\"primary\",name=\"vda5\"}[1m]) / rate(diskio_writes{role=\"primary\",name=\"vda5\"}[1m])", "legendFormat": "vda5 write", "refId": "B" },
+        { "expr": "diskio_io_await{role=\"primary\",name=\"dm-5\"}", "legendFormat": "dm-5 combined", "refId": "C" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ms", "min": 0, "thresholds": { "mode": "absolute", "steps": [
+        { "color": "green", "value": null }, { "color": "yellow", "value": 25 }, { "color": "red", "value": 50 }
+      ]}}}
+    },
+    {
+      "id": 4, "type": "timeseries", "title": "IOPS (reads + writes / s) — data disk",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 9 },
+      "targets": [
+        { "expr": "rate(diskio_reads{role=\"primary\",name=\"vda5\"}[1m])", "legendFormat": "reads", "refId": "A" },
+        { "expr": "rate(diskio_writes{role=\"primary\",name=\"vda5\"}[1m])", "legendFormat": "writes", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "iops" } }
+    },
+    {
+      "id": 5, "type": "timeseries", "title": "Throughput (B/s) — data disk",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 9 },
+      "targets": [
+        { "expr": "rate(diskio_read_bytes{role=\"primary\",name=\"vda5\"}[1m])", "legendFormat": "read", "refId": "A" },
+        { "expr": "rate(diskio_write_bytes{role=\"primary\",name=\"vda5\"}[1m])", "legendFormat": "write", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "Bps" } }
+    },
+    {
+      "id": 6, "type": "row", "title": "CPU / memory",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 16 }
+    },
+    {
+      "id": 7, "type": "timeseries", "title": "CPU usage (cpu-total)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 17 },
+      "targets": [
+        { "expr": "cpu_usage_user{role=\"primary\",cpu=\"cpu-total\"}", "legendFormat": "user", "refId": "A" },
+        { "expr": "cpu_usage_system{role=\"primary\",cpu=\"cpu-total\"}", "legendFormat": "system", "refId": "B" },
+        { "expr": "cpu_usage_iowait{role=\"primary\",cpu=\"cpu-total\"}", "legendFormat": "iowait", "refId": "C" },
+        { "expr": "100 - cpu_usage_idle{role=\"primary\",cpu=\"cpu-total\"}", "legendFormat": "used (100-idle)", "refId": "D" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "percent", "max": 100, "min": 0 } }
+    },
+    {
+      "id": 8, "type": "timeseries", "title": "Max per-CPU usage (find a pegged core)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 17 },
+      "targets": [{
+        "expr": "max by (host) (100 - cpu_usage_idle{role=\"primary\",cpu!=\"cpu-total\"})",
+        "legendFormat": "max core %",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "percent", "max": 100, "min": 0 } }
+    },
+    {
+      "id": 9, "type": "timeseries", "title": "System load (1/5/15) vs n_cpus",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 17 },
+      "targets": [
+        { "expr": "system_load1{role=\"primary\"}", "legendFormat": "load1", "refId": "A" },
+        { "expr": "system_load5{role=\"primary\"}", "legendFormat": "load5", "refId": "B" },
+        { "expr": "system_load15{role=\"primary\"}", "legendFormat": "load15", "refId": "C" },
+        { "expr": "system_n_cpus{role=\"primary\"}", "legendFormat": "n_cpus", "refId": "D" }
+      ]
+    },
+    {
+      "id": 10, "type": "timeseries", "title": "Memory used / available / cached",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 24 },
+      "targets": [
+        { "expr": "mem_used{role=\"primary\"}", "legendFormat": "used", "refId": "A" },
+        { "expr": "mem_available{role=\"primary\"}", "legendFormat": "available", "refId": "B" },
+        { "expr": "mem_cached{role=\"primary\"}", "legendFormat": "cached", "refId": "C" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes" } }
+    },
+    {
+      "id": 11, "type": "timeseries", "title": "Swap activity (rate)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 24 },
+      "targets": [
+        { "expr": "rate(swap_in{role=\"primary\"}[5m])", "legendFormat": "swap in B/s", "refId": "A" },
+        { "expr": "rate(swap_out{role=\"primary\"}[5m])", "legendFormat": "swap out B/s", "refId": "B" },
+        { "expr": "swap_used{role=\"primary\"}", "legendFormat": "swap used (current)", "refId": "C" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "Bps" } }
+    },
+    {
+      "id": 12, "type": "row", "title": "Postgres internals",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 31 }
+    },
+    {
+      "id": 13, "type": "timeseries", "title": "Connections by state",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 32 },
+      "targets": [
+        { "expr": "postgresql_pg_stat_activity_conn_count{role=\"primary\"}", "legendFormat": "total", "refId": "A" },
+        { "expr": "postgresql_pg_stat_activity_active_conn_count{role=\"primary\"}", "legendFormat": "active", "refId": "B" },
+        { "expr": "postgresql_pg_stat_activity_idle_conn_count{role=\"primary\"}", "legendFormat": "idle", "refId": "C" }
+      ]
+    },
+    {
+      "id": 14, "type": "timeseries", "title": "Cache hit ratio (db-wide)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 32 },
+      "targets": [{
+        "expr": "rate(postgresql_pg_stat_database_blks_hit{role=\"primary\",datname=\"defaultdb\"}[5m]) / (rate(postgresql_pg_stat_database_blks_hit{role=\"primary\",datname=\"defaultdb\"}[5m]) + rate(postgresql_pg_stat_database_blks_read{role=\"primary\",datname=\"defaultdb\"}[5m]))",
+        "legendFormat": "hit ratio",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "percentunit", "max": 1, "min": 0 } }
+    },
+    {
+      "id": 15, "type": "timeseries", "title": "TPS (commits + rollbacks)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 32 },
+      "targets": [
+        { "expr": "rate(postgresql_pg_stat_database_xact_commit{role=\"primary\",datname=\"defaultdb\"}[1m])", "legendFormat": "commits/s", "refId": "A" },
+        { "expr": "rate(postgresql_pg_stat_database_xact_rollback{role=\"primary\",datname=\"defaultdb\"}[1m])", "legendFormat": "rollbacks/s", "refId": "B" }
+      ]
+    },
+    {
+      "id": 16, "type": "timeseries", "title": "Checkpoints (timed vs forced) per minute",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 39 },
+      "targets": [
+        { "expr": "rate(postgresql_pg_stat_bgwriter_checkpoints_timed{role=\"primary\"}[5m]) * 60", "legendFormat": "timed/min", "refId": "A" },
+        { "expr": "rate(postgresql_pg_stat_bgwriter_checkpoints_req{role=\"primary\"}[5m]) * 60", "legendFormat": "forced/min", "refId": "B" }
+      ]
+    },
+    {
+      "id": 17, "type": "timeseries", "title": "Bgwriter buffers / s",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 39 },
+      "targets": [
+        { "expr": "rate(postgresql_pg_stat_bgwriter_buffers_checkpoint{role=\"primary\"}[1m])", "legendFormat": "checkpoint", "refId": "A" },
+        { "expr": "rate(postgresql_pg_stat_bgwriter_buffers_clean{role=\"primary\"}[1m])", "legendFormat": "clean", "refId": "B" },
+        { "expr": "rate(postgresql_pg_stat_bgwriter_buffers_backend{role=\"primary\"}[1m])", "legendFormat": "backend", "refId": "C" }
+      ]
+    },
+    {
+      "id": 18, "type": "timeseries", "title": "Temp file bytes / s + replica flush lag",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 39 },
+      "targets": [
+        { "expr": "rate(postgresql_pg_stat_database_temp_bytes{role=\"primary\",datname=\"defaultdb\"}[1m])", "legendFormat": "temp bytes/s", "refId": "A" },
+        { "expr": "postgresql_pg_stat_replication_replication_flush_lag_bytes{role=\"primary\"}", "legendFormat": "replica flush lag bytes", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "Bps" } }
+    },
+    {
+      "id": 19, "type": "row", "title": "Per-table hotspots",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 46 }
+    },
+    {
+      "id": 20, "type": "bargauge", "title": "Worst cache hit ratio (by schema/table)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 47 },
+      "options": { "orientation": "horizontal", "displayMode": "gradient" },
+      "targets": [{
+        "expr": "bottomk(15, postgresql_pg_statio_user_tables_cache_hit_ratio{role=\"primary\",schema_name=~\"$schema\"})",
+        "legendFormat": "{{schema_name}}.{{table_name}}",
+        "refId": "A",
+        "instant": true
+      }],
+      "fieldConfig": { "defaults": { "unit": "percentunit", "max": 1, "min": 0 } }
+    },
+    {
+      "id": 21, "type": "bargauge", "title": "Largest tables (current size)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 47 },
+      "options": { "orientation": "horizontal", "displayMode": "gradient" },
+      "targets": [{
+        "expr": "topk(15, postgresql_pg_class_table_size{role=\"primary\"})",
+        "legendFormat": "{{table_name}}",
+        "refId": "A",
+        "instant": true
+      }],
+      "fieldConfig": { "defaults": { "unit": "bytes" } }
+    },
+    {
+      "id": 22, "type": "timeseries", "title": "Dead tuples",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 57 },
+      "targets": [{
+        "expr": "postgresql_pg_stat_user_tables_n_dead_tup{role=\"primary\"}",
+        "legendFormat": "dead tuples",
+        "refId": "A"
+      }]
+    },
+    {
+      "id": 23, "type": "timeseries", "title": "Max table XID age (wraparound risk)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 57 },
+      "targets": [{
+        "expr": "max by (table_name) (postgresql_pg_class_xid_age{role=\"primary\"})",
+        "legendFormat": "{{table_name}}",
+        "refId": "A"
+      }]
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/indexer-bankr.json
+++ b/monitoring/grafana/provisioning/dashboards/indexer-bankr.json
@@ -1,0 +1,181 @@
+{
+  "title": "Indexer — bankr",
+  "uid": "indexer-bankr",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "timezone": "browser",
+  "tags": ["ponder", "indexer", "bankr"],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": { "text": "Prometheus", "value": "Prometheus" }
+      },
+      {
+        "name": "chain",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "query": "label_values(ponder_sync_block_timestamp{indexer=\"prod\"}, chain)",
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": "All", "value": "$__all" },
+        "refresh": 2
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1, "type": "row", "title": "Lag",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
+    },
+    {
+      "id": 2, "type": "timeseries", "title": "Lag per chain (sync_block - indexing) seconds",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "targets": [{
+        "expr": "ponder_sync_block_timestamp{indexer=\"prod\",chain=~\"$chain\"} - ponder_indexing_timestamp{indexer=\"prod\",chain=~\"$chain\"}",
+        "legendFormat": "{{chain}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "s", "thresholds": { "mode": "absolute", "steps": [
+        { "color": "green", "value": null }, { "color": "yellow", "value": 30 }, { "color": "red", "value": 120 }
+      ]}}}
+    },
+    {
+      "id": 3, "type": "timeseries", "title": "Realtime mode (1=live, 0=historical)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "targets": [{
+        "expr": "ponder_sync_is_realtime{indexer=\"prod\",chain=~\"$chain\"}",
+        "legendFormat": "{{chain}}",
+        "refId": "A"
+      }]
+    },
+    {
+      "id": 4, "type": "row", "title": "HTTP / API",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 }
+    },
+    {
+      "id": 5, "type": "timeseries", "title": "Request rate by endpoint",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 10 },
+      "targets": [{
+        "expr": "sum by (path) (rate(ponder_http_server_request_duration_ms_count{indexer=\"prod\"}[1m]))",
+        "legendFormat": "{{path}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "reqps" } }
+    },
+    {
+      "id": 6, "type": "timeseries", "title": "p95 latency by endpoint (ms)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 10 },
+      "targets": [{
+        "expr": "histogram_quantile(0.95, sum by (path, le) (rate(ponder_http_server_request_duration_ms_bucket{indexer=\"prod\"}[5m])))",
+        "legendFormat": "{{path}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "ms" } }
+    },
+    {
+      "id": 7, "type": "row", "title": "Database calls (from this indexer)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 17 }
+    },
+    {
+      "id": 8, "type": "timeseries", "title": "select_checkpoints avg latency (DB contention proxy)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 18 },
+      "targets": [{
+        "expr": "rate(ponder_database_method_duration_sum{indexer=\"prod\",method=\"select_checkpoints\"}[5m]) / rate(ponder_database_method_duration_count{indexer=\"prod\",method=\"select_checkpoints\"}[5m])",
+        "legendFormat": "avg ms",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "ms" } }
+    },
+    {
+      "id": 9, "type": "timeseries", "title": "DB method avg latency (top 8 by traffic)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 18 },
+      "targets": [{
+        "expr": "topk(8, rate(ponder_database_method_duration_sum{indexer=\"prod\"}[5m]) / rate(ponder_database_method_duration_count{indexer=\"prod\"}[5m]))",
+        "legendFormat": "{{method}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "ms" } }
+    },
+    {
+      "id": 10, "type": "timeseries", "title": "DB method error rate",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 18 },
+      "targets": [{
+        "expr": "rate(ponder_database_method_error_total{indexer=\"prod\"}[5m])",
+        "legendFormat": "{{method}}",
+        "refId": "A"
+      }]
+    },
+    {
+      "id": 11, "type": "row", "title": "Indexing + RPC",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 25 }
+    },
+    {
+      "id": 12, "type": "timeseries", "title": "Indexing event rate (top 10)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 26 },
+      "targets": [{
+        "expr": "topk(10, rate(ponder_indexing_function_duration_count{indexer=\"prod\"}[1m]))",
+        "legendFormat": "{{event}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "ops" } }
+    },
+    {
+      "id": 13, "type": "timeseries", "title": "Indexing function avg ms (top 10)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 26 },
+      "targets": [{
+        "expr": "topk(10, 1000 * rate(ponder_indexing_function_duration_sum{indexer=\"prod\"}[5m]) / rate(ponder_indexing_function_duration_count{indexer=\"prod\"}[5m]))",
+        "legendFormat": "{{event}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "ms" } }
+    },
+    {
+      "id": 14, "type": "timeseries", "title": "RPC error rate (per chain/method)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 26 },
+      "targets": [{
+        "expr": "rate(ponder_rpc_request_error_total{indexer=\"prod\",chain=~\"$chain\"}[5m])",
+        "legendFormat": "{{chain}} {{method}}",
+        "refId": "A"
+      }]
+    },
+    {
+      "id": 15, "type": "row", "title": "Process health",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 33 }
+    },
+    {
+      "id": 16, "type": "timeseries", "title": "Event-loop lag (p99, max)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 34 },
+      "targets": [
+        { "expr": "nodejs_eventloop_lag_p99_seconds{indexer=\"prod\"}", "legendFormat": "p99", "refId": "A" },
+        { "expr": "nodejs_eventloop_lag_max_seconds{indexer=\"prod\"}", "legendFormat": "max", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" } }
+    },
+    {
+      "id": 17, "type": "timeseries", "title": "Process memory (RSS, heap)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 34 },
+      "targets": [
+        { "expr": "process_resident_memory_bytes{indexer=\"prod\"}", "legendFormat": "rss", "refId": "A" },
+        { "expr": "process_heap_bytes{indexer=\"prod\"}", "legendFormat": "heap", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes" } }
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/indexer-prod.json
+++ b/monitoring/grafana/provisioning/dashboards/indexer-prod.json
@@ -1,0 +1,212 @@
+{
+  "title": "Indexer — prod",
+  "uid": "indexer-prod",
+  "schemaVersion": 39,
+  "version": 2,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "timezone": "browser",
+  "tags": ["ponder", "indexer", "prod"],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": { "text": "Prometheus", "value": "Prometheus" }
+      },
+      {
+        "name": "chain",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "query": "label_values(ponder_sync_block_timestamp{indexer=\"prod-indexer\"}, chain)",
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": "All", "value": "$__all" },
+        "refresh": 2
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1, "type": "row", "title": "Lag",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
+    },
+    {
+      "id": 2, "type": "timeseries", "title": "Lag per chain (sync_block - indexing) seconds",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "targets": [{
+        "expr": "ponder_sync_block_timestamp{indexer=\"prod-indexer\",chain=~\"$chain\"} - ponder_indexing_timestamp{indexer=\"prod-indexer\",chain=~\"$chain\"}",
+        "legendFormat": "{{chain}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "s", "thresholds": { "mode": "absolute", "steps": [
+        { "color": "green", "value": null }, { "color": "yellow", "value": 30 }, { "color": "red", "value": 120 }
+      ]}}}
+    },
+    {
+      "id": 3, "type": "timeseries", "title": "Realtime mode (1=live, 0=historical)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "targets": [{
+        "expr": "ponder_sync_is_realtime{indexer=\"prod-indexer\",chain=~\"$chain\"}",
+        "legendFormat": "{{chain}}",
+        "refId": "A"
+      }]
+    },
+    {
+      "id": 4, "type": "row", "title": "HTTP / API (read-API droplet)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 }
+    },
+    {
+      "id": 5, "type": "timeseries", "title": "Request rate by endpoint",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 10 },
+      "targets": [{
+        "expr": "sum by (path) (rate(ponder_http_server_request_duration_ms_count{indexer=\"prod-api\"}[1m]))",
+        "legendFormat": "{{path}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "reqps" } }
+    },
+    {
+      "id": 6, "type": "timeseries", "title": "Request p95 by endpoint",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 10 },
+      "targets": [{
+        "expr": "histogram_quantile(0.95, sum by (path, le) (rate(ponder_http_server_request_duration_ms_bucket{indexer=\"prod-api\"}[5m])))",
+        "legendFormat": "{{path}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "ms" } }
+    },
+    {
+      "id": 18, "type": "timeseries", "title": "/sql/* latency percentiles by status",
+      "description": "Ponder collapses every /sql query under path=/sql/*, so we can't break down by SQL text. Status splits timeouts (5XX) from slow successes (2XX). For per-query investigation use pg_stat_statements on the prod_readonly droplet.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 17 },
+      "targets": [
+        { "expr": "histogram_quantile(0.50, sum by (status, le) (rate(ponder_http_server_request_duration_ms_bucket{indexer=\"prod-api\",path=\"/sql/*\"}[5m])))", "legendFormat": "p50 {{status}}", "refId": "A" },
+        { "expr": "histogram_quantile(0.95, sum by (status, le) (rate(ponder_http_server_request_duration_ms_bucket{indexer=\"prod-api\",path=\"/sql/*\"}[5m])))", "legendFormat": "p95 {{status}}", "refId": "B" },
+        { "expr": "histogram_quantile(0.99, sum by (status, le) (rate(ponder_http_server_request_duration_ms_bucket{indexer=\"prod-api\",path=\"/sql/*\"}[5m])))", "legendFormat": "p99 {{status}}", "refId": "C" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ms" } }
+    },
+    {
+      "id": 19, "type": "heatmap", "title": "/sql/* latency distribution",
+      "description": "Heatmap of request rate per latency bucket. Bright cells near the top (>= the 500000 ms top bucket) are requests overflowing the histogram cap — those are truly stuck/timed-out.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 17 },
+      "targets": [{
+        "expr": "sum by (le) (rate(ponder_http_server_request_duration_ms_bucket{indexer=\"prod-api\",path=\"/sql/*\"}[1m]))",
+        "format": "heatmap",
+        "legendFormat": "{{le}}",
+        "refId": "A"
+      }],
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": { "scheme": "Spectral", "mode": "scheme", "exponent": 0.5, "steps": 64 },
+        "yAxis": { "unit": "ms", "decimals": 0 },
+        "tooltip": { "show": true, "yHistogram": true }
+      }
+    },
+    {
+      "id": 7, "type": "row", "title": "Database calls (from indexer process)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 24 }
+    },
+    {
+      "id": 8, "type": "timeseries", "title": "select_checkpoints avg latency (DB contention proxy)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 25 },
+      "targets": [{
+        "expr": "rate(ponder_database_method_duration_sum{indexer=\"prod-indexer\",method=\"select_checkpoints\"}[5m]) / rate(ponder_database_method_duration_count{indexer=\"prod-indexer\",method=\"select_checkpoints\"}[5m])",
+        "legendFormat": "avg ms",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "ms" } }
+    },
+    {
+      "id": 9, "type": "timeseries", "title": "DB method avg latency (top 8 by traffic)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 25 },
+      "targets": [{
+        "expr": "topk(8, rate(ponder_database_method_duration_sum{indexer=\"prod-indexer\"}[5m]) / rate(ponder_database_method_duration_count{indexer=\"prod-indexer\"}[5m]))",
+        "legendFormat": "{{method}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "ms" } }
+    },
+    {
+      "id": 10, "type": "timeseries", "title": "DB method error rate",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 25 },
+      "targets": [{
+        "expr": "rate(ponder_database_method_error_total{indexer=\"prod-indexer\"}[5m])",
+        "legendFormat": "{{method}}",
+        "refId": "A"
+      }]
+    },
+    {
+      "id": 11, "type": "row", "title": "Indexing + RPC",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 }
+    },
+    {
+      "id": 12, "type": "timeseries", "title": "Indexing event rate (top 10)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 33 },
+      "targets": [{
+        "expr": "topk(10, rate(ponder_indexing_function_duration_count{indexer=\"prod-indexer\"}[1m]))",
+        "legendFormat": "{{event}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "ops" } }
+    },
+    {
+      "id": 13, "type": "timeseries", "title": "Indexing function avg ms (top 10)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 33 },
+      "targets": [{
+        "expr": "topk(10, 1000 * rate(ponder_indexing_function_duration_sum{indexer=\"prod-indexer\"}[5m]) / rate(ponder_indexing_function_duration_count{indexer=\"prod-indexer\"}[5m]))",
+        "legendFormat": "{{event}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "ms" } }
+    },
+    {
+      "id": 14, "type": "timeseries", "title": "RPC error rate (per chain/method)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 33 },
+      "targets": [{
+        "expr": "rate(ponder_rpc_request_error_total{indexer=\"prod-indexer\",chain=~\"$chain\"}[5m])",
+        "legendFormat": "{{chain}} {{method}}",
+        "refId": "A"
+      }]
+    },
+    {
+      "id": 15, "type": "row", "title": "Process health (indexer + api)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 40 }
+    },
+    {
+      "id": 16, "type": "timeseries", "title": "Event-loop lag (p99, max)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 41 },
+      "targets": [
+        { "expr": "nodejs_eventloop_lag_p99_seconds{indexer=~\"prod-(api|indexer)\"}", "legendFormat": "{{indexer}} p99", "refId": "A" },
+        { "expr": "nodejs_eventloop_lag_max_seconds{indexer=~\"prod-(api|indexer)\"}", "legendFormat": "{{indexer}} max", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" } }
+    },
+    {
+      "id": 17, "type": "timeseries", "title": "Process memory (RSS, heap)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 41 },
+      "targets": [
+        { "expr": "process_resident_memory_bytes{indexer=~\"prod-(api|indexer)\"}", "legendFormat": "{{indexer}} rss", "refId": "A" },
+        { "expr": "process_heap_bytes{indexer=~\"prod-(api|indexer)\"}", "legendFormat": "{{indexer}} heap", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes" } }
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/indexer-staging.json
+++ b/monitoring/grafana/provisioning/dashboards/indexer-staging.json
@@ -1,0 +1,181 @@
+{
+  "title": "Indexer — staging",
+  "uid": "indexer-staging",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "timezone": "browser",
+  "tags": ["ponder", "indexer", "staging"],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": { "text": "Prometheus", "value": "Prometheus" }
+      },
+      {
+        "name": "chain",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "query": "label_values(ponder_sync_block_timestamp{indexer=\"prod\"}, chain)",
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": "All", "value": "$__all" },
+        "refresh": 2
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1, "type": "row", "title": "Lag",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
+    },
+    {
+      "id": 2, "type": "timeseries", "title": "Lag per chain (sync_block - indexing) seconds",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "targets": [{
+        "expr": "ponder_sync_block_timestamp{indexer=\"prod\",chain=~\"$chain\"} - ponder_indexing_timestamp{indexer=\"prod\",chain=~\"$chain\"}",
+        "legendFormat": "{{chain}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "s", "thresholds": { "mode": "absolute", "steps": [
+        { "color": "green", "value": null }, { "color": "yellow", "value": 30 }, { "color": "red", "value": 120 }
+      ]}}}
+    },
+    {
+      "id": 3, "type": "timeseries", "title": "Realtime mode (1=live, 0=historical)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "targets": [{
+        "expr": "ponder_sync_is_realtime{indexer=\"prod\",chain=~\"$chain\"}",
+        "legendFormat": "{{chain}}",
+        "refId": "A"
+      }]
+    },
+    {
+      "id": 4, "type": "row", "title": "HTTP / API",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 }
+    },
+    {
+      "id": 5, "type": "timeseries", "title": "Request rate by endpoint",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 10 },
+      "targets": [{
+        "expr": "sum by (path) (rate(ponder_http_server_request_duration_ms_count{indexer=\"prod\"}[1m]))",
+        "legendFormat": "{{path}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "reqps" } }
+    },
+    {
+      "id": 6, "type": "timeseries", "title": "p95 latency by endpoint (ms)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 10 },
+      "targets": [{
+        "expr": "histogram_quantile(0.95, sum by (path, le) (rate(ponder_http_server_request_duration_ms_bucket{indexer=\"prod\"}[5m])))",
+        "legendFormat": "{{path}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "ms" } }
+    },
+    {
+      "id": 7, "type": "row", "title": "Database calls (from this indexer)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 17 }
+    },
+    {
+      "id": 8, "type": "timeseries", "title": "select_checkpoints avg latency (DB contention proxy)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 18 },
+      "targets": [{
+        "expr": "rate(ponder_database_method_duration_sum{indexer=\"prod\",method=\"select_checkpoints\"}[5m]) / rate(ponder_database_method_duration_count{indexer=\"prod\",method=\"select_checkpoints\"}[5m])",
+        "legendFormat": "avg ms",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "ms" } }
+    },
+    {
+      "id": 9, "type": "timeseries", "title": "DB method avg latency (top 8 by traffic)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 18 },
+      "targets": [{
+        "expr": "topk(8, rate(ponder_database_method_duration_sum{indexer=\"prod\"}[5m]) / rate(ponder_database_method_duration_count{indexer=\"prod\"}[5m]))",
+        "legendFormat": "{{method}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "ms" } }
+    },
+    {
+      "id": 10, "type": "timeseries", "title": "DB method error rate",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 18 },
+      "targets": [{
+        "expr": "rate(ponder_database_method_error_total{indexer=\"prod\"}[5m])",
+        "legendFormat": "{{method}}",
+        "refId": "A"
+      }]
+    },
+    {
+      "id": 11, "type": "row", "title": "Indexing + RPC",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 25 }
+    },
+    {
+      "id": 12, "type": "timeseries", "title": "Indexing event rate (top 10)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 26 },
+      "targets": [{
+        "expr": "topk(10, rate(ponder_indexing_function_duration_count{indexer=\"prod\"}[1m]))",
+        "legendFormat": "{{event}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "ops" } }
+    },
+    {
+      "id": 13, "type": "timeseries", "title": "Indexing function avg ms (top 10)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 26 },
+      "targets": [{
+        "expr": "topk(10, 1000 * rate(ponder_indexing_function_duration_sum{indexer=\"prod\"}[5m]) / rate(ponder_indexing_function_duration_count{indexer=\"prod\"}[5m]))",
+        "legendFormat": "{{event}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "ms" } }
+    },
+    {
+      "id": 14, "type": "timeseries", "title": "RPC error rate (per chain/method)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 26 },
+      "targets": [{
+        "expr": "rate(ponder_rpc_request_error_total{indexer=\"prod\",chain=~\"$chain\"}[5m])",
+        "legendFormat": "{{chain}} {{method}}",
+        "refId": "A"
+      }]
+    },
+    {
+      "id": 15, "type": "row", "title": "Process health",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 33 }
+    },
+    {
+      "id": 16, "type": "timeseries", "title": "Event-loop lag (p99, max)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 34 },
+      "targets": [
+        { "expr": "nodejs_eventloop_lag_p99_seconds{indexer=\"prod\"}", "legendFormat": "p99", "refId": "A" },
+        { "expr": "nodejs_eventloop_lag_max_seconds{indexer=\"prod\"}", "legendFormat": "max", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" } }
+    },
+    {
+      "id": 17, "type": "timeseries", "title": "Process memory (RSS, heap)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 34 },
+      "targets": [
+        { "expr": "process_resident_memory_bytes{indexer=\"prod\"}", "legendFormat": "rss", "refId": "A" },
+        { "expr": "process_heap_bytes{indexer=\"prod\"}", "legendFormat": "heap", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes" } }
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/indexer-testnet.json
+++ b/monitoring/grafana/provisioning/dashboards/indexer-testnet.json
@@ -1,0 +1,181 @@
+{
+  "title": "Indexer — testnet",
+  "uid": "indexer-testnet",
+  "schemaVersion": 39,
+  "version": 2,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "timezone": "browser",
+  "tags": ["ponder", "indexer", "testnet"],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": { "text": "Prometheus", "value": "Prometheus" }
+      },
+      {
+        "name": "chain",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "query": "label_values(ponder_sync_block_timestamp{indexer=\"testnet-indexer\"}, chain)",
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": "All", "value": "$__all" },
+        "refresh": 2
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1, "type": "row", "title": "Lag",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
+    },
+    {
+      "id": 2, "type": "timeseries", "title": "Lag per chain (sync_block - indexing) seconds",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "targets": [{
+        "expr": "ponder_sync_block_timestamp{indexer=\"testnet-indexer\",chain=~\"$chain\"} - ponder_indexing_timestamp{indexer=\"testnet-indexer\",chain=~\"$chain\"}",
+        "legendFormat": "{{chain}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "s", "thresholds": { "mode": "absolute", "steps": [
+        { "color": "green", "value": null }, { "color": "yellow", "value": 30 }, { "color": "red", "value": 120 }
+      ]}}}
+    },
+    {
+      "id": 3, "type": "timeseries", "title": "Realtime mode (1=live, 0=historical)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "targets": [{
+        "expr": "ponder_sync_is_realtime{indexer=\"testnet-indexer\",chain=~\"$chain\"}",
+        "legendFormat": "{{chain}}",
+        "refId": "A"
+      }]
+    },
+    {
+      "id": 4, "type": "row", "title": "HTTP / API (read-API droplet)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 }
+    },
+    {
+      "id": 5, "type": "timeseries", "title": "Request rate by endpoint",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 10 },
+      "targets": [{
+        "expr": "sum by (path) (rate(ponder_http_server_request_duration_ms_count{indexer=\"testnet-api\"}[1m]))",
+        "legendFormat": "{{path}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "reqps" } }
+    },
+    {
+      "id": 6, "type": "timeseries", "title": "p95 latency by endpoint (ms)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 10 },
+      "targets": [{
+        "expr": "histogram_quantile(0.95, sum by (path, le) (rate(ponder_http_server_request_duration_ms_bucket{indexer=\"testnet-api\"}[5m])))",
+        "legendFormat": "{{path}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "ms" } }
+    },
+    {
+      "id": 7, "type": "row", "title": "Database calls (from indexer process)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 17 }
+    },
+    {
+      "id": 8, "type": "timeseries", "title": "select_checkpoints avg latency (DB contention proxy)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 18 },
+      "targets": [{
+        "expr": "rate(ponder_database_method_duration_sum{indexer=\"testnet-indexer\",method=\"select_checkpoints\"}[5m]) / rate(ponder_database_method_duration_count{indexer=\"testnet-indexer\",method=\"select_checkpoints\"}[5m])",
+        "legendFormat": "avg ms",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "ms" } }
+    },
+    {
+      "id": 9, "type": "timeseries", "title": "DB method avg latency (top 8 by traffic)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 18 },
+      "targets": [{
+        "expr": "topk(8, rate(ponder_database_method_duration_sum{indexer=\"testnet-indexer\"}[5m]) / rate(ponder_database_method_duration_count{indexer=\"testnet-indexer\"}[5m]))",
+        "legendFormat": "{{method}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "ms" } }
+    },
+    {
+      "id": 10, "type": "timeseries", "title": "DB method error rate",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 18 },
+      "targets": [{
+        "expr": "rate(ponder_database_method_error_total{indexer=\"testnet-indexer\"}[5m])",
+        "legendFormat": "{{method}}",
+        "refId": "A"
+      }]
+    },
+    {
+      "id": 11, "type": "row", "title": "Indexing + RPC",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 25 }
+    },
+    {
+      "id": 12, "type": "timeseries", "title": "Indexing event rate (top 10)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 26 },
+      "targets": [{
+        "expr": "topk(10, rate(ponder_indexing_function_duration_count{indexer=\"testnet-indexer\"}[1m]))",
+        "legendFormat": "{{event}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "ops" } }
+    },
+    {
+      "id": 13, "type": "timeseries", "title": "Indexing function avg ms (top 10)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 26 },
+      "targets": [{
+        "expr": "topk(10, 1000 * rate(ponder_indexing_function_duration_sum{indexer=\"testnet-indexer\"}[5m]) / rate(ponder_indexing_function_duration_count{indexer=\"testnet-indexer\"}[5m]))",
+        "legendFormat": "{{event}}",
+        "refId": "A"
+      }],
+      "fieldConfig": { "defaults": { "unit": "ms" } }
+    },
+    {
+      "id": 14, "type": "timeseries", "title": "RPC error rate (per chain/method)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 26 },
+      "targets": [{
+        "expr": "rate(ponder_rpc_request_error_total{indexer=\"testnet-indexer\",chain=~\"$chain\"}[5m])",
+        "legendFormat": "{{chain}} {{method}}",
+        "refId": "A"
+      }]
+    },
+    {
+      "id": 15, "type": "row", "title": "Process health (indexer + api)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 33 }
+    },
+    {
+      "id": 16, "type": "timeseries", "title": "Event-loop lag (p99, max)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 34 },
+      "targets": [
+        { "expr": "nodejs_eventloop_lag_p99_seconds{indexer=~\"testnet-(api|indexer)\"}", "legendFormat": "{{indexer}} p99", "refId": "A" },
+        { "expr": "nodejs_eventloop_lag_max_seconds{indexer=~\"testnet-(api|indexer)\"}", "legendFormat": "{{indexer}} max", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" } }
+    },
+    {
+      "id": 17, "type": "timeseries", "title": "Process memory (RSS, heap)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 34 },
+      "targets": [
+        { "expr": "process_resident_memory_bytes{indexer=~\"testnet-(api|indexer)\"}", "legendFormat": "{{indexer}} rss", "refId": "A" },
+        { "expr": "process_heap_bytes{indexer=~\"testnet-(api|indexer)\"}", "legendFormat": "{{indexer}} heap", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes" } }
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/monitoring/prometheus.yml.tmpl
+++ b/monitoring/prometheus.yml.tmpl
@@ -1,0 +1,81 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: postgres
+    static_configs:
+      - targets:
+          - postgres-exporter:9187
+        labels:
+          role: primary
+
+  - job_name: ponder
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - __PONDER_PROD_API_HOST__
+        labels:
+          indexer: prod-api
+      - targets:
+          - __PONDER_PROD_INDEXER_HOST__
+        labels:
+          indexer: prod-indexer
+      - targets:
+          - __PONDER_STAGING_HOST__
+        labels:
+          indexer: staging
+      - targets:
+          - __PONDER_TESTNET_API_HOST__
+        labels:
+          indexer: testnet-api
+      - targets:
+          - __PONDER_TESTNET_INDEXER_HOST__
+        labels:
+          indexer: testnet-indexer
+  - job_name: ponder-bankr
+    scheme: https
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - __PONDER_BANKR_HOST__
+        labels:
+          indexer: bankr
+
+  # DigitalOcean managed Postgres telegraf-style metrics endpoint.
+  # Replace the URL/auth with whatever DO gave you (usually exposed per-database
+  # under "Metrics" → "Prometheus integration"). Drop the high-cardinality labels
+  # we don't need to keep the time series count down.
+  - job_name: do-postgres
+    scheme: https
+    metrics_path: /metrics
+    basic_auth:
+      username: "__DO_PG_USER__"
+      password: "__DO_PG_PASSWORD__"
+    tls_config:
+      insecure_skip_verify: true
+    static_configs:
+      - targets:
+          - __DO_PG_HOST__
+        labels:
+          role: primary
+    metric_relabel_configs:
+      - action: labeldrop
+        regex: (cloud|project|service|service_type)
+
+  - job_name: do-postgres-replica
+    scheme: https
+    metrics_path: /metrics
+    basic_auth:
+      username: "__DO_PG_USER__"
+      password: "__DO_PG_PASSWORD__"
+    tls_config:
+      insecure_skip_verify: true
+    static_configs:
+      - targets:
+          - __DO_PG_REPLICA_HOST__
+        labels:
+          role: replica
+    metric_relabel_configs:
+      - action: labeldrop
+        regex: (cloud|project|service|service_type)


### PR DESCRIPTION
## Summary

Adds the `monitoring/` directory containing a docker-compose stack for local/host-side observability:

- **Prometheus** scrapes Ponder indexer instances (prod / staging / testnet / bankr), a Postgres exporter, and DigitalOcean managed-Postgres Prometheus integrations (primary + replica). Config is templated from env vars at container start.
- **postgres-exporter** points at `DATABASE_URL`.
- **Grafana** with provisioned datasource and dashboards for the indexers and DB / DB-replica.

Secrets stay out of git: `monitoring/.env` is covered by the existing top-level `.env` rule in `.gitignore`; `monitoring/.env.example` documents the required variables.