### PR TITLE
perf: cache immutable v4 pool reads to cut per-swap eth_call volume

### DIFF
--- a/src/utils/v4-utils/getV4PoolData.ts
+++ b/src/utils/v4-utils/getV4PoolData.ts
@@ -27,18 +27,34 @@ import { getMulticallOptions } from "@app/core/utils";
 import { chainConfigs } from "@app/config";
 import { getQuoteInfo, QuoteInfo } from "@app/utils/getQuoteInfo";
 import { isPrecompileAddress } from "../validation";
+import {
+  V4PoolImmutables,
+  getCachedV4Immutables,
+  hasCachedV4Immutables,
+  setCachedV4Immutables,
+} from "./v4ImmutableCache";
 
-export const getV4PoolData = async ({
+/**
+ * Fetch (and memoize) the immutable on-chain values for a v4 hook pool: its
+ * pool key, pool config, base token and decimals. These never change after
+ * pool creation, so the result is cached per (chainId, hook) and the contract
+ * reads only happen on the first event seen for each pool.
+ *
+ * Returns `null` for pools whose currencies are precompile addresses; that
+ * verdict is cached too so the pool is skipped without re-reading poolKey.
+ */
+const getV4PoolImmutables = async ({
   hook,
   context,
-  quoteInfo: providedQuoteInfo,
 }: {
   hook: Address;
   context: Context;
-  quoteInfo?: QuoteInfo;
-}): Promise<V4PoolData | null> => {
-  const { stateView } = chainConfigs[context.chain.name].addresses.v4;
+}): Promise<V4PoolImmutables | null> => {
   const { client, chain } = context;
+
+  if (hasCachedV4Immutables(chain.id, hook)) {
+    return getCachedV4Immutables(chain.id, hook) ?? null;
+  }
 
   const poolConfig = await getV4PoolConfig({ hook, context });
 
@@ -58,8 +74,49 @@ export const getV4PoolData = async ({
 
   // Skip events where either currency in the pool is a precompile address
   if (isPrecompileAddress(key.currency0) || isPrecompileAddress(key.currency1)) {
+    setCachedV4Immutables(chain.id, hook, null);
     return null;
   }
+
+  const assetData0 = await getAssetData(key.currency0, context);
+
+  const baseToken =
+    assetData0.poolInitializer != zeroAddress ? key.currency0 : key.currency1;
+  const isToken0 = baseToken === key.currency0;
+  const baseTokenDecimals = await client.readContract({
+    abi: DERC20ABI,
+    address: baseToken,
+    functionName: "decimals",
+  });
+
+  const immutables: V4PoolImmutables = {
+    key,
+    poolConfig,
+    baseToken,
+    isToken0,
+    baseTokenDecimals,
+  };
+  setCachedV4Immutables(chain.id, hook, immutables);
+  return immutables;
+};
+
+export const getV4PoolData = async ({
+  hook,
+  context,
+  quoteInfo: providedQuoteInfo,
+}: {
+  hook: Address;
+  context: Context;
+  quoteInfo?: QuoteInfo;
+}): Promise<V4PoolData | null> => {
+  const { stateView } = chainConfigs[context.chain.name].addresses.v4;
+  const { client, chain } = context;
+
+  const immutables = await getV4PoolImmutables({ hook, context });
+  if (!immutables) {
+    return null;
+  }
+  const { key, poolConfig, isToken0, baseTokenDecimals } = immutables;
 
   const poolId = getPoolId(key);
 
@@ -96,17 +153,6 @@ export const getV4PoolData = async ({
 
   const liquidityResult = liquidity?.result ?? 0n;
 
-  const assetData0 = await getAssetData(key.currency0, context);
-
-  const baseToken =
-    assetData0.poolInitializer != zeroAddress ? key.currency0 : key.currency1;
-  const isToken0 = baseToken === key.currency0;
-  const baseTokenDecimals = await context.client.readContract({
-    abi: DERC20ABI,
-    address: baseToken,
-    functionName: "decimals",
-  });
-  
   let quoteInfo: QuoteInfo;
   if (providedQuoteInfo) {    
     quoteInfo = providedQuoteInfo;

--- a/src/utils/v4-utils/v4ImmutableCache.ts
+++ b/src/utils/v4-utils/v4ImmutableCache.ts
@@ -1,0 +1,51 @@
+import { Address } from "viem";
+import { PoolKey, V4PoolConfig } from "@app/types/v4-types";
+
+/**
+ * Immutable, per-pool on-chain values for a v4 (Doppler hook) pool. These are
+ * all set when the pool is created and never change afterwards, so they can be
+ * read from chain once and cached for the lifetime of the process.
+ *
+ * Caching these avoids re-fetching ~4 `eth_call`s on every swap (poolKey,
+ * pool config, airlock asset data, base-token decimals), leaving only the live
+ * slot0/liquidity read on the hot path. See getV4PoolData.
+ */
+export interface V4PoolImmutables {
+  key: PoolKey;
+  poolConfig: V4PoolConfig;
+  baseToken: Address;
+  isToken0: boolean;
+  baseTokenDecimals: number;
+}
+
+// `null` is a valid, cached value: it marks a hook whose pool currencies are
+// precompile addresses and is permanently skipped (so we don't re-read poolKey
+// for it on every event).
+const cache = new Map<string, V4PoolImmutables | null>();
+
+function getCacheKey(chainId: number, hook: string): string {
+  return `${chainId}:${hook.toLowerCase()}`;
+}
+
+export function hasCachedV4Immutables(chainId: number, hook: string): boolean {
+  return cache.has(getCacheKey(chainId, hook));
+}
+
+export function getCachedV4Immutables(
+  chainId: number,
+  hook: string
+): V4PoolImmutables | null | undefined {
+  return cache.get(getCacheKey(chainId, hook));
+}
+
+export function setCachedV4Immutables(
+  chainId: number,
+  hook: string,
+  value: V4PoolImmutables | null
+): void {
+  cache.set(getCacheKey(chainId, hook), value);
+}
+
+export function getV4ImmutableCacheSize(): number {
+  return cache.size;
+}


### PR DESCRIPTION
## Problem

`getV4PoolData` runs on **every `UniswapV4Pool:Swap`** (`indexer-v4.ts:130`) and fired **5 `eth_call`s per swap**, 4 of which read values that are fixed at pool creation and never change:

| read | mutable? |
|---|---|
| `getV4PoolConfig` (11-fn multicall on the hook) | immutable |
| `poolKey` | immutable |
| `getSlot0` + `getLiquidity` multicall | **live** |
| airlock `getAssetData` | immutable |
| base-token `decimals` | immutable |

On a high-volume v4 chain like **base** this dominated RPC load. With all chains sharing one Alchemy key (one compute-units-per-second budget), base's `eth_call` volume (~1.24M) was a primary driver of `429 "exceeded compute units per second"` throttling — which starves *every* chain's latest-block fetch, including monad's, and shows up as cross-chain indexing lag.

## Change

Memoize the immutable reads per `(chainId, hook)` in a small in-memory cache (`v4ImmutableCache.ts`), matching the existing `dhookPoolCache` / `v4MigrationPoolCache` idiom. The contract reads now happen only on the **first** event seen for each pool; steady-state swaps drop from **5 → 1 `eth_call`** (only the live slot0/liquidity multicall remains).

- Precompile-currency pools are cached as a `null` verdict, so they're skipped without re-reading `poolKey`.
- The live read and the precompile short-circuit are preserved exactly; only the immutable reads are cached.
- Cache is unbounded but bounded in practice by pool count (one entry per pool), same as the existing pool caches — no eviction needed since the values never change.

## Impact

Roughly an **80% cut to the v4-swap `eth_call` path**, which should meaningfully relieve the shared-key Alchemy CUPS pressure behind the 429s. Complementary to giving each chain its own RPC key.

## Risk / correctness

Behavior is unchanged: cached values are immutable on-chain, so a cached read returns the same result a fresh read would. `tsc --noEmit` passes clean. v3 and dhook swap paths already read these from a batched multicall / the DB entity respectively and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)