### PR TITLE
[EVM-3] feat: add queryable pool beneficiary indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,19 +3,19 @@
 ## Multicurve Quickstart
 
 - Prereqs: pnpm installed and Postgres reachable; copy `.env.local.example` to `.env.local` and set required RPC URLs and DB connection.
-- Dev run: `pnpm run dev --config ./ponder.config.multicurve.ts`
-- Prod run: `pnpm run start --config ./ponder.config.multicurve.ts`
+- Dev run: `pnpm run dev --config ./ponder.config.local.ts`
+- Prod run: `pnpm run start --config ./ponder.config.ts`
 
-This uses the `ponder.config.multicurve.ts` file to index the Multicurve setup. Logs will show chains and contracts being synced according to that config.
+This uses the Ponder config to index the configured Doppler sources. Logs will show chains and contracts being synced according to that config.
 
-This package ships with multiple Ponder configs so you can index different networks or a Zora‑only subset. You can select a config at runtime via `--config` when using `ponder dev` or `ponder start`.
+You can select a config at runtime via `--config` when using `ponder dev` or `ponder start`.
 
 ## Configs
 
-- `ponder.config.ts`: Multichain (Base, Unichain, Ink) + Zora listeners on Base.
-- `ponder.config.multichain.ts`: Multichain (same scope as above).
-- `ponder.config.multicurve.ts`: Multicurve indexing setup.
-- `ponder.config.zora.ts`: Zora-only on Base (limits chains/contracts to Zora needs).
+- `ponder.config.ts`: Main indexer config.
+- `ponder.config.testnet.ts`: Testnet indexer config
+- `ponder.config.bankr.ts`: Bankr indexer config
+- `ponder.config.local.ts`: Local frontend testing config. This file is intentionally ignored by git; copy `ponder.config.local.ts.example` as a reference point.
 
 ## Run
 
@@ -23,11 +23,6 @@ From this package directory:
 
 - Dev (hot reload): `ponder dev --config ./ponder.config.ts`
 - Prod: `ponder start --config ./ponder.config.ts`
-
-Swap the config path to target a different setup, for example:
-
-- Multichain: `ponder dev --config ./ponder.config.multichain.ts`
-- Zora-only: `ponder dev --config ./ponder.config.zora.ts`
 
 ## Local Base/Ethereum Frontend Testing
 
@@ -74,6 +69,24 @@ pnpm run db:local-compat
 This applies `scripts/create-local-compat-views.sql` to the Docker Compose Postgres service and creates or replaces `public.mv_pool_day_agg_2` as a normal Postgres view. The view exposes the frontend-required columns `pool`, `volume`, `percent_day_change`, `open`, and `close` using local indexed data.
 
 Run `pnpm run db:local-compat` again any time you reset the local database with `docker compose down -v`. You do not need to rerun it for every indexer restart unless the database volume was recreated or the view was dropped.
+
+### Pool Beneficiary Backfill
+
+Deploying the `pool_beneficiary` table into a database that already contains indexed pools requires either a full Ponder replay into a fresh schema or a one-time backfill from current on-chain beneficiary state.
+
+Use the dry-run first:
+
+```bash
+node scripts/backfill-pool-beneficiaries.mjs --schema public
+```
+
+Then apply after reviewing the selected pool and row counts:
+
+```bash
+node scripts/backfill-pool-beneficiaries.mjs --schema public --apply
+```
+
+The script pins one snapshot block per selected chain, reads `getBeneficiaries()` at those blocks for multicurve, scheduled multicurve, decay multicurve, dhook, and rehype pools, then replaces active rows in `pool_beneficiary` for those pools. Use `--chain-id` only to limit the run to one chain.
 
 ## Notes
 

--- a/ponder.schema.ts
+++ b/ponder.schema.ts
@@ -788,7 +788,7 @@ export const swapRelations = relations(swap, ({ one }) => ({
 // pools have many positions
 export const poolRelations = relations(pool, ({ one, many }) => ({
   positions: many(position),
-  beneficiaries: many(poolBeneficiary),
+  beneficiariesRows: many(poolBeneficiary),
   baseToken: one(token, {
     fields: [pool.baseToken, pool.chainId],
     references: [token.address, token.chainId],

--- a/ponder.schema.ts
+++ b/ponder.schema.ts
@@ -654,6 +654,30 @@ export const cumulatedFees = onchainTable(
   })
 );
 
+export const poolBeneficiary = onchainTable(
+  "pool_beneficiary",
+  (t) => ({
+    poolId: t.hex().notNull(),
+    chainId: t.integer().notNull(),
+    beneficiary: t.hex().notNull(),
+    assetId: t.hex().notNull(),
+    shares: t.bigint().notNull(),
+    initializer: t.hex().notNull(),
+    discoveredAt: t.bigint().notNull(),
+    updatedAt: t.bigint().notNull(),
+  }),
+  (table) => ({
+    pk: primaryKey({ columns: [table.poolId, table.chainId, table.beneficiary] }),
+    beneficiaryIdx: index().on(table.beneficiary),
+    assetIdx: index().on(table.assetId),
+    chainIdIdx: index().on(table.chainId),
+    beneficiaryAssetIdx: index().on(table.beneficiary, table.assetId, table.chainId),
+    beneficiaryUpdatedIdx: index().on(table.beneficiary, table.updatedAt, table.chainId, table.assetId),
+    beneficiaryAssetUpdatedIdx: index().on(table.beneficiary, table.assetId, table.chainId, table.updatedAt),
+    assetUpdatedIdx: index().on(table.assetId, table.updatedAt, table.chainId, table.beneficiary),
+  })
+);
+
 export const userAsset = onchainTable(
   "user_asset",
   (t) => ({
@@ -764,6 +788,7 @@ export const swapRelations = relations(swap, ({ one }) => ({
 // pools have many positions
 export const poolRelations = relations(pool, ({ one, many }) => ({
   positions: many(position),
+  beneficiaries: many(poolBeneficiary),
   baseToken: one(token, {
     fields: [pool.baseToken, pool.chainId],
     references: [token.address, token.chainId],
@@ -850,6 +875,22 @@ export const tokenVestingReleaseRelations = relations(tokenVestingRelease, ({ on
 // users have many assets and positions
 export const userRelations = relations(user, ({ many }) => ({
   userAssets: many(userAsset),
+  poolBeneficiaries: many(poolBeneficiary),
+}));
+
+export const poolBeneficiaryRelations = relations(poolBeneficiary, ({ one }) => ({
+  pool: one(pool, {
+    fields: [poolBeneficiary.poolId, poolBeneficiary.chainId],
+    references: [pool.address, pool.chainId],
+  }),
+  beneficiary: one(user, {
+    fields: [poolBeneficiary.beneficiary, poolBeneficiary.chainId],
+    references: [user.address, user.chainId],
+  }),
+  token: one(token, {
+    fields: [poolBeneficiary.assetId, poolBeneficiary.chainId],
+    references: [token.address, token.chainId],
+  }),
 }));
 
 // userAsset has one user and one asset
@@ -886,7 +927,7 @@ export const fifteenMinuteBucketUsdRelations = relations(
 );
 
 // v4pools relations
-export const v4poolsRelations = relations(v4pools, ({ one, many }) => ({
+export const v4poolsRelations = relations(v4pools, ({ one }) => ({
   baseToken: one(token, {
     fields: [v4pools.baseToken],
     references: [token.address],

--- a/scripts/backfill-pool-beneficiaries.mjs
+++ b/scripts/backfill-pool-beneficiaries.mjs
@@ -1,0 +1,522 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import process from "node:process";
+import { createPublicClient, http } from "viem";
+
+const SUPPORTED_POOL_TYPES = ["multicurve", "scheduled-multicurve", "decay-multicurve", "dhook", "rehype"];
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+const RPC_ENV_BY_CHAIN = {
+  1: ["PONDER_RPC_URL_1", "MAINNET_RPC"],
+  130: ["PONDER_RPC_URL_130", "UNICHAIN_RPC"],
+  143: ["PONDER_RPC_URL_143", "MONAD_RPC"],
+  8453: ["PONDER_RPC_URL_8453", "BASE_RPC"],
+  57073: ["PONDER_RPC_URL_57073", "INK_RPC"],
+};
+
+const GET_BENEFICIARIES_ABI = [
+  {
+    type: "function",
+    name: "getBeneficiaries",
+    stateMutability: "view",
+    inputs: [{ name: "asset", type: "address" }],
+    outputs: [
+      {
+        name: "",
+        type: "tuple[]",
+        components: [
+          { name: "beneficiary", type: "address" },
+          { name: "shares", type: "uint96" },
+        ],
+      },
+    ],
+  },
+];
+
+function loadDotEnv(path) {
+  if (!existsSync(path)) return;
+  for (const rawLine of readFileSync(path, "utf8").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (!match) continue;
+    const [, key, rawValue] = match;
+    if (process.env[key] !== undefined) continue;
+    process.env[key] = rawValue.trim().replace(/^(['"])(.*)\1$/, "$2");
+  }
+}
+
+loadDotEnv(resolve(process.cwd(), ".env"));
+loadDotEnv(resolve(process.cwd(), ".env.local"));
+
+function parseArgs(argv) {
+  const args = {
+    apply: false,
+    schema: undefined,
+    databaseUrl: process.env.DATABASE_URL,
+    rpcUrl: undefined,
+    chainId: undefined,
+    limit: undefined,
+    blockNumber: undefined,
+    concurrency: 4,
+    applyBatchSize: 500,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--") continue;
+    if (arg === "--help" || arg === "-h") args.help = true;
+    else if (arg === "--apply") args.apply = true;
+    else if (arg.startsWith("--")) {
+      const key = arg.slice(2);
+      const value = argv[++i];
+      if (value === undefined || value.startsWith("--")) {
+        throw new Error(`Missing value for ${arg}`);
+      }
+      if (key === "database-url") args.databaseUrl = value;
+      else if (key === "rpc-url") args.rpcUrl = value;
+      else if (key === "chain-id") args.chainId = Number(value);
+      else if (key === "schema") args.schema = value;
+      else if (key === "limit") args.limit = Number(value);
+      else if (key === "block-number") args.blockNumber = BigInt(value);
+      else if (key === "concurrency") args.concurrency = Number(value);
+      else if (key === "apply-batch-size") args.applyBatchSize = Number(value);
+      else throw new Error(`Unknown argument ${arg}`);
+    } else throw new Error(`Unknown argument ${arg}`);
+  }
+
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/backfill-pool-beneficiaries.mjs [options]
+
+Backfills pool_beneficiary from current on-chain getBeneficiaries() state.
+Use this after deploying the pool_beneficiary table into a database that already
+contains indexed multicurve, scheduled multicurve, decay multicurve, dhook, or rehype pools.
+
+The script replaces pool_beneficiary rows for the selected pools and refreshes
+pool.beneficiaries with the same current on-chain snapshot. Rehype hook-local
+beneficiary fee accounting is separate from this base beneficiary backfill.
+
+Options:
+  --database-url <url>       Postgres URL. Defaults to DATABASE_URL.
+  --rpc-url <url>            RPC URL for a single-chain run. Without this,
+                             each chain uses PONDER_RPC_URL_<chainId>.
+  --chain-id <id>            Limit selected pools to one chain. Defaults to all
+                             chains represented by selected indexed pools.
+  --schema <schema>          Ponder schema containing pool and pool_beneficiary.
+  --limit <n>                Limit selected pool rows.
+  --block-number <n>         Pin eth_call reads to a block. Defaults to one
+                             auto-pinned block per selected chain.
+  --concurrency <n>          Concurrent getBeneficiaries calls. Defaults to 4.
+  --apply-batch-size <n>     Pools per DB transaction. Defaults to 500.
+  --apply                   Write rows. Without this flag, dry-run only.
+
+Examples:
+  node scripts/backfill-pool-beneficiaries.mjs --schema public
+  node scripts/backfill-pool-beneficiaries.mjs --schema public --apply
+  node scripts/backfill-pool-beneficiaries.mjs --schema public --chain-id 8453 --apply
+`);
+}
+
+function psqlJson(databaseUrl, sql) {
+  const stdout = execFileSync(
+    "psql",
+    [databaseUrl, "-X", "-A", "-t", "-v", "ON_ERROR_STOP=1", "-c", sql],
+    { encoding: "utf8", maxBuffer: 1024 * 1024 * 512 },
+  ).trim();
+  return JSON.parse(stdout || "[]");
+}
+
+function psqlExec(databaseUrl, sql) {
+  execFileSync("psql", [databaseUrl, "-X", "-v", "ON_ERROR_STOP=1"], {
+    input: sql,
+    encoding: "utf8",
+    stdio: ["pipe", "inherit", "inherit"],
+  });
+}
+
+function qi(identifier) {
+  return `"${String(identifier).replaceAll('"', '""')}"`;
+}
+
+function ql(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function normalizeHex(value) {
+  const lower = String(value).toLowerCase();
+  return lower.startsWith("0x") ? lower : `0x${lower}`;
+}
+
+function normalizeAddress(value, label) {
+  const address = normalizeHex(value);
+  if (!/^0x[a-f0-9]{40}$/.test(address)) {
+    throw new Error(`Invalid ${label} address ${value}`);
+  }
+  return address;
+}
+
+function hexNoPrefix(value) {
+  return normalizeHex(value).slice(2);
+}
+
+function sqlHex(value, columnType) {
+  const hex = hexNoPrefix(value);
+  return columnType === "bytea" ? `decode(${ql(hex)}, 'hex')` : ql(`0x${hex}`);
+}
+
+function sqlJson(value, columnType) {
+  const type = columnType === "json" ? "json" : "jsonb";
+  return `${ql(JSON.stringify(value))}::${type}`;
+}
+
+function selectHex(columnName, columnType, alias) {
+  const column = qi(columnName);
+  if (columnType === "bytea") {
+    return `concat('0x', lower(encode(${column}, 'hex'))) as ${qi(alias)}`;
+  }
+  return `case when lower(${column}::text) like '0x%' then lower(${column}::text) else concat('0x', lower(${column}::text)) end as ${qi(alias)}`;
+}
+
+function resolveTable(databaseUrl, schemaName, tableName) {
+  const filter = schemaName
+    ? `and table_schema = ${ql(schemaName)}`
+    : "and table_schema not in ('pg_catalog', 'information_schema')";
+  const rows = psqlJson(
+    databaseUrl,
+    `select coalesce(json_agg(q), '[]'::json) from (
+       select table_schema, table_name from information_schema.tables
+       where table_name = ${ql(tableName)} ${filter}
+       order by table_schema limit 2
+     ) q`,
+  );
+  if (rows.length === 0) {
+    throw new Error(`Table ${tableName} not found${schemaName ? ` in schema ${schemaName}` : ""}`);
+  }
+  if (rows.length > 1) {
+    throw new Error(`Multiple ${tableName} tables found; pass --schema explicitly.`);
+  }
+  return rows[0];
+}
+
+function loadColumns(databaseUrl, table) {
+  const rows = psqlJson(
+    databaseUrl,
+    `select coalesce(json_agg(q), '[]'::json) from (
+       select column_name, data_type from information_schema.columns
+       where table_schema = ${ql(table.table_schema)}
+         and table_name = ${ql(table.table_name)}
+       order by ordinal_position
+     ) q`,
+  );
+  const columns = new Map();
+  for (const row of rows) columns.set(row.column_name, row.data_type);
+  return columns;
+}
+
+function requireColumn(columns, name) {
+  const type = columns.get(name);
+  if (!type) throw new Error(`Missing required column ${name}`);
+  return type;
+}
+
+function loadPoolRows({ databaseUrl, poolTable, poolColumns, limit, chainId }) {
+  const qualified = `${qi(poolTable.table_schema)}.${qi(poolTable.table_name)}`;
+  const addressType = requireColumn(poolColumns, "address");
+  const baseTokenType = requireColumn(poolColumns, "base_token");
+  const initializerType = requireColumn(poolColumns, "initializer");
+  const chainFilter = chainId ? `and chain_id = ${Number(chainId)}` : "";
+  const limitSql = limit ? `limit ${Number(limit)}` : "";
+
+  return psqlJson(
+    databaseUrl,
+    `select coalesce(json_agg(q), '[]'::json) from (
+       select
+         ${selectHex("address", addressType, "pool_id")},
+         ${selectHex("base_token", baseTokenType, "asset_id")},
+         ${selectHex("initializer", initializerType, "initializer")},
+         lower(type::text) as type,
+         chain_id::text as chain_id,
+         created_at::text as created_at
+       from ${qualified}
+       where lower(type::text) in (${SUPPORTED_POOL_TYPES.map(ql).join(", ")})
+         and initializer is not null
+         ${chainFilter}
+       order by chain_id, address
+       ${limitSql}
+     ) q`,
+  );
+}
+
+function normalizeBeneficiaries(beneficiaries) {
+  const sharesByBeneficiary = new Map();
+  if (!Array.isArray(beneficiaries)) return [];
+
+  for (const entry of beneficiaries) {
+    if (!entry || typeof entry !== "object") continue;
+    const beneficiary = normalizeAddress(entry.beneficiary, "beneficiary");
+    let shares;
+    try {
+      shares = BigInt(entry.shares ?? 0);
+    } catch {
+      continue;
+    }
+    if (beneficiary === ZERO_ADDRESS || shares <= 0n) continue;
+    sharesByBeneficiary.set(beneficiary, (sharesByBeneficiary.get(beneficiary) ?? 0n) + shares);
+  }
+
+  return [...sharesByBeneficiary.entries()].map(([beneficiary, shares]) => ({
+    beneficiary,
+    shares: shares.toString(),
+  }));
+}
+
+function resolveRpcUrl({ chainId, rpcUrl }) {
+  if (rpcUrl) return rpcUrl;
+  const envVars = RPC_ENV_BY_CHAIN[chainId] ?? [`PONDER_RPC_URL_${chainId}`];
+  for (const envVar of envVars) {
+    if (process.env[envVar]) return process.env[envVar];
+  }
+  throw new Error(`Missing RPC URL for chain ${chainId}. Set PONDER_RPC_URL_${chainId} or pass --rpc-url.`);
+}
+
+function createClient(rpcUrl) {
+  return createPublicClient({ transport: http(rpcUrl) });
+}
+
+async function verifyClientChain({ client, chainId }) {
+  const actualChainId = await client.getChainId();
+  if (actualChainId !== Number(chainId)) {
+    throw new Error(`RPC chain mismatch: expected ${chainId}, got ${actualChainId}`);
+  }
+}
+
+async function pinSnapshotBlock({ client, blockNumber }) {
+  const pinnedBlockNumber = blockNumber ?? await client.getBlockNumber();
+  const block = await client.getBlock({ blockNumber: pinnedBlockNumber });
+  return {
+    blockNumber: pinnedBlockNumber,
+    timestamp: block.timestamp,
+  };
+}
+
+async function mapWithConcurrency(items, concurrency, mapper) {
+  const results = new Array(items.length);
+  let nextIndex = 0;
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex++;
+      results[currentIndex] = await mapper(items[currentIndex], currentIndex);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+async function loadCurrentBeneficiaries({ poolRows, rpcUrl, blockNumber, concurrency }) {
+  const chainIds = [...new Set(poolRows.map((pool) => Number(pool.chain_id)))].sort((a, b) => a - b);
+  if (rpcUrl && chainIds.length > 1) {
+    throw new Error("--rpc-url can only be used with a single selected chain. Pass --chain-id or use per-chain PONDER_RPC_URL_<chainId> env vars.");
+  }
+  const clientByChain = new Map();
+  const snapshotByChain = new Map();
+  for (const chainId of chainIds) {
+    const client = createClient(resolveRpcUrl({ chainId, rpcUrl }));
+    await verifyClientChain({ client, chainId });
+    clientByChain.set(chainId, client);
+    snapshotByChain.set(chainId, await pinSnapshotBlock({ client, blockNumber }));
+  }
+
+  return mapWithConcurrency(poolRows, concurrency, async (poolRow) => {
+    const chainId = Number(poolRow.chain_id);
+    const client = clientByChain.get(chainId);
+    const snapshot = snapshotByChain.get(chainId);
+    const initializer = normalizeAddress(poolRow.initializer, "initializer");
+    const assetId = normalizeAddress(poolRow.asset_id, "asset");
+    const beneficiaries = await client.readContract({
+      abi: GET_BENEFICIARIES_ABI,
+      address: initializer,
+      functionName: "getBeneficiaries",
+      args: [assetId],
+      blockNumber: snapshot.blockNumber,
+    });
+
+    return {
+      pool: {
+        ...poolRow,
+        pool_id: normalizeHex(poolRow.pool_id),
+        asset_id: assetId,
+        initializer,
+        chain_id: String(chainId),
+      },
+      beneficiaries: normalizeBeneficiaries(beneficiaries),
+      snapshot,
+    };
+  });
+}
+
+function buildRows(poolStates) {
+  const rows = [];
+  for (const { pool, beneficiaries, snapshot } of poolStates) {
+    for (const beneficiary of beneficiaries) {
+      rows.push({
+        poolId: normalizeHex(pool.pool_id),
+        chainId: Number(pool.chain_id),
+        beneficiary: beneficiary.beneficiary,
+        assetId: pool.asset_id,
+        shares: BigInt(beneficiary.shares),
+        initializer: pool.initializer,
+        discoveredAt: BigInt(pool.created_at),
+        updatedAt: snapshot.timestamp,
+      });
+    }
+  }
+  return rows;
+}
+
+function buildInsertSql(rows, beneficiaryColumns, beneficiaryTable) {
+  const qualified = `${qi(beneficiaryTable.table_schema)}.${qi(beneficiaryTable.table_name)}`;
+  const poolIdType = requireColumn(beneficiaryColumns, "pool_id");
+  const beneficiaryType = requireColumn(beneficiaryColumns, "beneficiary");
+  const assetIdType = requireColumn(beneficiaryColumns, "asset_id");
+  const initializerType = requireColumn(beneficiaryColumns, "initializer");
+
+  const values = rows.map((row) => `(
+    ${sqlHex(row.poolId, poolIdType)},
+    ${Number(row.chainId)},
+    ${sqlHex(row.beneficiary, beneficiaryType)},
+    ${sqlHex(row.assetId, assetIdType)},
+    ${row.shares.toString()},
+    ${sqlHex(row.initializer, initializerType)},
+    ${row.discoveredAt.toString()},
+    ${row.updatedAt.toString()}
+  )`);
+
+  return `insert into ${qualified} as target
+    (pool_id, chain_id, beneficiary, asset_id, shares, initializer, discovered_at, updated_at)
+    values ${values.join(",\n")}
+    on conflict (pool_id, chain_id, beneficiary) do update set
+      asset_id = excluded.asset_id,
+      shares = excluded.shares,
+      initializer = excluded.initializer,
+      discovered_at = excluded.discovered_at,
+      updated_at = excluded.updated_at;`;
+}
+
+function buildReplaceSql({ poolStates, rows, poolColumns, beneficiaryColumns, poolTable, beneficiaryTable }) {
+  const poolQualified = `${qi(poolTable.table_schema)}.${qi(poolTable.table_name)}`;
+  const beneficiaryQualified = `${qi(beneficiaryTable.table_schema)}.${qi(beneficiaryTable.table_name)}`;
+  const poolAddressType = requireColumn(poolColumns, "address");
+  const poolBeneficiariesType = requireColumn(poolColumns, "beneficiaries");
+  const beneficiaryPoolIdType = requireColumn(beneficiaryColumns, "pool_id");
+
+  const selectedPools = poolStates.map(({ pool }) => `(
+    ${sqlHex(pool.pool_id, beneficiaryPoolIdType)},
+    ${Number(pool.chain_id)}
+  )`);
+
+  const selectedPoolSnapshots = poolStates.map(({ pool, beneficiaries }) => `(
+    ${sqlHex(pool.pool_id, poolAddressType)},
+    ${Number(pool.chain_id)},
+    ${sqlJson(beneficiaries, poolBeneficiariesType)}
+  )`);
+
+  const insertSql = rows.length > 0
+    ? buildInsertSql(rows, beneficiaryColumns, beneficiaryTable)
+    : "";
+
+  return `begin;
+with selected(pool_id, chain_id) as (values ${selectedPools.join(",\n")})
+delete from ${beneficiaryQualified} as target
+using selected
+where target.pool_id = selected.pool_id
+  and target.chain_id = selected.chain_id;
+
+with selected(pool_id, chain_id, beneficiaries) as (values ${selectedPoolSnapshots.join(",\n")})
+update ${poolQualified} as target
+set beneficiaries = selected.beneficiaries
+from selected
+where target.address = selected.pool_id
+  and target.chain_id = selected.chain_id;
+
+${insertSql}
+commit;`;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+  if (!args.databaseUrl) throw new Error("Missing --database-url or DATABASE_URL");
+  if (args.chainId !== undefined && (!Number.isInteger(args.chainId) || args.chainId <= 0)) {
+    throw new Error("--chain-id must be a positive integer");
+  }
+  if (args.limit !== undefined && (!Number.isInteger(args.limit) || args.limit <= 0)) {
+    throw new Error("--limit must be a positive integer");
+  }
+  if (!Number.isInteger(args.concurrency) || args.concurrency <= 0) {
+    throw new Error("--concurrency must be a positive integer");
+  }
+  if (!Number.isInteger(args.applyBatchSize) || args.applyBatchSize <= 0) {
+    throw new Error("--apply-batch-size must be a positive integer");
+  }
+
+  const poolTable = resolveTable(args.databaseUrl, args.schema, "pool");
+  const beneficiaryTable = resolveTable(args.databaseUrl, args.schema, "pool_beneficiary");
+  const poolColumns = loadColumns(args.databaseUrl, poolTable);
+  const beneficiaryColumns = loadColumns(args.databaseUrl, beneficiaryTable);
+  const poolRows = loadPoolRows({
+    databaseUrl: args.databaseUrl,
+    poolTable,
+    poolColumns,
+    limit: args.limit,
+    chainId: args.chainId,
+  });
+  const poolStates = await loadCurrentBeneficiaries({
+    poolRows,
+    rpcUrl: args.rpcUrl,
+    blockNumber: args.blockNumber,
+    concurrency: args.concurrency,
+  });
+  const rows = buildRows(poolStates);
+
+  console.log(`Resolved pool table: ${poolTable.table_schema}.${poolTable.table_name}`);
+  console.log(`Resolved pool_beneficiary table: ${beneficiaryTable.table_schema}.${beneficiaryTable.table_name}`);
+  console.log(`Source: current on-chain getBeneficiaries()`);
+  console.log(`Pool types: ${SUPPORTED_POOL_TYPES.join(", ")}`);
+  console.log(`Chains: ${[...new Set(poolRows.map((pool) => Number(pool.chain_id)))].sort((a, b) => a - b).join(", ") || "none"}`);
+  console.log(`Snapshot blocks: ${[...new Map(poolStates.map(({ pool, snapshot }) => [Number(pool.chain_id), snapshot])).entries()].map(([chainId, snapshot]) => `${chainId}:${snapshot.blockNumber}`).join(", ") || "none"}`);
+  console.log(`Selected pools: ${poolRows.length}`);
+  console.log(`Backfill rows: ${rows.length}`);
+
+  if (!args.apply) {
+    console.log("Dry run only. Pass --apply to write rows.");
+    return;
+  }
+
+  for (let i = 0; i < poolStates.length; i += args.applyBatchSize) {
+    const poolBatch = poolStates.slice(i, i + args.applyBatchSize);
+    if (poolBatch.length === 0) continue;
+    const poolKeys = new Set(poolBatch.map(({ pool }) => `${Number(pool.chain_id)}:${normalizeHex(pool.pool_id)}`));
+    const rowBatch = rows.filter((row) => poolKeys.has(`${Number(row.chainId)}:${normalizeHex(row.poolId)}`));
+    psqlExec(args.databaseUrl, buildReplaceSql({
+      poolStates: poolBatch,
+      rows: rowBatch,
+      poolColumns,
+      beneficiaryColumns,
+      poolTable,
+      beneficiaryTable,
+    }));
+    console.log(`Applied ${Math.min(i + poolBatch.length, poolStates.length)}/${poolStates.length} pools`);
+  }
+}
+
+main();

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -9,6 +9,15 @@ app.use("/graphql", graphql({ db, schema }));
 app.use("/", graphql({ db, schema }));
 app.use("/sql/*", client({ db, schema }));
 
+function parseChainIds(value: string | undefined): number[] | null {
+  if (value === undefined) {
+    return [];
+  }
+
+  const chainIds = value.split(",").map((id) => Number(id));
+  return chainIds.some((id) => !Number.isInteger(id) || id <= 0) ? null : chainIds;
+}
+
 // Debug endpoint to view current database locks and blocking queries
 app.get("/debug/locks", async (c) => {
   try {
@@ -76,20 +85,21 @@ app.get("/debug/activity", async (c) => {
 app.get("/search/:query", async (c) => {
   try {
     const query = c.req.param("query");
+    const chainIds = parseChainIds(c.req.query("chain_ids"));
 
-    const chainIds = c.req
-      .query("chain_ids")
-      ?.split(",")
-      .map((id) => Number(id));
+    if (chainIds === null) {
+      return c.json({ error: "Invalid chain_ids" }, 400);
+    }
 
-    // Normalize address queries to lowercase for case-insensitive matching
+    if (chainIds.length === 0) {
+      return c.json([]);
+    }
+
     const normalizedQuery =
       query.startsWith("0x") && query.length === 42
         ? query.toLowerCase()
         : query;
 
-    if (!chainIds) return c.json([]);
-    // First search tokens directly
     const tokenResults = await db.execute(sql`
       SELECT
        t.address,
@@ -102,7 +112,7 @@ app.get("/search/:query", async (c) => {
       LEFT JOIN pool p ON p.address = t.pool
       LEFT JOIN mv_pool_day_agg_2 ohlc ON ohlc.pool = t.pool
       WHERE
-        t.chain_id in (${chainIds.join(",")})
+        t.chain_id in (${sql.join(chainIds.map((id) => sql`${id}`), sql`,`)})
       AND
         (t.name ILIKE ${`${normalizedQuery}%`}
         OR t.address ILIKE ${`${normalizedQuery}%`}

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -2,6 +2,8 @@ export * from "./indexer-shared";
 export * from "./indexer-v3";
 export * from "./indexer-v2";
 export * from "./indexer-v4";
+export * from "./indexer-v4-scheduled";
+export * from "./indexer-v4-decay";
 // export * from "./indexer-v4-migrated";
 export * from "./blockHandlers";
 export * from "./indexer-zora";

--- a/src/indexer/indexer-dhook.ts
+++ b/src/indexer/indexer-dhook.ts
@@ -6,19 +6,17 @@ import { insertAssetIfNotExists, updateAsset } from "./shared/entities/asset";
 import { SwapOrchestrator, PriceService, MarketDataService } from "@app/core";
 import { updateFifteenMinuteBucketUsd } from "@app/utils/time-buckets";
 import { chainConfigs } from "@app/config/chains";
-import { pool, token, asset } from "ponder:schema";
-import { Address } from "viem";
+import { pool, token } from "ponder:schema";
 import { getQuoteInfo } from "@app/utils/getQuoteInfo";
 import { computeReservesFromPositions } from "@app/utils/v4-utils/computeReservesFromPositions";
 import { getPositionsForPool } from "./shared/entities/positionLedger";
 import { PoolKey } from "@app/types/v4-types";
 import { getDHookPoolData } from "@app/utils/dhook-utils";
-import { StateViewABI, DopplerHookInitializerABI, DopplerHookMigratorABI, RehypeDopplerHookInitializerABI } from "@app/abis";
+import { StateViewABI, DopplerHookInitializerABI, RehypeDopplerHookInitializerABI } from "@app/abis";
 import { isPrecompileAddress } from "@app/utils/validation";
 import { updateCumulatedFees } from "./shared/cumulatedFees";
-import { fetchV4MigrationPool, updateV4Pool } from "./shared/entities/v4pools";
-import { v4pools } from "ponder:schema";
 import { Context } from "ponder:registry";
+import { transferPoolBeneficiary } from "./shared/entities/multicurve/poolBeneficiary";
 
 type PositionEntry = { tickLower: number; tickUpper: number; liquidity: bigint };
 
@@ -26,13 +24,11 @@ async function fetchPositions({
   initializerAddress,
   assetAddress,
   poolId,
-  poolType,
   context,
 }: {
   initializerAddress: `0x${string}`;
   assetAddress: `0x${string}`;
   poolId: `0x${string}`;
-  poolType?: string;
   context: Context;
 }): Promise<readonly PositionEntry[]> {
   // Try getPositions (public on older initializer deployments, internal on newer)
@@ -73,7 +69,7 @@ async function fetchPositions({
 }
 
 onIndexerEvent("DopplerHookInitializer:Create", async ({ event, context }) => {
-  const { poolOrHook, asset: assetId, numeraire } = event.args;
+  const { asset: assetId, numeraire } = event.args;
   const { block, transaction } = event;
   const timestamp = block.timestamp;
 
@@ -151,7 +147,6 @@ onIndexerEvent("DopplerHookInitializer:Create", async ({ event, context }) => {
     initializerAddress: initializerAddress as `0x${string}`,
     assetAddress,
     poolId: poolAddress,
-    poolType: poolEntity.type,
     context,
   });
 
@@ -225,8 +220,21 @@ onIndexerEvent("DopplerHookInitializer:Collect", async ({ event, context }) => {
   });
 });
 
+onIndexerEvent("DopplerHookInitializer:UpdateBeneficiary", async ({ event, context }) => {
+  const { poolId, oldBeneficiary, newBeneficiary } = event.args;
+  const poolAddress = (poolId as string).toLowerCase() as `0x${string}`;
+
+  await transferPoolBeneficiary({
+    poolId: poolAddress,
+    oldBeneficiary,
+    newBeneficiary,
+    timestamp: event.block.timestamp,
+    context,
+  });
+});
+
 onIndexerEvent("DopplerHookInitializer:Swap", async ({ event, context }) => {
-  const { sender, poolKey: poolKeyTuple, poolId, params, amount0, amount1 } = event.args;
+  const { sender, poolId, amount0, amount1 } = event.args;
   const timestamp = event.block.timestamp;
   const { chain, client, db } = context;
 
@@ -266,7 +274,6 @@ onIndexerEvent("DopplerHookInitializer:Swap", async ({ event, context }) => {
       initializerAddress,
       assetAddress: poolEntity.baseToken,
       poolId: poolAddress,
-      poolType: poolEntity.type,
       context,
     }),
     getQuoteInfo(poolEntity.quoteToken, timestamp, context),
@@ -330,7 +337,7 @@ onIndexerEvent("DopplerHookInitializer:Swap", async ({ event, context }) => {
 
   const swapData = SwapOrchestrator.createSwapData({
     poolAddress,
-    sender: sender,
+    sender,
     transactionHash: event.transaction.hash,
     transactionFrom: event.transaction.from,
     blockNumber: event.block.number,
@@ -456,7 +463,6 @@ onIndexerEvent("DopplerHookInitializer:ModifyLiquidity", async ({ event, context
       initializerAddress: event.log.address as `0x${string}`,
       assetAddress: poolEntity.baseToken,
       poolId: poolAddress,
-      poolType: poolEntity.type,
       context,
     }),
   ]);

--- a/src/indexer/indexer-v4-decay.ts
+++ b/src/indexer/indexer-v4-decay.ts
@@ -29,6 +29,7 @@ import { zeroAddress } from "viem";
 import { getQuoteInfo } from "@app/utils/getQuoteInfo";
 import { readContractWithZeroDataPadding } from "@app/utils/readContractWithZeroDataPadding";
 import { updateCumulatedFees, handleCollect } from "./shared/cumulatedFees";
+import { transferPoolBeneficiary } from "./shared/entities/multicurve/poolBeneficiary";
 
 onIndexerEvent(
   "DecayMulticurveInitializer:Create",
@@ -154,6 +155,22 @@ onIndexerEvent(
       context,
     });
   }
+);
+
+onIndexerEvent(
+  "DecayMulticurveInitializer:UpdateBeneficiary",
+  async ({ event, context }) => {
+    const { poolId, oldBeneficiary, newBeneficiary } = event.args;
+    const poolAddress = (poolId as string).toLowerCase() as `0x${string}`;
+
+    await transferPoolBeneficiary({
+      poolId: poolAddress,
+      oldBeneficiary,
+      newBeneficiary,
+      timestamp: event.block.timestamp,
+      context,
+    });
+  },
 );
 
 onIndexerEvent(

--- a/src/indexer/indexer-v4-scheduled.ts
+++ b/src/indexer/indexer-v4-scheduled.ts
@@ -29,6 +29,7 @@ import { zeroAddress } from "viem";
 import { getQuoteInfo } from "@app/utils/getQuoteInfo";
 import { readContractWithZeroDataPadding } from "@app/utils/readContractWithZeroDataPadding";
 import { updateCumulatedFees, handleCollect } from "./shared/cumulatedFees";
+import { transferPoolBeneficiary } from "./shared/entities/multicurve/poolBeneficiary";
 
 onIndexerEvent(
   "UniswapV4ScheduledMulticurveInitializer:Create",
@@ -153,6 +154,22 @@ onIndexerEvent(
       context,
     });
   }
+);
+
+onIndexerEvent(
+  "UniswapV4ScheduledMulticurveInitializer:UpdateBeneficiary",
+  async ({ event, context }) => {
+    const { poolId, oldBeneficiary, newBeneficiary } = event.args;
+    const poolAddress = (poolId as string).toLowerCase() as `0x${string}`;
+
+    await transferPoolBeneficiary({
+      poolId: poolAddress,
+      oldBeneficiary,
+      newBeneficiary,
+      timestamp: event.block.timestamp,
+      context,
+    });
+  },
 );
 
 onIndexerEvent(

--- a/src/indexer/indexer-v4.ts
+++ b/src/indexer/indexer-v4.ts
@@ -38,6 +38,7 @@ import { readContractWithZeroDataPadding } from "@app/utils/readContractWithZero
 import { updateCumulatedFees, handleCollect } from "./shared/cumulatedFees";
 import { computeReservesFromPositions } from "@app/utils/v4-utils/computeReservesFromPositions";
 import { upsertPositionLedger, getPositionsForPool } from "./shared/entities/positionLedger";
+import { transferPoolBeneficiary } from "./shared/entities/multicurve/poolBeneficiary";
 
 onIndexerEvent("UniswapV4Initializer:Create", async ({ event, context }) => {
   const { poolOrHook, asset: assetId, numeraire } = event.args;
@@ -424,6 +425,22 @@ onIndexerEvent(
       context,
     });
   }
+);
+
+onIndexerEvent(
+  "UniswapV4MulticurveInitializer:UpdateBeneficiary",
+  async ({ event, context }) => {
+    const { poolId, oldBeneficiary, newBeneficiary } = event.args;
+    const poolAddress = (poolId as string).toLowerCase() as `0x${string}`;
+
+    await transferPoolBeneficiary({
+      poolId: poolAddress,
+      oldBeneficiary,
+      newBeneficiary,
+      timestamp: event.block.timestamp,
+      context,
+    });
+  },
 );
 
 onIndexerEvent(

--- a/src/indexer/shared/entities/multicurve/pool.ts
+++ b/src/indexer/shared/entities/multicurve/pool.ts
@@ -13,6 +13,8 @@ import { UniswapV4MulticurveInitializerABI } from "@app/abis/multicurve-abis/Uni
 import { readContractWithZeroDataPadding } from "@app/utils/readContractWithZeroDataPadding";
 import { upsertTokenWithPool } from "../token-optimized";
 import { MarketDataService } from "@app/core";
+import { replacePoolBeneficiaries } from "./poolBeneficiary";
+import { normalizePoolBeneficiaries } from "./poolBeneficiaryUtils";
 
 function getActiveInitializers(addresses: Address | Address[], blockNumber: bigint): Address[] {
   const addrArray = Array.isArray(addresses) ? addresses : [addresses];
@@ -178,7 +180,7 @@ export const insertMulticurvePoolV4Optimized = async ({
       address: resolvedInitializer,
       functionName: "getBeneficiaries",
       args: [baseToken],
-    }).catch(() => null),
+    }),
   ]);
 
   const isToken0 = baseToken.toLowerCase() < quoteToken.toLowerCase();
@@ -228,8 +230,10 @@ export const insertMulticurvePoolV4Optimized = async ({
 
   const isQuoteEth = quoteInfo.quoteToken === QuoteToken.Eth ? true : false;
   const hasValidQuote = isValidQuoteToken(quoteInfo.quoteToken);
+  const normalizedBeneficiaries = normalizePoolBeneficiaries(beneficiaries);
+
   // Insert new pool with all data at once
-  return await db.insert(pool).values({
+  const poolEntity = await db.insert(pool).values({
     address,
     tick,
     sqrtPrice: sqrtPriceX96,
@@ -267,9 +271,18 @@ export const insertMulticurvePoolV4Optimized = async ({
       hooks: poolKey.hooks.toLowerCase(),
     },
     tickLower: tick,
-    beneficiaries: beneficiaries
-      ? beneficiaries.map(b => ({ beneficiary: b.beneficiary.toLowerCase() as `0x${string}`, shares: b.shares.toString() }))
-      : null,
+    beneficiaries: normalizedBeneficiaries,
     initializer: resolvedInitializer.toLowerCase() as `0x${string}`,
   });
+
+  await replacePoolBeneficiaries({
+    poolId: address,
+    assetId: baseToken,
+    initializer: resolvedInitializer,
+    beneficiaries,
+    timestamp,
+    context,
+  });
+
+  return poolEntity;
 };

--- a/src/indexer/shared/entities/multicurve/poolBeneficiary.test.ts
+++ b/src/indexer/shared/entities/multicurve/poolBeneficiary.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { mergePoolBeneficiaryTransfer, normalizeIndexedPoolBeneficiaries, normalizePoolBeneficiaries } from "./poolBeneficiaryUtils";
+
+describe("normalizePoolBeneficiaries", () => {
+  it("normalizes beneficiary addresses and stringifies shares", () => {
+    expect(
+      normalizePoolBeneficiaries([
+        {
+          beneficiary: "0xABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD",
+          shares: 100n,
+        },
+      ]),
+    ).toEqual([
+      {
+        beneficiary: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+        shares: "100",
+      },
+    ]);
+  });
+
+  it("filters the zero address", () => {
+    expect(
+      normalizePoolBeneficiaries([
+        {
+          beneficiary: "0x0000000000000000000000000000000000000000",
+          shares: 100n,
+        },
+        {
+          beneficiary: "0x1111111111111111111111111111111111111111",
+          shares: 200n,
+        },
+      ]),
+    ).toEqual([
+      {
+        beneficiary: "0x1111111111111111111111111111111111111111",
+        shares: "200",
+      },
+    ]);
+  });
+
+  it("filters zero-share beneficiaries", () => {
+    expect(
+      normalizePoolBeneficiaries([
+        {
+          beneficiary: "0x1111111111111111111111111111111111111111",
+          shares: 0n,
+        },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("merges duplicate beneficiaries", () => {
+    expect(
+      normalizePoolBeneficiaries([
+        {
+          beneficiary: "0x1111111111111111111111111111111111111111",
+          shares: 100n,
+        },
+        {
+          beneficiary: "0x1111111111111111111111111111111111111111",
+          shares: 200n,
+        },
+      ]),
+    ).toEqual([
+      {
+        beneficiary: "0x1111111111111111111111111111111111111111",
+        shares: "300",
+      },
+    ]);
+  });
+
+  it("normalizes persisted beneficiary snapshots", () => {
+    expect(
+      normalizeIndexedPoolBeneficiaries([
+        { beneficiary: "0xABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD", shares: "100" },
+        { beneficiary: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd", shares: "50" },
+        { beneficiary: "0x2222222222222222222222222222222222222222", shares: "0" },
+        { beneficiary: "0x3333333333333333333333333333333333333333", shares: "bad" },
+        { beneficiary: 123, shares: "10" },
+      ]),
+    ).toEqual([
+      {
+        beneficiary: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+        shares: "150",
+      },
+    ]);
+  });
+
+  it("merges transferred shares into an existing beneficiary", () => {
+    expect(
+      mergePoolBeneficiaryTransfer({
+        beneficiaries: [
+          { beneficiary: "0x1111111111111111111111111111111111111111", shares: "100" },
+          { beneficiary: "0x2222222222222222222222222222222222222222", shares: "50" },
+        ],
+        oldBeneficiary: "0x1111111111111111111111111111111111111111",
+        newBeneficiary: "0x2222222222222222222222222222222222222222",
+        shares: 100n,
+      }),
+    ).toEqual([
+      { beneficiary: "0x2222222222222222222222222222222222222222", shares: "150" },
+    ]);
+  });
+});

--- a/src/indexer/shared/entities/multicurve/poolBeneficiary.ts
+++ b/src/indexer/shared/entities/multicurve/poolBeneficiary.ts
@@ -1,0 +1,225 @@
+import { and, eq } from "ponder";
+import { Context } from "ponder:registry";
+import { pool, poolBeneficiary } from "ponder:schema";
+import { Address } from "viem";
+import { setBeneficiariesCache } from "../../beneficiariesCache";
+import {
+  IndexedPoolBeneficiary,
+  MulticurveBeneficiary,
+  mergePoolBeneficiaryTransfer,
+  normalizeIndexedPoolBeneficiaries,
+  normalizePoolBeneficiaries,
+} from "./poolBeneficiaryUtils";
+
+export type { IndexedPoolBeneficiary, MulticurveBeneficiary } from "./poolBeneficiaryUtils";
+
+const GET_BENEFICIARIES_ABI = [
+  {
+    type: "function",
+    name: "getBeneficiaries",
+    stateMutability: "view",
+    inputs: [{ name: "asset", type: "address" }],
+    outputs: [
+      {
+        name: "",
+        type: "tuple[]",
+        components: [
+          { name: "beneficiary", type: "address" },
+          { name: "shares", type: "uint96" },
+        ],
+      },
+    ],
+  },
+] as const;
+
+async function refetchPoolBeneficiaries({
+  poolId,
+  poolEntity,
+  timestamp,
+  context,
+}: {
+  poolId: Address;
+  poolEntity: typeof pool.$inferSelect;
+  timestamp: bigint;
+  context: Context;
+}): Promise<IndexedPoolBeneficiary[]> {
+  const beneficiaries = await context.client.readContract({
+    abi: GET_BENEFICIARIES_ABI,
+    address: poolEntity.initializer!,
+    functionName: "getBeneficiaries",
+    args: [poolEntity.baseToken],
+  });
+
+  return replacePoolBeneficiaries({
+    poolId,
+    assetId: poolEntity.baseToken,
+    initializer: poolEntity.initializer!,
+    beneficiaries,
+    timestamp,
+    context,
+  });
+}
+
+export async function replacePoolBeneficiaries({
+  poolId,
+  assetId,
+  initializer,
+  beneficiaries,
+  timestamp,
+  context,
+}: {
+  poolId: Address;
+  assetId: Address;
+  initializer: Address;
+  beneficiaries: readonly MulticurveBeneficiary[];
+  timestamp: bigint;
+  context: Context;
+}): Promise<IndexedPoolBeneficiary[]> {
+  const chainId = context.chain.id;
+  const poolIdAddr = poolId.toLowerCase() as `0x${string}`;
+  const assetIdAddr = assetId.toLowerCase() as `0x${string}`;
+  const initializerAddr = initializer.toLowerCase() as `0x${string}`;
+  const normalizedBeneficiaries = normalizePoolBeneficiaries(beneficiaries);
+
+  await context.db.sql
+    .delete(poolBeneficiary)
+    .where(and(
+      eq(poolBeneficiary.poolId, poolIdAddr),
+      eq(poolBeneficiary.chainId, chainId),
+    ));
+
+  await Promise.all(
+    normalizedBeneficiaries.map((beneficiary) =>
+      context.db.insert(poolBeneficiary).values({
+        poolId: poolIdAddr,
+        chainId,
+        beneficiary: beneficiary.beneficiary,
+        assetId: assetIdAddr,
+        shares: BigInt(beneficiary.shares),
+        initializer: initializerAddr,
+        discoveredAt: timestamp,
+        updatedAt: timestamp,
+      }),
+    ),
+  );
+
+  await context.db
+    .update(pool, { address: poolIdAddr, chainId })
+    .set({ beneficiaries: normalizedBeneficiaries });
+
+  setBeneficiariesCache(chainId, poolIdAddr, {
+    beneficiaries: normalizedBeneficiaries.map((beneficiary) => ({
+      beneficiary: beneficiary.beneficiary,
+      shares: BigInt(beneficiary.shares),
+    })),
+    initializer: initializerAddr,
+  });
+
+  return normalizedBeneficiaries;
+}
+
+export async function transferPoolBeneficiary({
+  poolId,
+  oldBeneficiary,
+  newBeneficiary,
+  timestamp,
+  context,
+}: {
+  poolId: Address;
+  oldBeneficiary: Address;
+  newBeneficiary: Address;
+  timestamp: bigint;
+  context: Context;
+}): Promise<IndexedPoolBeneficiary[] | null> {
+  const chainId = context.chain.id;
+  const poolIdAddr = poolId.toLowerCase() as `0x${string}`;
+  const oldBeneficiaryAddr = oldBeneficiary.toLowerCase() as `0x${string}`;
+  const newBeneficiaryAddr = newBeneficiary.toLowerCase() as `0x${string}`;
+
+  if (oldBeneficiaryAddr === newBeneficiaryAddr) {
+    return normalizeIndexedPoolBeneficiaries((await context.db.find(pool, {
+      address: poolIdAddr,
+      chainId,
+    }))?.beneficiaries);
+  }
+
+  const poolEntity = await context.db.find(pool, {
+    address: poolIdAddr,
+    chainId,
+  });
+
+  if (!poolEntity || !poolEntity.initializer) {
+    return null;
+  }
+
+  const existingBeneficiary = await context.db.find(poolBeneficiary, {
+    poolId: poolIdAddr,
+    chainId,
+    beneficiary: oldBeneficiaryAddr,
+  });
+  const snapshotBeneficiaries = normalizeIndexedPoolBeneficiaries(poolEntity.beneficiaries);
+  const snapshotMatch = snapshotBeneficiaries.find(
+    (beneficiary) => beneficiary.beneficiary === oldBeneficiaryAddr,
+  );
+
+  if (!existingBeneficiary && !snapshotMatch) {
+    return refetchPoolBeneficiaries({
+      poolId: poolIdAddr,
+      poolEntity,
+      timestamp,
+      context,
+    });
+  }
+
+  const shares = existingBeneficiary?.shares ?? (snapshotMatch ? BigInt(snapshotMatch.shares) : 0n);
+
+  await context.db.sql
+    .delete(poolBeneficiary)
+    .where(and(
+      eq(poolBeneficiary.poolId, poolIdAddr),
+      eq(poolBeneficiary.chainId, chainId),
+      eq(poolBeneficiary.beneficiary, oldBeneficiaryAddr),
+    ));
+
+  const nextBeneficiaries = shares > 0n
+    ? mergePoolBeneficiaryTransfer({
+      beneficiaries: snapshotBeneficiaries,
+      oldBeneficiary: oldBeneficiaryAddr,
+      newBeneficiary: newBeneficiaryAddr,
+      shares,
+    })
+    : snapshotBeneficiaries.filter((beneficiary) => beneficiary.beneficiary !== oldBeneficiaryAddr);
+
+  if (shares > 0n && newBeneficiaryAddr !== oldBeneficiaryAddr) {
+    await context.db
+      .insert(poolBeneficiary)
+      .values({
+        poolId: poolIdAddr,
+        chainId,
+        beneficiary: newBeneficiaryAddr,
+        assetId: poolEntity.baseToken,
+        shares,
+        initializer: poolEntity.initializer,
+        discoveredAt: timestamp,
+        updatedAt: timestamp,
+      })
+      .onConflictDoUpdate((existing) => ({
+        shares: existing.shares + shares,
+        updatedAt: timestamp,
+      }));
+  }
+
+  await context.db
+    .update(pool, { address: poolIdAddr, chainId })
+    .set({ beneficiaries: nextBeneficiaries });
+
+  setBeneficiariesCache(chainId, poolIdAddr, {
+    beneficiaries: nextBeneficiaries.map((beneficiary) => ({
+      beneficiary: beneficiary.beneficiary,
+      shares: BigInt(beneficiary.shares),
+    })),
+    initializer: poolEntity.initializer,
+  });
+
+  return nextBeneficiaries;
+}

--- a/src/indexer/shared/entities/multicurve/poolBeneficiaryUtils.ts
+++ b/src/indexer/shared/entities/multicurve/poolBeneficiaryUtils.ts
@@ -1,0 +1,104 @@
+import { Address, zeroAddress } from "viem";
+
+export type MulticurveBeneficiary = {
+  beneficiary: Address;
+  shares: bigint;
+};
+
+export type IndexedPoolBeneficiary = {
+  beneficiary: `0x${string}`;
+  shares: string;
+};
+
+export function normalizePoolBeneficiaries(
+  beneficiaries: readonly MulticurveBeneficiary[],
+): IndexedPoolBeneficiary[] {
+  const sharesByBeneficiary = new Map<`0x${string}`, bigint>();
+
+  for (const { beneficiary, shares } of beneficiaries) {
+    const beneficiaryAddress = beneficiary.toLowerCase() as `0x${string}`;
+    if (beneficiaryAddress === zeroAddress || shares <= 0n) {
+      continue;
+    }
+
+    sharesByBeneficiary.set(
+      beneficiaryAddress,
+      (sharesByBeneficiary.get(beneficiaryAddress) ?? 0n) + shares,
+    );
+  }
+
+  return [...sharesByBeneficiary.entries()].map(([beneficiary, shares]) => ({
+    beneficiary,
+    shares: shares.toString(),
+  }));
+}
+
+export function mergePoolBeneficiaryTransfer({
+  beneficiaries,
+  oldBeneficiary,
+  newBeneficiary,
+  shares,
+}: {
+  beneficiaries: readonly IndexedPoolBeneficiary[];
+  oldBeneficiary: `0x${string}`;
+  newBeneficiary: `0x${string}`;
+  shares: bigint;
+}): IndexedPoolBeneficiary[] {
+  const nextBeneficiaries = beneficiaries.filter(
+    (beneficiary) => beneficiary.beneficiary !== oldBeneficiary,
+  );
+  const existingNewBeneficiary = nextBeneficiaries.find(
+    (beneficiary) => beneficiary.beneficiary === newBeneficiary,
+  );
+
+  if (existingNewBeneficiary) {
+    existingNewBeneficiary.shares = (BigInt(existingNewBeneficiary.shares) + shares).toString();
+    return nextBeneficiaries;
+  }
+
+  return [...nextBeneficiaries, { beneficiary: newBeneficiary, shares: shares.toString() }];
+}
+
+export function normalizeIndexedPoolBeneficiaries(beneficiaries: unknown): IndexedPoolBeneficiary[] {
+  if (!Array.isArray(beneficiaries)) {
+    return [];
+  }
+
+  const sharesByBeneficiary = new Map<`0x${string}`, bigint>();
+
+  for (const beneficiary of beneficiaries) {
+    if (!isIndexedPoolBeneficiary(beneficiary)) {
+      continue;
+    }
+
+    let shares: bigint;
+    try {
+      shares = BigInt(beneficiary.shares);
+    } catch {
+      continue;
+    }
+    const beneficiaryAddress = beneficiary.beneficiary.toLowerCase() as `0x${string}`;
+    if (beneficiaryAddress === zeroAddress || shares <= 0n) {
+      continue;
+    }
+
+    sharesByBeneficiary.set(
+      beneficiaryAddress,
+      (sharesByBeneficiary.get(beneficiaryAddress) ?? 0n) + shares,
+    );
+  }
+
+  return [...sharesByBeneficiary.entries()].map(([beneficiary, shares]) => ({
+    beneficiary,
+    shares: shares.toString(),
+  }));
+}
+
+function isIndexedPoolBeneficiary(value: unknown): value is IndexedPoolBeneficiary {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Partial<IndexedPoolBeneficiary>;
+  return typeof candidate.beneficiary === "string" && typeof candidate.shares === "string";
+}

--- a/src/indexer/shared/entities/pool.ts
+++ b/src/indexer/shared/entities/pool.ts
@@ -6,17 +6,17 @@ import { getV3PoolData, getSlot0Data, getV3PoolReserves } from "@app/utils/v3-ut
 import { computeGraduationPercentage } from "@app/utils/v4-utils";
 import { getReservesV4 } from "@app/utils/v4-utils/getV4PoolData";
 import { Context } from "ponder:registry";
-import { pool, token } from "ponder:schema";
+import { pool } from "ponder:schema";
 import { Address, zeroAddress } from "viem";
-import { fetchMonadPrice, fetchZoraPrice } from "../oracle";
 import { getQuoteInfo, QuoteToken, QuoteInfo, isValidQuoteToken } from "@app/utils/getQuoteInfo";
 import { getLockableV3PoolData } from "@app/utils/v3-utils/getV3PoolData";
 import { chainConfigs } from "@app/config";
 import { AssetData } from "@app/types";
 import { Network } from "@app/types/config-types";
-import { eq, and } from "ponder";
 import { isPrecompileAddress } from "@app/utils/validation";
 import { addToDHookPoolCache } from "../dhookPoolCache";
+import { replacePoolBeneficiaries } from "./multicurve/poolBeneficiary";
+import { normalizePoolBeneficiaries } from "./multicurve/poolBeneficiaryUtils";
 
 export const fetchExistingPool = async ({
   poolAddress,
@@ -370,7 +370,6 @@ export const insertPoolIfNotExistsV4 = async ({
   poolAddress,
   timestamp,
   poolData,
-  ethPrice,
   context,
 }: {
   poolAddress: Address;
@@ -486,7 +485,6 @@ export const insertPoolIfNotExistsDHook = async ({
   poolAddress,
   timestamp,
   poolData,
-  ethPrice,
   context,
   beneficiaries,
   initializerAddress,
@@ -506,10 +504,6 @@ export const insertPoolIfNotExistsDHook = async ({
     chainId: chain.id,
   });
 
-  if (existingPool) {
-    return existingPool;
-  }
-
   const { poolKey, slot0Data, liquidity, price, poolConfig } = poolData;
   const { fee } = poolKey;
 
@@ -517,6 +511,21 @@ export const insertPoolIfNotExistsDHook = async ({
   const numeraireAddr = (poolConfig.isToken0
     ? poolKey.currency1
     : poolKey.currency0).toLowerCase() as `0x${string}`;
+
+  if (existingPool) {
+    if (beneficiaries && initializerAddress) {
+      await replacePoolBeneficiaries({
+        poolId: address,
+        assetId: assetAddr,
+        initializer: initializerAddress,
+        beneficiaries,
+        timestamp,
+        context,
+      });
+    }
+
+    return existingPool;
+  }
 
   const [totalSupply, assetData, quoteInfo] = await Promise.all([
     client.readContract({
@@ -555,6 +564,10 @@ export const insertPoolIfNotExistsDHook = async ({
   let migrationType = getMigrationType(assetData, chain.name);
   
   const isQuoteEth = quoteInfo.quoteToken === QuoteToken.Eth;
+  const normalizedBeneficiaries = beneficiaries === undefined || beneficiaries === null
+    ? null
+    : normalizePoolBeneficiaries(beneficiaries);
+
   const inserted = await db.insert(pool).values({
     address,
     chainId: chain.id,
@@ -593,11 +606,20 @@ export const insertPoolIfNotExistsDHook = async ({
     hasValidQuote: isValidQuoteToken(quoteInfo.quoteToken),
     integrator: assetData.integrator,
     migrationType: migrationType,
-    beneficiaries: beneficiaries
-      ? beneficiaries.map(b => ({ beneficiary: b.beneficiary.toLowerCase() as `0x${string}`, shares: b.shares.toString() }))
-      : null,
+    beneficiaries: normalizedBeneficiaries,
     initializer: initializerAddress ? initializerAddress.toLowerCase() as `0x${string}` : null,
   });
+
+  if (beneficiaries !== undefined && beneficiaries !== null && initializerAddress) {
+    await replacePoolBeneficiaries({
+      poolId: address,
+      assetId: assetAddr,
+      initializer: initializerAddress,
+      beneficiaries,
+      timestamp,
+      context,
+    });
+  }
 
   addToDHookPoolCache(chain.id, address);
 


### PR DESCRIPTION
This PR adds a normalized `pool_beneficiary` table so the frontend can service fee claims without querying and attempting to filter encoded beneficiary JSON from `pool.beneficiaries`. Previously, beneficiary data was only stored as a JSON snapshot on the pool row, which made it awkward to answer frontend questions like “is this address a beneficiary for this token?” or “which tokens can this address claim fees for?” This branch keeps the JSON snapshot for compatibility, but adds a new queryable table keyed by pool, chain, and beneficiary, with asset-aware indexes for frontend lookup flows.

The new table is populated when multicurve pools are indexed, updated when `UpdateBeneficiary` events fire, and can be backfilled for existing indexed pools from current on-chain `getBeneficiaries()` state. Note: `cumulated_fees` is still present and still wired into swap/collect handling. This PR reduces the frontend’s need to depend on that accumulator, but does not remove the table or fee accumulation code.

### What Changed
- Adds `pool_beneficiary` with `beneficiary`, `asset`, `chain`, `share`, `initializer`, and `timestamp` fields.
- Normalizes beneficiary snapshots by lowercasing addresses, removing zero-address/zero-share entries, and merging duplicates.
- Syncs beneficiary rows on new pool indexing for multicurve, scheduled multicurve, decay multicurve, DHook, and Rehype-style pools.
- Handles `UpdateBeneficiary` events by moving shares from the old beneficiary to the new beneficiary.
- Adds a dry-run-first backfill script for existing databases.
- Adds tests for beneficiary normalization and transfer merging.
- Hardens the search endpoint’s `chain_ids` parsing and SQL parameterization.

### Changed Files
- `ponder.schema.ts` - Adds the `pool_beneficiary` table, indexes, and relations to `pool`, `user`, and `token`.
- `scripts/backfill-pool-beneficiaries.mjs` - Adds a dry-run/apply script that backfills beneficiary rows from on-chain snapshots.
- `README.md` - Documents the pool beneficiary backfill workflow and updates local config notes.
- `src/indexer/shared/entities/multicurve/poolBeneficiary.ts` - Adds helper logic to replace beneficiary rows, update pool snapshots, refresh cache, and transfer beneficiary shares.
- `src/indexer/shared/entities/multicurve/poolBeneficiaryUtils.ts` - Adds normalization and merge utilities for beneficiary lists.
- `src/indexer/shared/entities/multicurve/poolBeneficiary.test.ts` - Tests beneficiary normalization, filtering, duplicate merging, and transfer merging.
- `src/indexer/shared/entities/multicurve/pool.ts` - Writes normalized multicurve beneficiaries into both `pool.beneficiaries` and `pool_beneficiary`.
- `src/indexer/shared/entities/pool.ts` - Extends DHook pool creation/update paths to sync beneficiary snapshots into `pool_beneficiary`.
- `src/indexer/indexer-v4.ts` - Registers multicurve `UpdateBeneficiary` handling.
- `src/indexer/indexer-v4-scheduled.ts` - Registers scheduled multicurve `UpdateBeneficiary` handling.
- `src/indexer/indexer-v4-decay.ts` - Registers decay multicurve `UpdateBeneficiary` handling.
- `src/indexer/indexer-dhook.ts` - Registers DHook `UpdateBeneficiary` handling and keeps DHook beneficiary state synced.
- `src/indexer/index.ts` - Exports scheduled and decay indexers so their handlers are registered.
- `src/api/index.ts` - Safely parses chain_ids and parameterizes the token search SQL IN clause.