### PR TITLE
perf: short-circuit RPC calls in lockable V3 pool indexing

### DIFF
--- a/src/indexer/indexer-v3.ts
+++ b/src/indexer/indexer-v3.ts
@@ -99,7 +99,8 @@ onIndexerEvent("LockableUniswapV3Initializer:Create", async ({ event, context })
   const result = await insertLockableV3PoolIfNotExists({
     poolAddress: poolOrHookId,
     context,
-    timestamp,  
+    timestamp,
+    initializer: event.log.address.toLowerCase() as `0x${string}`,
   });
 
   if (!result) {

--- a/src/indexer/shared/entities/pool.ts
+++ b/src/indexer/shared/entities/pool.ts
@@ -607,11 +607,13 @@ export const insertPoolIfNotExistsDHook = async ({
 export const insertLockableV3PoolIfNotExists = async ({
   poolAddress,
   timestamp,
-  context,  
+  context,
+  initializer,
 }: {
   poolAddress: Address;
   timestamp: bigint;
-  context: Context;  
+  context: Context;
+  initializer?: Address;
 }): Promise<[typeof pool.$inferSelect, QuoteInfo] | null> => {
   const { db, chain, client } = context;
   const address = poolAddress.toLowerCase() as `0x${string}`;
@@ -621,9 +623,24 @@ export const insertLockableV3PoolIfNotExists = async ({
     chainId: chain.id,
   });
 
+  // Fast path: the pool is already indexed, so we don't need to re-derive its
+  // state from RPC. Reading pool state would probe the lockable initializers
+  // via `getState`, and the one that didn't create this pool returns 0x, which
+  // ponder retries with exponential backoff (~32s) and stalls the backfill.
+  // The stored quote token is all we need to rebuild `quoteInfo`.
+  if (existingPool) {
+    const quoteInfo = await getQuoteInfo(
+      existingPool.quoteToken as `0x${string}`,
+      timestamp,
+      context,
+    );
+    return [existingPool, quoteInfo];
+  }
+
   const poolData = await getLockableV3PoolData({
     address,
     context,
+    initializer,
   });
 
   if (!poolData) {
@@ -656,13 +673,6 @@ export const insertLockableV3PoolIfNotExists = async ({
       decimals: quoteInfo.quotePriceDecimals
     }
   )
-  
-  if (existingPool) {
-    return [
-      existingPool,
-      quoteInfo,
-    ];
-  }
 
   const isQuoteEth = quoteInfo.quoteToken === QuoteToken.Eth;
   return [await db.insert(pool).values({
@@ -694,6 +704,9 @@ export const insertLockableV3PoolIfNotExists = async ({
     isQuoteEth,
     hasValidQuote: isValidQuoteToken(quoteInfo.quoteToken),
     integrator: assetData.integrator,
+    initializer: initializer
+      ? (initializer.toLowerCase() as `0x${string}`)
+      : null,
   }),
     quoteInfo
   ];

--- a/src/utils/v3-utils/getV3PoolData.ts
+++ b/src/utils/v3-utils/getV3PoolData.ts
@@ -212,9 +212,11 @@ export const getV3PoolData = async ({
 export const getLockableV3PoolData = async ({
   address,
   context,
+  initializer,
 }: {
   address: Address;
   context: Context;
+  initializer?: Address;
 }): Promise<LockableV3PoolData | null> => {
   const { slot0Data, liquidity, token0, token1, fee } = await getSlot0Data({
     address,
@@ -231,6 +233,7 @@ export const getLockableV3PoolData = async ({
     token0,
     token1,
     context,
+    initializer,
   });
 
   const { reserve0, reserve1 } = await getV3PoolReserves({
@@ -358,18 +361,28 @@ const getLockablePoolState = async ({
   token0,
   token1,
   context,
+  initializer,
 }: {
   poolAddress: Address;
   token0: Address;
   token1: Address;
   context: Context;
+  initializer?: Address;
 }) => {
   const { client } = context;
   const lockableV3Initializer =
     chainConfigs[context.chain.name].addresses.v3.lockableV3Initializer;
-  const initializerAddresses = Array.isArray(lockableV3Initializer)
+  const configuredInitializers = Array.isArray(lockableV3Initializer)
     ? lockableV3Initializer
     : [lockableV3Initializer];
+
+  // When the owning initializer is known (passed through from the Create
+  // event), only query that one. Probing every configured initializer makes
+  // `getState` return 0x on the ones that didn't create this pool, and ponder
+  // retries those with exponential backoff (~32s), stalling the backfill.
+  const initializerAddresses = initializer
+    ? [initializer]
+    : configuredInitializers;
 
   const results = await Promise.all(
     initializerAddresses.map((initializerAddress) =>


### PR DESCRIPTION
## Summary

Two changes that eliminate redundant RPC round-trips during backfill of lockable Uniswap V3 pools. Together they remove the ~32s exponential-backoff stalls that were the dominant cost per pool.

### 1. Fast-path already-indexed pools

`insertLockableV3PoolIfNotExists` now returns early when the pool already exists, rebuilding `quoteInfo` from the stored `quoteToken` instead of re-deriving pool state from RPC. Previously it always called `getLockableV3PoolData` and only checked `existingPool` at the *end* — so every repeat event (Mint/Burn/Swap) for a known pool paid the full RPC cost. This matches the existing fast-path already present in `insertPoolIfNotExists`, `insertPoolIfNotExistsV4`, `insertPoolIfNotExistsDHook`, and `insertMulticurvePoolV4Optimized`.

### 2. Thread the owning initializer through to `getLockablePoolState`

The initializer address from the `Create` event is now passed down the call chain (`indexer-v3.ts` → `insertLockableV3PoolIfNotExists` → `getLockableV3PoolData` → `getLockablePoolState`), so only that initializer's `getState` is queried. Previously every configured initializer was probed; the ones that didn't create the pool return `0x`, which the transport retries with exponential backoff (~32s) before failing — stalling the backfill. The initializer is also now persisted on the `pool` row.

## Testing

Observed substantially faster backfill locally.