### PR TITLE
perf(robinhood): source dhook swap price from PoolManager:Swap, drop per-swap getSlot0

### DIFF
--- a/src/indexer/indexer-dhook.ts
+++ b/src/indexer/indexer-dhook.ts
@@ -7,6 +7,7 @@ import { SwapOrchestrator, PriceService, MarketDataService } from "@app/core";
 import { getMulticallOptions } from "@app/core/utils/multicall";
 import { updateFifteenMinuteBucketUsd } from "@app/utils/time-buckets";
 import { chainConfigs } from "@app/config/chains";
+import { CHAIN_IDS } from "@app/config";
 import { pool, token } from "ponder:schema";
 import { getQuoteInfo } from "@app/utils/getQuoteInfo";
 import { computeReservesFromPositions } from "@app/utils/v4-utils/computeReservesFromPositions";
@@ -18,7 +19,7 @@ import { isPrecompileAddress } from "@app/utils/validation";
 import { updateCumulatedFees } from "./shared/cumulatedFees";
 import { Context } from "ponder:registry";
 import { transferPoolBeneficiary } from "./shared/entities/multicurve/poolBeneficiary";
-import { decodeAbiParameters } from "viem";
+import { decodeAbiParameters, Address } from "viem";
 
 // keccak256("ModifyLiquidity(bytes32,address,int24,int24,int256,bytes32)") — v4 PoolManager.
 const POOL_MANAGER_MODIFY_LIQUIDITY_TOPIC =
@@ -236,12 +237,41 @@ onIndexerEvent("DopplerHookInitializer:UpdateBeneficiary", async ({ event, conte
   });
 });
 
-onIndexerEvent("DopplerHookInitializer:Swap", async ({ event, context }) => {
-  const { sender, poolId, amount0, amount1 } = event.args;
-  const timestamp = event.block.timestamp;
+/**
+ * Processes a Doppler-hook (dhook/rehype) pool swap: recomputes price, reserves,
+ * market cap and dollar liquidity, then writes the pool / asset / 15-min-bucket
+ * updates (this path never persists a swap row and never uses `sender`).
+ *
+ * `priceData` supplies the post-swap sqrtPriceX96 and tick. When omitted (the
+ * DopplerHookInitializer:Swap path used on non-robinhood chains) we read them with a
+ * getSlot0 RPC. On robinhood the caller (PoolManager:Swap) passes them straight from
+ * the event, eliminating that per-swap RPC — the realtime-throughput bottleneck on
+ * that high-block-rate chain.
+ */
+export async function processDHookSwap({
+  context,
+  poolAddress,
+  sender,
+  amount0,
+  amount1,
+  timestamp,
+  transactionHash,
+  transactionFrom,
+  blockNumber,
+  priceData,
+}: {
+  context: Context;
+  poolAddress: `0x${string}`;
+  sender: Address;
+  amount0: bigint;
+  amount1: bigint;
+  timestamp: bigint;
+  transactionHash: `0x${string}`;
+  transactionFrom: Address;
+  blockNumber: bigint;
+  priceData?: { sqrtPriceX96: bigint; currentTick: number };
+}): Promise<void> {
   const { chain, client, db } = context;
-
-  const poolAddress = (poolId as string).toLowerCase() as `0x${string}`;
 
   const poolEntity = await db.find(pool, {
     address: poolAddress,
@@ -263,15 +293,19 @@ onIndexerEvent("DopplerHookInitializer:Swap", async ({ event, context }) => {
     return;
   }
 
+  // On chains that don't supply the post-swap price in the event, read it once here,
+  // concurrently with the ledger / quote / token reads below.
   const { stateView } = chainConfigs[chain.name].addresses.v4;
+  const slot0Promise = priceData
+    ? null
+    : client.readContract({
+        abi: StateViewABI,
+        address: stateView,
+        functionName: "getSlot0",
+        args: [poolAddress],
+      });
 
-  const [slot0, onChainPositions, quoteInfo, tokenEntity] = await Promise.all([
-    client.readContract({
-      abi: StateViewABI,
-      address: stateView,
-      functionName: "getSlot0",
-      args: [poolId],
-    }),
+  const [onChainPositions, quoteInfo, tokenEntity] = await Promise.all([
     getPositionsForPool({ poolId: poolAddress, context }),
     getQuoteInfo(poolEntity.quoteToken, timestamp, context),
     db.find(token, {
@@ -285,7 +319,16 @@ onIndexerEvent("DopplerHookInitializer:Swap", async ({ event, context }) => {
     return;
   }
 
-  const [sqrtPriceX96, currentTick] = slot0;
+  let sqrtPriceX96: bigint;
+  let currentTick: number;
+  if (priceData) {
+    sqrtPriceX96 = priceData.sqrtPriceX96;
+    currentTick = priceData.currentTick;
+  } else {
+    const slot0 = await slot0Promise!;
+    sqrtPriceX96 = slot0[0];
+    currentTick = slot0[1];
+  }
 
   const price = PriceService.computePriceFromSqrtPriceX96({
     sqrtPriceX96,
@@ -335,9 +378,9 @@ onIndexerEvent("DopplerHookInitializer:Swap", async ({ event, context }) => {
   const swapData = SwapOrchestrator.createSwapData({
     poolAddress,
     sender,
-    transactionHash: event.transaction.hash,
-    transactionFrom: event.transaction.from,
-    blockNumber: event.block.number,
+    transactionHash,
+    transactionFrom,
+    blockNumber,
     timestamp,
     assetAddress: poolEntity.baseToken,
     quoteAddress: poolEntity.quoteToken,
@@ -405,6 +448,30 @@ onIndexerEvent("DopplerHookInitializer:Swap", async ({ event, context }) => {
       context,
     }),
   ]);
+}
+
+onIndexerEvent("DopplerHookInitializer:Swap", async ({ event, context }) => {
+  // Robinhood dhook/rehype swaps are processed in PoolManager:Swap instead, which
+  // carries the post-swap sqrtPriceX96/tick and so avoids a getSlot0 RPC per swap —
+  // the realtime-throughput bottleneck on that high-block-rate chain. Skipping here
+  // avoids double-processing the same swap; other chains keep using this handler.
+  if (context.chain.id === CHAIN_IDS.robinhood) {
+    return;
+  }
+
+  const { sender, poolId, amount0, amount1 } = event.args;
+
+  await processDHookSwap({
+    context,
+    poolAddress: (poolId as string).toLowerCase() as `0x${string}`,
+    sender,
+    amount0,
+    amount1,
+    timestamp: event.block.timestamp,
+    transactionHash: event.transaction.hash,
+    transactionFrom: event.transaction.from,
+    blockNumber: event.block.number,
+  });
 });
 
 onIndexerEvent("DopplerHookInitializer:ModifyLiquidity", async ({ event, context }) => {

--- a/src/indexer/indexer-v4.ts
+++ b/src/indexer/indexer-v4.ts
@@ -30,6 +30,8 @@ import { computeGraduationPercentage } from "@app/utils/v4-utils";
 import { updateFifteenMinuteBucketUsd } from "@app/utils/time-buckets";
 import { UniswapV4MulticurveInitializerABI } from "@app/abis/multicurve-abis/UniswapV4MulticurveInitializerABI";
 import { chainConfigs } from "@app/config/chains";
+import { CHAIN_IDS } from "@app/config";
+import { processDHookSwap } from "./indexer-dhook";
 import { insertMulticurvePoolV4Optimized } from "./shared/entities/multicurve/pool";
 import { pool, token } from "ponder:schema";
 import { handleOptimizedSwap } from "./shared/swap-optimizer";
@@ -628,6 +630,32 @@ onIndexerEvent("PoolManager:Swap", async ({ event, context }) => {
 
   if (!isV4MigrationPoolCacheInitialized()) {
     await initializeV4MigrationPoolCache(context);
+  }
+
+  // Robinhood dhook/rehype pools: process the swap here rather than in
+  // DopplerHookInitializer:Swap. PoolManager:Swap carries the post-swap sqrtPriceX96
+  // and tick, so we avoid a getSlot0 RPC round-trip per swap — the realtime
+  // throughput bottleneck on that high-block-rate chain. Other chains keep using the
+  // DopplerHookInitializer:Swap handler.
+  if (chain.id === CHAIN_IDS.robinhood) {
+    if (!isDHookPoolCacheInitialized()) {
+      await initializeDHookPoolCache(context);
+    }
+    if (isKnownDHookPool(chain.id, poolId as string)) {
+      await processDHookSwap({
+        context,
+        poolAddress: (poolId as string).toLowerCase() as `0x${string}`,
+        sender: sender.toLowerCase() as Address,
+        amount0: BigInt(amount0),
+        amount1: BigInt(amount1),
+        timestamp,
+        transactionHash: txHash,
+        transactionFrom: txFrom,
+        blockNumber: event.block.number,
+        priceData: { sqrtPriceX96, currentTick: Number(tick) },
+      });
+      return;
+    }
   }
 
   if (!isKnownV4MigrationPool(chain.id, poolId as string)) {


### PR DESCRIPTION
## Problem

Robinhood (chain 4663) produces blocks at ~10/s — above what the shared `ordering: "multichain"` pipeline can index in realtime — so it steadily lags and needs periodic restarts. Its hot path is dhook/rehype pool swaps, and the per-swap floor is a **`getSlot0` RPC round-trip** inside `DopplerHookInitializer:Swap`: that event carries only swap *inputs* (`zeroForOne`, `amountSpecified`, `sqrtPriceLimitX96`), no post-swap price, so price genuinely needed a live read.

## What this does

Re-points robinhood dhook/rehype swap processing to **`PoolManager:Swap`**, which already carries the post-swap `sqrtPriceX96` and `tick` — eliminating the `getSlot0` RPC per swap.

### Why it's safe (verified on-chain against live robinhood)
- Every `DopplerHookInitializer:Swap` has a `PoolManager:Swap` twin in the same tx with **byte-identical `amount0`/`amount1`**, and the counts are **1:1 per dhook pool** — so repointing fires the handler the same number of times with the same amounts (no inversion, no double-count, no missed rows). Compound txs (user swap + rehype rebalance) emit matched pairs of both events.
- `PoolManager` is synced for robinhood, and the dhook pool's primary key **is** the v4 `poolId` that `PoolManager:Swap.id` emits.
- Recorded price is actually **more accurate**: the true per-swap `sqrtPriceX96` instead of a live `getSlot0` that can reflect a near-tip (future) value.

### Compatibility with swap-row indexing (feat/rehype-swaps, now on main)
The swap row is written inside `performSwapUpdates` with **`user: swapData.transactionFrom`** (the EOA — *not* the event `sender`) and deduped by `(txHash, chainId)`. The repoint feeds `processDHookSwap` → `performSwapUpdates` for robinhood too, so robinhood swaps are still indexed, and `user` is `tx.from` either way — the PoolManager-vs-hook `sender` difference has **no effect on the persisted row**.

**Nuance:** with one-row-per-tx dedup, compound txs keep only the first-processed leg. On robinhood the repoint processes the lower-logIndex **PM** events, so it tends to keep the *user* leg; the hook path tended to keep the *rehype-rebalance* leg. Same `user` (tx.from) either way — only the recorded `amountIn`/`type`/`pool` differ, and the user leg is arguably the better one to surface. Recording *all* legs would require `logIndex` in the swap PK (independent of this PR).

### Change shape
- Extract the dhook swap body into **`processDHookSwap()`** with an optional `priceData` param. When omitted (base/monad/mainnet, still on `DopplerHookInitializer:Swap`) it reads `getSlot0` exactly as before.
- `DopplerHookInitializer:Swap` now **skips robinhood** (handled by `PoolManager:Swap`) to avoid double-processing.
- `PoolManager:Swap` gains a **robinhood-scoped** dhook/rehype branch gated on `isKnownDHookPool`.

**Blast radius: robinhood only.** base/monad/mainnet behavior is byte-identical.

Rebased onto main, which now carries the #76 shaves (`extraPoolUpdate` fold — single `performSwapUpdates` call, `updateCumulatedFees` removed) and swap-row indexing; `processDHookSwap` uses the folded single-call form.

## Why this is more valuable now, not less
Swap-indexing added a per-swap `insertSwap` **DB write** to robinhood's hot path, raising the per-swap commit cost. Eliminating the per-swap `getSlot0` **RPC** offsets that — they're independent levers on the same bottleneck.

## Deploy note
This is an indexing-code change, so it **requires a fresh-schema re-index** (Ponder `buildId` rotation refuses to resume the existing schema) — deploy via the staging → promote flow. The `ponder_sync` RPC cache is reused, so blocks aren't refetched. Good moment to eyeball a few robinhood pool prices on staging before promoting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)