### PR TITLE
fix: seed position_ledger from create tx in dhook Create handler

### DIFF
--- a/src/indexer/indexer-dhook.ts
+++ b/src/indexer/indexer-dhook.ts
@@ -12,7 +12,7 @@ import { computeReservesFromPositions } from "@app/utils/v4-utils/computeReserve
 import { getPositionsForPool, upsertPositionLedger } from "./shared/entities/positionLedger";
 import { PoolKey } from "@app/types/v4-types";
 import { getDHookPoolData } from "@app/utils/dhook-utils";
-import { StateViewABI, DopplerHookInitializerABI, RehypeDopplerHookInitializerABI } from "@app/abis";
+import { StateViewABI, DopplerHookInitializerABI } from "@app/abis";
 import { isPrecompileAddress } from "@app/utils/validation";
 import { updateCumulatedFees } from "./shared/cumulatedFees";
 import { Context } from "ponder:registry";
@@ -60,56 +60,6 @@ async function seedPositionLedgerFromCreateTx({
       context,
     });
   }
-}
-
-type PositionEntry = { tickLower: number; tickUpper: number; liquidity: bigint };
-
-async function fetchPositions({
-  initializerAddress,
-  assetAddress,
-  poolId,
-  context,
-}: {
-  initializerAddress: `0x${string}`;
-  assetAddress: `0x${string}`;
-  poolId: `0x${string}`;
-  context: Context;
-}): Promise<readonly PositionEntry[]> {
-  // Try getPositions (public on older initializer deployments, internal on newer)
-  try {
-    const positions = await context.client.readContract({
-      abi: DopplerHookInitializerABI,
-      address: initializerAddress,
-      functionName: "getPositions",
-      args: [assetAddress],
-    });
-    return positions;
-  } catch {}
-
-  // Fallback: use getState to discover dopplerHook, then getPosition on it
-  try {
-    const state = await context.client.readContract({
-      abi: DopplerHookInitializerABI,
-      address: initializerAddress,
-      functionName: "getState",
-      args: [assetAddress],
-    });
-    const dopplerHook = (state[2] as string).toLowerCase() as `0x${string}`;
-    if (dopplerHook !== "0x0000000000000000000000000000000000000000") {
-      const result = await context.client.readContract({
-        abi: RehypeDopplerHookInitializerABI,
-        address: dopplerHook,
-        functionName: "getPosition",
-        args: [poolId],
-      });
-      const [tickLower, tickUpper, liquidity] = result;
-      if (liquidity > 0n) return [{ tickLower, tickUpper, liquidity }];
-      return [];
-    }
-  } catch {}
-
-  // Last resort: position ledger
-  return getPositionsForPool({ poolId, context });
 }
 
 onIndexerEvent("DopplerHookInitializer:Create", async ({ event, context }) => {
@@ -313,7 +263,6 @@ onIndexerEvent("DopplerHookInitializer:Swap", async ({ event, context }) => {
   }
 
   const { stateView } = chainConfigs[chain.name].addresses.v4;
-  const initializerAddress = (poolEntity.initializer ?? event.log.address) as `0x${string}`;
 
   const [slot0, onChainPositions, quoteInfo, tokenEntity] = await Promise.all([
     client.readContract({
@@ -322,12 +271,7 @@ onIndexerEvent("DopplerHookInitializer:Swap", async ({ event, context }) => {
       functionName: "getSlot0",
       args: [poolId],
     }),
-    fetchPositions({
-      initializerAddress,
-      assetAddress: poolEntity.baseToken,
-      poolId: poolAddress,
-      context,
-    }),
+    getPositionsForPool({ poolId: poolAddress, context }),
     getQuoteInfo(poolEntity.quoteToken, timestamp, context),
     db.find(token, {
       address: poolEntity.baseToken,
@@ -511,12 +455,7 @@ onIndexerEvent("DopplerHookInitializer:ModifyLiquidity", async ({ event, context
         },
       ],
     }),
-    fetchPositions({
-      initializerAddress: event.log.address as `0x${string}`,
-      assetAddress: poolEntity.baseToken,
-      poolId: poolAddress,
-      context,
-    }),
+    getPositionsForPool({ poolId: poolAddress, context }),
   ]);
 
   const [slot0, liquidityResult] = multicallResults;

--- a/src/indexer/indexer-dhook.ts
+++ b/src/indexer/indexer-dhook.ts
@@ -9,7 +9,7 @@ import { chainConfigs } from "@app/config/chains";
 import { pool, token } from "ponder:schema";
 import { getQuoteInfo } from "@app/utils/getQuoteInfo";
 import { computeReservesFromPositions } from "@app/utils/v4-utils/computeReservesFromPositions";
-import { getPositionsForPool } from "./shared/entities/positionLedger";
+import { getPositionsForPool, upsertPositionLedger } from "./shared/entities/positionLedger";
 import { PoolKey } from "@app/types/v4-types";
 import { getDHookPoolData } from "@app/utils/dhook-utils";
 import { StateViewABI, DopplerHookInitializerABI, RehypeDopplerHookInitializerABI } from "@app/abis";
@@ -17,6 +17,50 @@ import { isPrecompileAddress } from "@app/utils/validation";
 import { updateCumulatedFees } from "./shared/cumulatedFees";
 import { Context } from "ponder:registry";
 import { transferPoolBeneficiary } from "./shared/entities/multicurve/poolBeneficiary";
+import { decodeAbiParameters } from "viem";
+
+// keccak256("ModifyLiquidity(bytes32,address,int24,int24,int256,bytes32)") — v4 PoolManager.
+const POOL_MANAGER_MODIFY_LIQUIDITY_TOPIC =
+  "0xf208f4912782fd25c7f114ca3723a2d5dd6f3bcc3ac8db5af63baa85f711d5ec";
+
+async function seedPositionLedgerFromCreateTx({
+  poolAddress,
+  context,
+  txHash,
+}: {
+  poolAddress: `0x${string}`;
+  context: Context;
+  txHash: `0x${string}`;
+}): Promise<void> {
+  const poolManagerAddress = chainConfigs[context.chain.name].addresses.v4.poolManager.toLowerCase();
+  const receipt = await context.client.getTransactionReceipt({ hash: txHash });
+
+  for (const log of receipt.logs) {
+    if (
+      log.address.toLowerCase() !== poolManagerAddress ||
+      log.topics[0] !== POOL_MANAGER_MODIFY_LIQUIDITY_TOPIC ||
+      log.topics[1]?.toLowerCase() !== poolAddress
+    ) {
+      continue;
+    }
+    const [tickLower, tickUpper, liquidityDelta] = decodeAbiParameters(
+      [
+        { type: "int24" },
+        { type: "int24" },
+        { type: "int256" },
+        { type: "bytes32" },
+      ],
+      log.data,
+    );
+    await upsertPositionLedger({
+      poolId: poolAddress,
+      tickLower: Number(tickLower),
+      tickUpper: Number(tickUpper),
+      liquidityDelta,
+      context,
+    });
+  }
+}
 
 type PositionEntry = { tickLower: number; tickUpper: number; liquidity: bigint };
 
@@ -141,11 +185,19 @@ onIndexerEvent("DopplerHookInitializer:Create", async ({ event, context }) => {
     decimals: quoteInfo.quotePriceDecimals,
   });
 
-  // Seed reserves from on-chain positions (falls back to position ledger for
-  // newer contracts where getPositions was changed to internal visibility)
-  const onChainPositions = await fetchPositions({
-    initializerAddress: initializerAddress as `0x${string}`,
-    assetAddress,
+  // Seed position_ledger from this transaction's PoolManager.ModifyLiquidity logs.
+  // The newer DopplerHookInitializer (0xBDF938...) does not re-emit ModifyLiquidity
+  // at the initializer level, and the PoolManager:ModifyLiquidity handler can't
+  // populate the ledger for these logs — they fire at a lower log index than this
+  // Create event, so the dhook pool cache hasn't been told about the pool yet.
+  // Replaying the receipt here makes the ledger authoritative for the seeded state.
+  await seedPositionLedgerFromCreateTx({
+    poolAddress,
+    context,
+    txHash: event.transaction.hash,
+  });
+
+  const onChainPositions = await getPositionsForPool({
     poolId: poolAddress,
     context,
   });


### PR DESCRIPTION
## Summary

The newer `DopplerHookInitializer` (`0xBDF938...`) doesn't re-emit `ModifyLiquidity` at the initializer level for seeding, and the seeding `PoolManager.ModifyLiquidity` logs fire at a *lower* `log_index` than the matching `Create` event in the same tx — so by the time the `PoolManager:ModifyLiquidity` handler runs, the pool isn't in the dhook cache yet and the upsert short-circuits. Net result: affected pools have an empty `position_ledger`, and every downstream `Swap` computes `reserves = computeReservesFromPositions([], tick) = {0, 0}`.

This patch closes the leak going forward by replaying the create tx's receipt in the `DopplerHookInitializer:Create` handler:

- Add `seedPositionLedgerFromCreateTx({ poolAddress, context, txHash })` that pulls `getTransactionReceipt`, filters PoolManager + `ModifyLiquidity` topic + `topic1 == poolId`, decodes `(int24, int24, int256, bytes32)`, and feeds each delta to the existing `upsertPositionLedger`.
- In the Create handler, call it right after `insertPoolIfNotExistsDHook` + cache registration, then compute reserves from the now-populated ledger via `getPositionsForPool` instead of `fetchPositions`.

One RPC call per Create event; no block-range walking; naturally scoped to the create tx so future ModifyLiquidity events still go through the standard PoolManager handler (which now succeeds because the cache has the pool).

## Follow-up

Pools created before this lands still have empty ledgers and need `scripts/backfill-position-ledger.mjs --schema prod ... --apply` to repair. Verified by hand against `0xf12523285529af9b21d9e9687c02c58cf5559ba3` on Base — its create tx (`0x9758db0b...`, block 46821559) contains exactly the two seeding `PoolManager.ModifyLiquidity` logs this handler would now decode and persist (`[119600, 229600] → 1.028e24` and `[-887200, 119600] → 2.530e24`).