### PR TITLE
perf: shave per-swap work to help robinhood (10 blk/s) keep up

### DIFF
--- a/src/core/swaps/SwapOrchestrator.ts
+++ b/src/core/swaps/SwapOrchestrator.ts
@@ -26,6 +26,9 @@ export interface SwapUpdateParams {
   };
   chainId: number;
   context: Context;
+  // Extra pool fields to write in the SAME updatePool as the standard swap
+  // update, so callers don't have to issue a second write to the pool row.
+  extraPoolUpdate?: Record<string, unknown>;
 }
 
 /**
@@ -49,7 +52,7 @@ export class SwapOrchestrator {
     params: SwapUpdateParams,
     updaters: EntityUpdaters
   ): Promise<void> {
-    const { swapData, metrics, poolData, chainId, context } = params;
+    const { swapData, metrics, poolData, chainId, context, extraPoolUpdate } = params;
     const {
       updatePool,
       updateFifteenMinuteBucketUsd,
@@ -106,11 +109,12 @@ export class SwapOrchestrator {
       : (poolData.isQuoteEth ? CHAINLINK_ETH_DECIMALS : WAD);
 
     const updates = [
-      // Update pool entity
+      // Update pool entity (merging any caller-supplied extra fields so the
+      // pool row is written exactly once per swap).
       updatePool({
         poolAddress: poolData.parentPoolAddress,
         context,
-        update: poolUpdate,
+        update: extraPoolUpdate ? { ...poolUpdate, ...extraPoolUpdate } : poolUpdate,
       }),
       updateFifteenMinuteBucketUsd(context, {
         poolAddress: poolData.parentPoolAddress,

--- a/src/indexer/indexer-dhook.ts
+++ b/src/indexer/indexer-dhook.ts
@@ -15,7 +15,6 @@ import { PoolKey } from "@app/types/v4-types";
 import { getDHookPoolData } from "@app/utils/dhook-utils";
 import { StateViewABI, DopplerHookInitializerABI } from "@app/abis";
 import { isPrecompileAddress } from "@app/utils/validation";
-import { updateCumulatedFees } from "./shared/cumulatedFees";
 import { Context } from "ponder:registry";
 import { transferPoolBeneficiary } from "./shared/entities/multicurve/poolBeneficiary";
 import { decodeAbiParameters } from "viem";
@@ -187,42 +186,6 @@ onIndexerEvent("DopplerHookInitializer:Create", async ({ event, context }) => {
   });
 });
 
-onIndexerEvent("DopplerHookInitializer:Collect", async ({ event, context }) => {
-  const { poolId } = event.args;
-  const timestamp = event.block.timestamp;
-  const { db, chain } = context;
-
-  const poolAddress = (poolId as string).toLowerCase() as `0x${string}`;
-
-  const poolEntity = await db.find(pool, {
-    address: poolAddress,
-    chainId: chain.id,
-  });
-
-  if (!poolEntity) {
-    return;
-  }
-
-  const quoteInfo = await getQuoteInfo(poolEntity.quoteToken, timestamp, context);
-
-  const price = PriceService.computePriceFromSqrtPriceX96({
-    sqrtPriceX96: poolEntity.sqrtPrice,
-    isToken0: poolEntity.isToken0,
-    decimals: 18,
-    quoteDecimals: quoteInfo.quoteDecimals,
-  });
-
-  // Re-fetch cumulated fees from the contract (reflects post-collection state)
-  await updateCumulatedFees({
-    poolId: poolAddress,
-    chainId: chain.id,
-    isToken0: poolEntity.isToken0,
-    price,
-    quoteInfo,
-    context,
-  });
-});
-
 onIndexerEvent("DopplerHookInitializer:UpdateBeneficiary", async ({ event, context }) => {
   const { poolId, oldBeneficiary, newBeneficiary } = event.args;
   const poolAddress = (poolId as string).toLowerCase() as `0x${string}`;
@@ -360,51 +323,35 @@ onIndexerEvent("DopplerHookInitializer:Swap", async ({ event, context }) => {
     updateAsset,
   };
 
-  await Promise.all([
-    SwapOrchestrator.performSwapUpdates(
-      {
-        swapData,
-        swapType: type,
-        metrics: marketMetrics,
-        poolData: {
-          parentPoolAddress: poolAddress,
-          price,
-          quotePriceDecimals: quoteInfo.quotePriceDecimals,
-          tickLower: 0,
-          currentTick,
-          graduationTick: poolEntity.graduationTick ?? 0,
-          type: "dhook",
-          baseToken: poolEntity.baseToken,
-        },
-        chainId: chain.id,
-        context,
-      },
-      entityUpdaters
-    ),
-    updatePool({
-      poolAddress,
-      context,
-      update: {
+  await SwapOrchestrator.performSwapUpdates(
+    {
+      swapData,
+      swapType: type,
+      metrics: marketMetrics,
+      poolData: {
+        parentPoolAddress: poolAddress,
         price,
+        quotePriceDecimals: quoteInfo.quotePriceDecimals,
+        tickLower: 0,
+        currentTick,
+        graduationTick: poolEntity.graduationTick ?? 0,
+        type: "dhook",
+        baseToken: poolEntity.baseToken,
+      },
+      chainId: chain.id,
+      context,
+      // Folded in from the previously-separate updatePool call: price, tick,
+      // dollarLiquidity, marketCapUsd and lastSwapTimestamp are already written
+      // by performSwapUpdates, so only the fields it doesn't cover remain here.
+      extraPoolUpdate: {
         sqrtPrice: sqrtPriceX96,
-        tick: currentTick,
         reserves0: newReserves0,
         reserves1: newReserves1,
-        dollarLiquidity,
-        marketCapUsd,
-        lastSwapTimestamp: timestamp,
         lastRefreshed: timestamp,
       },
-    }),
-    updateCumulatedFees({
-      poolId: poolAddress,
-      chainId: chain.id,
-      isToken0: poolEntity.isToken0,
-      price,
-      quoteInfo,
-      context,
-    }),
-  ]);
+    },
+    entityUpdaters
+  );
 });
 
 onIndexerEvent("DopplerHookInitializer:ModifyLiquidity", async ({ event, context }) => {

--- a/src/indexer/indexer-v4-decay.ts
+++ b/src/indexer/indexer-v4-decay.ts
@@ -28,7 +28,7 @@ import { StateViewABI } from "@app/abis";
 import { zeroAddress } from "viem";
 import { getQuoteInfo } from "@app/utils/getQuoteInfo";
 import { readContractWithZeroDataPadding } from "@app/utils/readContractWithZeroDataPadding";
-import { updateCumulatedFees, handleCollect } from "./shared/cumulatedFees";
+import { handleCollect } from "./shared/cumulatedFees";
 import { transferPoolBeneficiary } from "./shared/entities/multicurve/poolBeneficiary";
 
 onIndexerEvent(
@@ -351,14 +351,6 @@ onIndexerEvent(
         quoteInfo,
         poolEntity
       ),
-      updateCumulatedFees({
-        poolId: poolAddress,
-        chainId: context.chain.id,
-        isToken0: poolEntity.isToken0,
-        price,
-        quoteInfo,
-        context,
-      }),
     ]);
   },
 );

--- a/src/indexer/indexer-v4-scheduled.ts
+++ b/src/indexer/indexer-v4-scheduled.ts
@@ -28,7 +28,7 @@ import { StateViewABI } from "@app/abis";
 import { zeroAddress } from "viem";
 import { getQuoteInfo } from "@app/utils/getQuoteInfo";
 import { readContractWithZeroDataPadding } from "@app/utils/readContractWithZeroDataPadding";
-import { updateCumulatedFees, handleCollect } from "./shared/cumulatedFees";
+import { handleCollect } from "./shared/cumulatedFees";
 import { transferPoolBeneficiary } from "./shared/entities/multicurve/poolBeneficiary";
 
 onIndexerEvent(
@@ -349,14 +349,6 @@ onIndexerEvent(
         quoteInfo,
         poolEntity
       ),
-      updateCumulatedFees({
-        poolId: poolAddress,
-        chainId: context.chain.id,
-        isToken0: poolEntity.isToken0,
-        price,
-        quoteInfo,
-        context,
-      }),
     ]);
   },
 );

--- a/src/indexer/indexer-v4.ts
+++ b/src/indexer/indexer-v4.ts
@@ -37,7 +37,7 @@ import { StateViewABI } from "@app/abis";
 import { Address, zeroAddress } from "viem";
 import { QuoteToken, QuoteInfo, getQuoteInfo } from "@app/utils/getQuoteInfo";
 import { readContractWithZeroDataPadding } from "@app/utils/readContractWithZeroDataPadding";
-import { updateCumulatedFees, handleCollect } from "./shared/cumulatedFees";
+import { handleCollect } from "./shared/cumulatedFees";
 import { computeReservesFromPositions } from "@app/utils/v4-utils/computeReservesFromPositions";
 import { upsertPositionLedger, getPositionsForPool } from "./shared/entities/positionLedger";
 import { transferPoolBeneficiary } from "./shared/entities/multicurve/poolBeneficiary";
@@ -608,14 +608,6 @@ onIndexerEvent(
         quoteInfo,
         poolEntity
       ),
-      updateCumulatedFees({
-        poolId: poolAddress,
-        chainId: context.chain.id,
-        isToken0: poolEntity.isToken0,
-        price,
-        quoteInfo,
-        context,
-      }),
     ]);
   },
 );

--- a/src/indexer/shared/oracle.ts
+++ b/src/indexer/shared/oracle.ts
@@ -50,6 +50,32 @@ function setCachedFallbackPrice(key: string, price: bigint): void {
   fallbackPriceCache.set(key, { price, timestamp: Date.now() });
 }
 
+// Immutable per-bucket price memo. A (priceType, chainId, roundedTimestamp) key
+// maps to a fixed DB value once that 5-minute bucket has been written, so
+// repeated swaps in the same bucket skip the DB round-trip. Only populated on an
+// EXACT bucket hit (never on a walk-back fallback), so the in-progress realtime
+// bucket stays live until its price lands.
+const bucketPriceCache = new Map<string, bigint>();
+const BUCKET_PRICE_CACHE_MAX = 2000;
+
+function getBucketPrice(key: string): bigint | undefined {
+  return bucketPriceCache.get(key);
+}
+
+function setBucketPrice(key: string, price: bigint): void {
+  if (bucketPriceCache.size >= BUCKET_PRICE_CACHE_MAX) {
+    // Drop the oldest ~10% (Map preserves insertion order) to bound memory
+    // during long historical backfills.
+    const drop = Math.ceil(BUCKET_PRICE_CACHE_MAX / 10);
+    let i = 0;
+    for (const k of bucketPriceCache.keys()) {
+      bucketPriceCache.delete(k);
+      if (++i >= drop) break;
+    }
+  }
+  bucketPriceCache.set(key, price);
+}
+
 export const fetchEthPrice = async (
   timestamp: bigint,
   context: Context
@@ -64,6 +90,13 @@ export const fetchEthPrice = async (
   const sourceChainId = hasOwnOracle ? chain.id : CHAIN_IDS.base;
 
   let roundedTimestamp = BigInt(Math.floor(Number(timestamp) / 300) * 300);
+  const requestedBucket = roundedTimestamp;
+
+  const bucketKey = `eth:${sourceChainId}:${requestedBucket}`;
+  const memoizedPrice = getBucketPrice(bucketKey);
+  if (memoizedPrice !== undefined) {
+    return memoizedPrice;
+  }
 
   let ethPriceData;
   let attempts = 0;
@@ -80,6 +113,12 @@ export const fetchEthPrice = async (
   }
 
   if (ethPriceData) {
+    // Only memoize an exact bucket hit. If we walked back to an earlier bucket,
+    // the requested bucket isn't written yet (in-progress realtime bucket) —
+    // leave it uncached so later swaps pick up its price once it lands.
+    if (roundedTimestamp === requestedBucket) {
+      setBucketPrice(bucketKey, ethPriceData.price);
+    }
     return ethPriceData.price;
   }
 


### PR DESCRIPTION
## Why

Robinhood produces **~10 blocks/s** — far above what the shared single-threaded `ordering: "multichain"` pipeline can index in realtime (~6 blk/s effective for this chain), so it steadily falls behind (~15–20s of lag per minute) until a restart-backfill resets it. The bottleneck is **serial per-block work** (RPC reads + DB commit round-trips), not CPU. Rather than switch to `experimental_isolated` (which needs a fresh-schema re-index) on an indexer we're deprecating soon, this cuts redundant/dead per-swap work to widen the margin.

## Changes

**1. One pool write per swap (was two).**
The dhook `Swap` handler updated the pool row twice — once inside `SwapOrchestrator.performSwapUpdates` and again via a standalone `updatePool` carrying a few extra fields (`sqrtPrice`, `reserves0/1`, `lastRefreshed`). Added an optional `extraPoolUpdate` to `performSwapUpdates` so those fields ride along in the single update. Removes a DB write **and** the same-row write contention (both updates hit the same row concurrently) on every dhook swap.

**2. Memoize the eth-price oracle lookup.**
`fetchEthPrice` did a `db.find` on the 5-minute-rounded price bucket on every swap, though the value is identical for hundreds of consecutive swaps. Added a small immutable per-bucket memo keyed by `sourceChainId:roundedTimestamp`, populated **only on an exact bucket hit** — if the lookup had to walk back to an earlier bucket (the in-progress realtime bucket isn't written yet), it's left uncached so later swaps pick up the price once it lands. Robinhood quotes in WETH so this hits every robinhood swap; `usdc/usdt/usdg` are already hardcoded constants and untouched. Bounded cache (2000 entries, FIFO-ish eviction) for backfill safety.

**3. Remove cumulated-fees writes (deprecated).**
Cumulated fees are no longer used — the frontend derives them live from RPC using only the pool beneficiaries the indexer writes. Dropped every `updateCumulatedFees` call from the dhook and v4/decay/scheduled swap paths, and removed the `DopplerHookInitializer:Collect` handler, which existed solely to call it. `handleCollect` (pool-beneficiary maintenance, a different concern) is retained. The now-unused `updateCumulatedFees` export is left in place to keep the diff focused — it can be removed with the table in a later cleanup.

## Correctness

Behavior-preserving: the folded pool fields and the memoized prices are identical to what the removed code produced — only redundant or dead work is cut. `tsc --noEmit` passes clean project-wide.

## Impact

Cuts ~2 of the ~4 DB round-trips per dhook swap (redundant pool write + oracle read) plus all cumulated-fee reads/writes across v4 swap paths on every chain. Won't by itself guarantee robinhood clears 10 blk/s (the per-swap `getSlot0` RPC is a stubborn floor — the event carries no post-swap price), but it narrows the gap and stretches the interval between restart-backfills. The cumulated-fees removal also lightens base/mainnet/monad swap handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)