### PR TITLE
perf(indexer): shave DB/RPC round-trips from hot swap, transfer & create handlers

### DIFF
--- a/monitoring/grafana/provisioning/dashboards/indexer-prod.json
+++ b/monitoring/grafana/provisioning/dashboards/indexer-prod.json
@@ -2,211 +2,636 @@
   "title": "Indexer — prod",
   "uid": "indexer-prod",
   "schemaVersion": 39,
-  "version": 2,
+  "version": 6,
   "refresh": "30s",
-  "time": { "from": "now-1h", "to": "now" },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
   "timezone": "browser",
-  "tags": ["ponder", "indexer", "prod"],
+  "tags": [
+    "ponder",
+    "indexer",
+    "prod"
+  ],
   "templating": {
     "list": [
       {
         "name": "datasource",
         "type": "datasource",
         "query": "prometheus",
-        "current": { "text": "Prometheus", "value": "Prometheus" }
+        "current": {
+          "text": "Prometheus",
+          "value": "Prometheus"
+        }
       },
       {
         "name": "chain",
         "type": "query",
-        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
         "query": "label_values(ponder_sync_block_timestamp{indexer=\"prod-indexer\"}, chain)",
         "includeAll": true,
         "multi": true,
-        "current": { "text": "All", "value": "$__all" },
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
         "refresh": 2
       }
     ]
   },
   "panels": [
     {
-      "id": 1, "type": "row", "title": "Lag",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
-    },
-    {
-      "id": 2, "type": "timeseries", "title": "Lag per chain (sync_block - indexing) seconds",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
-      "targets": [{
-        "expr": "ponder_sync_block_timestamp{indexer=\"prod-indexer\",chain=~\"$chain\"} - ponder_indexing_timestamp{indexer=\"prod-indexer\",chain=~\"$chain\"}",
-        "legendFormat": "{{chain}}",
-        "refId": "A"
-      }],
-      "fieldConfig": { "defaults": { "unit": "s", "thresholds": { "mode": "absolute", "steps": [
-        { "color": "green", "value": null }, { "color": "yellow", "value": 30 }, { "color": "red", "value": 120 }
-      ]}}}
-    },
-    {
-      "id": 3, "type": "timeseries", "title": "Realtime mode (1=live, 0=historical)",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
-      "targets": [{
-        "expr": "ponder_sync_is_realtime{indexer=\"prod-indexer\",chain=~\"$chain\"}",
-        "legendFormat": "{{chain}}",
-        "refId": "A"
-      }]
-    },
-    {
-      "id": 4, "type": "row", "title": "HTTP / API (read-API droplet)",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 }
-    },
-    {
-      "id": 5, "type": "timeseries", "title": "Request rate by endpoint",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 10 },
-      "targets": [{
-        "expr": "sum by (path) (rate(ponder_http_server_request_duration_ms_count{indexer=\"prod-api\"}[1m]))",
-        "legendFormat": "{{path}}",
-        "refId": "A"
-      }],
-      "fieldConfig": { "defaults": { "unit": "reqps" } }
-    },
-    {
-      "id": 6, "type": "timeseries", "title": "Request p95 by endpoint",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 10 },
-      "targets": [{
-        "expr": "histogram_quantile(0.95, sum by (path, le) (rate(ponder_http_server_request_duration_ms_bucket{indexer=\"prod-api\"}[5m])))",
-        "legendFormat": "{{path}}",
-        "refId": "A"
-      }],
-      "fieldConfig": { "defaults": { "unit": "ms" } }
-    },
-    {
-      "id": 18, "type": "timeseries", "title": "/sql/* latency percentiles by status",
-      "description": "Ponder collapses every /sql query under path=/sql/*, so we can't break down by SQL text. Status splits timeouts (5XX) from slow successes (2XX). For per-query investigation use pg_stat_statements on the prod_readonly droplet.",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 17 },
-      "targets": [
-        { "expr": "histogram_quantile(0.50, sum by (status, le) (rate(ponder_http_server_request_duration_ms_bucket{indexer=\"prod-api\",path=\"/sql/*\"}[5m])))", "legendFormat": "p50 {{status}}", "refId": "A" },
-        { "expr": "histogram_quantile(0.95, sum by (status, le) (rate(ponder_http_server_request_duration_ms_bucket{indexer=\"prod-api\",path=\"/sql/*\"}[5m])))", "legendFormat": "p95 {{status}}", "refId": "B" },
-        { "expr": "histogram_quantile(0.99, sum by (status, le) (rate(ponder_http_server_request_duration_ms_bucket{indexer=\"prod-api\",path=\"/sql/*\"}[5m])))", "legendFormat": "p99 {{status}}", "refId": "C" }
-      ],
-      "fieldConfig": { "defaults": { "unit": "ms" } }
-    },
-    {
-      "id": 19, "type": "heatmap", "title": "/sql/* latency distribution",
-      "description": "Heatmap of request rate per latency bucket. Bright cells near the top (>= the 500000 ms top bucket) are requests overflowing the histogram cap — those are truly stuck/timed-out.",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 17 },
-      "targets": [{
-        "expr": "sum by (le) (rate(ponder_http_server_request_duration_ms_bucket{indexer=\"prod-api\",path=\"/sql/*\"}[1m]))",
-        "format": "heatmap",
-        "legendFormat": "{{le}}",
-        "refId": "A"
-      }],
-      "options": {
-        "calculate": false,
-        "cellGap": 1,
-        "color": { "scheme": "Spectral", "mode": "scheme", "exponent": 0.5, "steps": 64 },
-        "yAxis": { "unit": "ms", "decimals": 0 },
-        "tooltip": { "show": true, "yHistogram": true }
+      "id": 1,
+      "type": "row",
+      "title": "Lag",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
       }
     },
     {
-      "id": 7, "type": "row", "title": "Database calls (from indexer process)",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 24 }
-    },
-    {
-      "id": 8, "type": "timeseries", "title": "select_checkpoints avg latency (DB contention proxy)",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 25 },
-      "targets": [{
-        "expr": "rate(ponder_database_method_duration_sum{indexer=\"prod-indexer\",method=\"select_checkpoints\"}[5m]) / rate(ponder_database_method_duration_count{indexer=\"prod-indexer\",method=\"select_checkpoints\"}[5m])",
-        "legendFormat": "avg ms",
-        "refId": "A"
-      }],
-      "fieldConfig": { "defaults": { "unit": "ms" } }
-    },
-    {
-      "id": 9, "type": "timeseries", "title": "DB method avg latency (top 8 by traffic)",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 25 },
-      "targets": [{
-        "expr": "topk(8, rate(ponder_database_method_duration_sum{indexer=\"prod-indexer\"}[5m]) / rate(ponder_database_method_duration_count{indexer=\"prod-indexer\"}[5m]))",
-        "legendFormat": "{{method}}",
-        "refId": "A"
-      }],
-      "fieldConfig": { "defaults": { "unit": "ms" } }
-    },
-    {
-      "id": 10, "type": "timeseries", "title": "DB method error rate",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 25 },
-      "targets": [{
-        "expr": "rate(ponder_database_method_error_total{indexer=\"prod-indexer\"}[5m])",
-        "legendFormat": "{{method}}",
-        "refId": "A"
-      }]
-    },
-    {
-      "id": 11, "type": "row", "title": "Indexing + RPC",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 }
-    },
-    {
-      "id": 12, "type": "timeseries", "title": "Indexing event rate (top 10)",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 33 },
-      "targets": [{
-        "expr": "topk(10, rate(ponder_indexing_function_duration_count{indexer=\"prod-indexer\"}[1m]))",
-        "legendFormat": "{{event}}",
-        "refId": "A"
-      }],
-      "fieldConfig": { "defaults": { "unit": "ops" } }
-    },
-    {
-      "id": 13, "type": "timeseries", "title": "Indexing function avg ms (top 10)",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 33 },
-      "targets": [{
-        "expr": "topk(10, 1000 * rate(ponder_indexing_function_duration_sum{indexer=\"prod-indexer\"}[5m]) / rate(ponder_indexing_function_duration_count{indexer=\"prod-indexer\"}[5m]))",
-        "legendFormat": "{{event}}",
-        "refId": "A"
-      }],
-      "fieldConfig": { "defaults": { "unit": "ms" } }
-    },
-    {
-      "id": 14, "type": "timeseries", "title": "RPC error rate (per chain/method)",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 33 },
-      "targets": [{
-        "expr": "rate(ponder_rpc_request_error_total{indexer=\"prod-indexer\",chain=~\"$chain\"}[5m])",
-        "legendFormat": "{{chain}} {{method}}",
-        "refId": "A"
-      }]
-    },
-    {
-      "id": 15, "type": "row", "title": "Process health (indexer + api)",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 40 }
-    },
-    {
-      "id": 16, "type": "timeseries", "title": "Event-loop lag (p99, max)",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 41 },
+      "id": 2,
+      "type": "timeseries",
+      "title": "Lag per chain (sync_block - indexing) seconds",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
       "targets": [
-        { "expr": "nodejs_eventloop_lag_p99_seconds{indexer=~\"prod-(api|indexer)\"}", "legendFormat": "{{indexer}} p99", "refId": "A" },
-        { "expr": "nodejs_eventloop_lag_max_seconds{indexer=~\"prod-(api|indexer)\"}", "legendFormat": "{{indexer}} max", "refId": "B" }
+        {
+          "expr": "ponder_sync_block_timestamp{indexer=\"prod-indexer\",chain=~\"$chain\"} - ponder_indexing_timestamp{indexer=\"prod-indexer\",chain=~\"$chain\"}",
+          "legendFormat": "{{chain}}",
+          "refId": "A"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "s" } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 30
+              },
+              {
+                "color": "red",
+                "value": 120
+              }
+            ]
+          }
+        }
+      }
     },
     {
-      "id": 17, "type": "timeseries", "title": "Process memory (RSS, heap)",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 41 },
+      "id": 3,
+      "type": "timeseries",
+      "title": "Realtime mode (1=live, 0=historical)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
       "targets": [
-        { "expr": "process_resident_memory_bytes{indexer=~\"prod-(api|indexer)\"}", "legendFormat": "{{indexer}} rss", "refId": "A" },
-        { "expr": "process_heap_bytes{indexer=~\"prod-(api|indexer)\"}", "legendFormat": "{{indexer}} heap", "refId": "B" }
+        {
+          "expr": "ponder_sync_is_realtime{indexer=\"prod-indexer\",chain=~\"$chain\"}",
+          "legendFormat": "{{chain}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "row",
+      "title": "HTTP / API (read-API droplet)",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Request rate by endpoint",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "targets": [
+        {
+          "expr": "sum by (path) (rate(ponder_http_server_request_duration_ms_count{indexer=\"prod-api\"}[1m]))",
+          "legendFormat": "{{path}}",
+          "refId": "A"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "bytes" } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        }
+      }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Request p95 by endpoint",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (path, le) (rate(ponder_http_server_request_duration_ms_bucket{indexer=\"prod-api\"}[5m])))",
+          "legendFormat": "{{path}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        }
+      }
+    },
+    {
+      "id": 18,
+      "type": "timeseries",
+      "title": "/sql/* latency percentiles by status",
+      "description": "Ponder collapses every /sql query under path=/sql/*, so we can't break down by SQL text. Status splits timeouts (5XX) from slow successes (2XX). For per-query investigation use pg_stat_statements on the prod_readonly droplet.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (status, le) (rate(ponder_http_server_request_duration_ms_bucket{indexer=\"prod-api\",path=\"/sql/*\"}[5m])))",
+          "legendFormat": "p50 {{status}}",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (status, le) (rate(ponder_http_server_request_duration_ms_bucket{indexer=\"prod-api\",path=\"/sql/*\"}[5m])))",
+          "legendFormat": "p95 {{status}}",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (status, le) (rate(ponder_http_server_request_duration_ms_bucket{indexer=\"prod-api\",path=\"/sql/*\"}[5m])))",
+          "legendFormat": "p99 {{status}}",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        }
+      }
+    },
+    {
+      "id": 19,
+      "type": "heatmap",
+      "title": "/sql/* latency distribution",
+      "description": "Heatmap of request rate per latency bucket. Bright cells near the top (>= the 500000 ms top bucket) are requests overflowing the histogram cap — those are truly stuck/timed-out.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "targets": [
+        {
+          "expr": "sum by (le) (rate(ponder_http_server_request_duration_ms_bucket{indexer=\"prod-api\",path=\"/sql/*\"}[1m]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "scheme": "Spectral",
+          "mode": "scheme",
+          "exponent": 0.5,
+          "steps": 64
+        },
+        "yAxis": {
+          "unit": "ms",
+          "decimals": 0
+        },
+        "tooltip": {
+          "show": true,
+          "yHistogram": true
+        }
+      }
+    },
+    {
+      "id": 7,
+      "type": "row",
+      "title": "Database calls (from indexer process)",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      }
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "select_checkpoints avg latency (DB contention proxy)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 25
+      },
+      "targets": [
+        {
+          "expr": "rate(ponder_database_method_duration_sum{indexer=\"prod-indexer\",method=\"select_checkpoints\"}[5m]) / rate(ponder_database_method_duration_count{indexer=\"prod-indexer\",method=\"select_checkpoints\"}[5m])",
+          "legendFormat": "avg ms",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        }
+      }
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "DB method avg latency (top 8 by traffic)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 25
+      },
+      "targets": [
+        {
+          "expr": "topk(8, rate(ponder_database_method_duration_sum{indexer=\"prod-indexer\"}[5m]) / rate(ponder_database_method_duration_count{indexer=\"prod-indexer\"}[5m]))",
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        }
+      }
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "DB method error rate",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 25
+      },
+      "targets": [
+        {
+          "expr": "rate(ponder_database_method_error_total{indexer=\"prod-indexer\"}[5m])",
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "row",
+      "title": "Indexing + RPC",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      }
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Indexing event rate (top 10)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 33
+      },
+      "targets": [
+        {
+          "expr": "topk(10, rate(ponder_indexing_function_duration_count{indexer=\"prod-indexer\"}[1m]))",
+          "legendFormat": "{{event}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        }
+      }
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Indexing function avg ms (top 10)",
+      "description": "Metric ponder_indexing_function_duration is already in milliseconds (bucket le values run 0.001..100000 ms), so avg = rate(sum)/rate(count) with NO scaling. (Was previously multiplied by 1000, which inflated every value 1000x — e.g. made DopplerHookInitializer:Create's ~0.9s look like ~6-15 min.)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 33
+      },
+      "targets": [
+        {
+          "expr": "topk(10, rate(ponder_indexing_function_duration_sum{indexer=\"prod-indexer\"}[5m]) / rate(ponder_indexing_function_duration_count{indexer=\"prod-indexer\"}[5m]))",
+          "legendFormat": "{{event}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        }
+      }
+    },
+    {
+      "id": 14,
+      "type": "timeseries",
+      "title": "RPC error rate (per chain/method)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 33
+      },
+      "targets": [
+        {
+          "expr": "rate(ponder_rpc_request_error_total{indexer=\"prod-indexer\",chain=~\"$chain\"}[5m])",
+          "legendFormat": "{{chain}} {{method}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 15,
+      "type": "row",
+      "title": "Process health (indexer + api)",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      }
+    },
+    {
+      "id": 16,
+      "type": "timeseries",
+      "title": "Event-loop lag (p99, max)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 41
+      },
+      "targets": [
+        {
+          "expr": "nodejs_eventloop_lag_p99_seconds{indexer=~\"prod-(api|indexer)\"}",
+          "legendFormat": "{{indexer}} p99",
+          "refId": "A"
+        },
+        {
+          "expr": "nodejs_eventloop_lag_max_seconds{indexer=~\"prod-(api|indexer)\"}",
+          "legendFormat": "{{indexer}} max",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      }
+    },
+    {
+      "id": 17,
+      "type": "timeseries",
+      "title": "Process memory (RSS, heap)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 41
+      },
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes{indexer=~\"prod-(api|indexer)\"}",
+          "legendFormat": "{{indexer}} rss",
+          "refId": "A"
+        },
+        {
+          "expr": "process_heap_bytes{indexer=~\"prod-(api|indexer)\"}",
+          "legendFormat": "{{indexer}} heap",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        }
+      }
+    },
+    {
+      "id": 21,
+      "type": "row",
+      "title": "Indexing time budget",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 48
+      }
+    },
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "Indexing time share by event (% of total)",
+      "description": "Composition of indexing time. Each series is that event's share of total indexing time: 100 x rate(duration_sum for the event) / sum(rate(duration_sum for all events)). Bands are stacked so they fill to ~100% and each band's height is proportional to its share — and because the value IS the share, the tooltip number matches the band size. Watch how the mix shifts (e.g. DERC20:Transfer swelling). The widest bands are the shave targets. Complements the avg-ms panel — a cheap-but-frequent event (PoolManager:Swap) can out-total a slow-but-rare one (DopplerHookInitializer:Create). topk(12) hides a small long tail, so the stack tops out a hair under 100%.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 49
+      },
+      "targets": [
+        {
+          "expr": "topk(12, 100 * rate(ponder_indexing_function_duration_sum{indexer=\"prod-indexer\"}[5m]) / scalar(sum(rate(ponder_indexing_function_duration_sum{indexer=\"prod-indexer\"}[5m]))))",
+          "legendFormat": "{{event}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 75,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "gradientMode": "none",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 22,
+      "type": "timeseries",
+      "title": "Indexing time cost by event (% of one indexing thread, absolute)",
+      "description": "ABSOLUTE cost companion to the share panel above: 0.1 x rate(ponder_indexing_function_duration_sum[5m]) = ms of handler time per wall-second, expressed as % of one indexing thread (100% = thread saturated by that event alone). Unlike the normalized share panel, this is comparable ACROSS restarts and load levels — use it to judge whether a handler optimization actually reduced total time. Stack height ~= total indexing-thread utilization by these events.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 61
+      },
+      "targets": [
+        {
+          "expr": "topk(12, 0.1 * rate(ponder_indexing_function_duration_sum{indexer=\"prod-indexer\"}[5m]))",
+          "legendFormat": "{{event}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 60,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "gradientMode": "none",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
     }
   ]
 }

--- a/patches/ponder@0.16.3.patch
+++ b/patches/ponder@0.16.3.patch
@@ -57,10 +57,10 @@ index cd8df0b2352161ca01104b4b3e4882fe6ff25a03..6cc76d99b4219ce890b085121db9ba38
                      }
                  }
 diff --git a/dist/esm/database/actions.js b/dist/esm/database/actions.js
-index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..d1c03a848aed7d8755920590a1f095a8df078473 100644
+index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..01d272e5f1f71c32f3ec3855e7c3475c3728c5d7 100644
 --- a/dist/esm/database/actions.js
 +++ b/dist/esm/database/actions.js
-@@ -6,13 +6,82 @@ import { and, eq, getTableColumns, getTableName, getViewName, lte, sql, } from "
+@@ -6,13 +6,95 @@ import { and, eq, getTableColumns, getTableName, getViewName, lte, sql, } from "
  import { getTableConfig } from "drizzle-orm/pg-core";
  import { PONDER_CHECKPOINT_TABLE_NAME, PONDER_META_TABLE_NAME, getPonderCheckpointTable, } from "./index.js";
  export const createIndexes = async (qb, { statements }, context) => {
@@ -70,7 +70,6 @@ index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..d1c03a848aed7d8755920590a1f095a8
 -            await tx.wrap((tx) => tx.execute("SET statement_timeout = 3600000;"));
 -            await tx.wrap((tx) => tx.execute(statement));
 -        }, undefined, context);
--    }
 +    // Parallelize index creation. On Postgres we use CREATE INDEX CONCURRENTLY
 +    // so the build does not block writes — this lets live indexing run
 +    // concurrently with the index build (see runtime/{multichain,omnichain}.js
@@ -92,24 +91,37 @@ index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..d1c03a848aed7d8755920590a1f095a8
 +    // CREATE INDEX CONCURRENTLY (e.g. from a deadlock or process crash).
 +    // IF NOT EXISTS would otherwise skip recreating them, so they'd stay
 +    // invalid forever and queries wouldn't use them.
++    //
++    // Scope strictly to the schema(s) THIS app builds indexes in — parsed from
++    // each statement's `ON "schema"."table"`. A cluster-wide sweep would drop
++    // invalid indexes belonging to other apps/schemas on a shared Postgres,
++    // including another app's in-progress CREATE INDEX CONCURRENTLY (which reads
++    // as invalid until it finishes).
 +    if (isPostgres && queue.length > 0) {
-+        const sweepClient = await qb.$client.connect();
-+        try {
-+            const { rows } = await sweepClient.query(`
++        const schemas = [
++            ...new Set(queue
++                .map((s) => s.match(/\sON\s+"([^"]+)"\./i)?.[1])
++                .filter((s) => s !== undefined)),
++        ];
++        if (schemas.length > 0) {
++            const sweepClient = await qb.$client.connect();
++            try {
++                const { rows } = await sweepClient.query(`
 +                SELECT n.nspname AS schema, c.relname AS index
 +                FROM pg_index i
 +                JOIN pg_class c ON c.oid = i.indexrelid
 +                JOIN pg_namespace n ON n.oid = c.relnamespace
-+                WHERE NOT i.indisvalid
-+            `);
-+            for (const row of rows) {
-+                await sweepClient.query(`DROP INDEX IF EXISTS "${row.schema}"."${row.index}"`);
++                WHERE n.nspname = ANY($1) AND NOT i.indisvalid
++            `, [schemas]);
++                for (const row of rows) {
++                    await sweepClient.query(`DROP INDEX IF EXISTS "${row.schema}"."${row.index}"`);
++                }
++            }
++            finally {
++                sweepClient.release();
 +            }
 +        }
-+        finally {
-+            sweepClient.release();
-+        }
-+    }
+     }
 +    const runWorker = async () => {
 +        while (queue.length > 0) {
 +            const statement = queue.shift();
@@ -150,7 +162,7 @@ index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..d1c03a848aed7d8755920590a1f095a8
  };
  export const createTriggers = async (qb, { tables, chainId }, context) => {
      await qb.transaction(async (tx) => {
-@@ -54,6 +82,14 @@ export const dropTriggers = async (qb, { tables, chainId }, context) => {
+@@ -54,6 +136,14 @@ export const dropTriggers = async (qb, { tables, chainId }, context) => {
      }, undefined, context);
  };
  export const createLiveQueryTriggers = async (qb, { namespaceBuild, tables, chainId, }, context) => {
@@ -165,7 +177,7 @@ index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..d1c03a848aed7d8755920590a1f095a8
      await qb.transaction(async (tx) => {
          const notifyProcedure = getLiveQueryNotifyProcedureName();
          const notifyTrigger = getLiveQueryNotifyTriggerName();
-@@ -86,6 +122,11 @@ export const dropLiveQueryTriggers = async (qb, { namespaceBuild, tables, chainI
+@@ -86,6 +176,11 @@ export const dropLiveQueryTriggers = async (qb, { namespaceBuild, tables, chainI
      }, undefined, context);
  };
  export const createLiveQueryProcedures = async (qb, { namespaceBuild }, context) => {
@@ -177,7 +189,7 @@ index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..d1c03a848aed7d8755920590a1f095a8
      await qb.transaction(async (tx) => {
          const schema = namespaceBuild.schema;
          const procedure = getLiveQueryProcedureName();
-@@ -147,6 +188,13 @@ export const createViews = async (qb, { tables, views, namespaceBuild, }, contex
+@@ -147,6 +242,13 @@ export const createViews = async (qb, { tables, views, namespaceBuild, }, contex
          await tx.wrap((tx) => tx.execute(`DROP VIEW IF EXISTS "${namespaceBuild.viewsSchema}"."${PONDER_CHECKPOINT_TABLE_NAME}"`));
          await tx.wrap((tx) => tx.execute(`CREATE VIEW "${namespaceBuild.viewsSchema}"."${PONDER_META_TABLE_NAME}" AS SELECT * FROM "${namespaceBuild.schema}"."${PONDER_META_TABLE_NAME}"`));
          await tx.wrap((tx) => tx.execute(`CREATE VIEW "${namespaceBuild.viewsSchema}"."${PONDER_CHECKPOINT_TABLE_NAME}" AS SELECT * FROM "${namespaceBuild.schema}"."${PONDER_CHECKPOINT_TABLE_NAME}"`));
@@ -339,10 +351,10 @@ index 8b37dc75bc572b1a1ac33b5c0e4522dad8a480f2..462fc8b466b1dafcdf62d7bb40f026d7
                  hostname: "custom_transport",
              },
 diff --git a/dist/esm/runtime/multichain.js b/dist/esm/runtime/multichain.js
-index c5efbc3bf913959800f5e62c9bf98fdc76a3ba37..76b691a9d54f706ee0cf68400cc444ea8d41be7b 100644
+index c5efbc3bf913959800f5e62c9bf98fdc76a3ba37..5bef0b7abb89968d74258223c0379816a9717b21 100644
 --- a/dist/esm/runtime/multichain.js
 +++ b/dist/esm/runtime/multichain.js
-@@ -307,14 +307,34 @@ export async function runMultichain({ common, preBuild, namespaceBuild, schemaBu
+@@ -307,15 +307,13 @@ export async function runMultichain({ common, preBuild, namespaceBuild, schemaBu
      const tables = Object.values(schemaBuild.schema).filter(isTable);
      const views = Object.values(schemaBuild.schema).filter(isView);
      let endClock = startClock();
@@ -352,11 +364,29 @@ index c5efbc3bf913959800f5e62c9bf98fdc76a3ba37..76b691a9d54f706ee0cf68400cc444ea
 -            msg: "Created database indexes",
 -            count: schemaBuild.statements.indexes.sql.length,
 -            duration: endClock(),
+-        });
+-    }
+-    endClock = startClock();
++    // Create triggers BEFORE kicking off the background index build. Trigger
++    // creation takes SHARE ROW EXCLUSIVE locks on every table inside a single
++    // transaction, which conflicts with the SHARE UPDATE EXCLUSIVE lock a
++    // concurrent CREATE INDEX CONCURRENTLY holds — running them at the same
++    // time can deadlock (Postgres kills one, orphaning an INVALID index or
++    // failing trigger creation on restart). Triggers are fast metadata ops,
++    // so finish them first, then start the long-running non-blocking build.
+     await createTriggers(database.adminQB, { tables });
+     await createLiveQueryTriggers(database.adminQB, { namespaceBuild, tables });
+     common.logger.debug({
+@@ -323,6 +321,35 @@ export async function runMultichain({ common, preBuild, namespaceBuild, schemaBu
+         count: tables.length,
+         duration: endClock(),
+     });
 +    // Kick off index creation in the background so live indexing can start
 +    // immediately instead of blocking 10-15 minutes for index builds. Uses
 +    // CREATE INDEX CONCURRENTLY (see database/actions.js::createIndexes) so
 +    // builds don't block writes from the live indexer. Shares the user pool
 +    // with live indexing; concurrency is capped low inside createIndexes.
++    endClock = startClock();
 +    const indexCount = schemaBuild.statements.indexes.sql.length;
 +    const indexBuildPromise = createIndexes(database.userQB, { statements: schemaBuild.statements })
 +        .then(() => {
@@ -372,8 +402,7 @@ index c5efbc3bf913959800f5e62c9bf98fdc76a3ba37..76b691a9d54f706ee0cf68400cc444ea
 +        common.logger.error({
 +            msg: "Background index build failed",
 +            error: err?.message ?? String(err),
-         });
--    }
++        });
 +    });
 +    // Best-effort: await background index build during shutdown so partially
 +    // built CONCURRENTLY indexes don't get orphaned as INVALID. IF NOT EXISTS
@@ -381,14 +410,14 @@ index c5efbc3bf913959800f5e62c9bf98fdc76a3ba37..76b691a9d54f706ee0cf68400cc444ea
 +    common.shutdown.add(async () => {
 +        await indexBuildPromise;
 +    });
-     endClock = startClock();
-     await createTriggers(database.adminQB, { tables });
-     await createLiveQueryTriggers(database.adminQB, { namespaceBuild, tables });
+     if (namespaceBuild.viewsSchema !== undefined) {
+         const endClock = startClock();
+         await createViews(database.adminQB, { tables, views, namespaceBuild });
 diff --git a/dist/esm/runtime/omnichain.js b/dist/esm/runtime/omnichain.js
-index ff59bf37e048955f06311123a89af83d401ef3a0..87696e596dd52e05e159c93789a7699896ba1614 100644
+index ff59bf37e048955f06311123a89af83d401ef3a0..4e50de4d8dee15ed4a2c0722cb427cd74259153a 100644
 --- a/dist/esm/runtime/omnichain.js
 +++ b/dist/esm/runtime/omnichain.js
-@@ -314,14 +314,34 @@ export async function runOmnichain({ common, preBuild, namespaceBuild, schemaBui
+@@ -314,15 +314,13 @@ export async function runOmnichain({ common, preBuild, namespaceBuild, schemaBui
      const tables = Object.values(schemaBuild.schema).filter(isTable);
      const views = Object.values(schemaBuild.schema).filter(isView);
      let endClock = startClock();
@@ -398,11 +427,29 @@ index ff59bf37e048955f06311123a89af83d401ef3a0..87696e596dd52e05e159c93789a76998
 -            msg: "Created database indexes",
 -            count: schemaBuild.statements.indexes.sql.length,
 -            duration: endClock(),
+-        });
+-    }
+-    endClock = startClock();
++    // Create triggers BEFORE kicking off the background index build. Trigger
++    // creation takes SHARE ROW EXCLUSIVE locks on every table inside a single
++    // transaction, which conflicts with the SHARE UPDATE EXCLUSIVE lock a
++    // concurrent CREATE INDEX CONCURRENTLY holds — running them at the same
++    // time can deadlock (Postgres kills one, orphaning an INVALID index or
++    // failing trigger creation on restart). Triggers are fast metadata ops,
++    // so finish them first, then start the long-running non-blocking build.
+     await createTriggers(database.adminQB, { tables });
+     await createLiveQueryTriggers(database.adminQB, { namespaceBuild, tables });
+     common.logger.debug({
+@@ -330,6 +328,35 @@ export async function runOmnichain({ common, preBuild, namespaceBuild, schemaBui
+         count: tables.length,
+         duration: endClock(),
+     });
 +    // Kick off index creation in the background so live indexing can start
 +    // immediately instead of blocking 10-15 minutes for index builds. Uses
 +    // CREATE INDEX CONCURRENTLY (see database/actions.js::createIndexes) so
 +    // builds don't block writes from the live indexer. Shares the user pool
 +    // with live indexing; concurrency is capped low inside createIndexes.
++    endClock = startClock();
 +    const indexCount = schemaBuild.statements.indexes.sql.length;
 +    const indexBuildPromise = createIndexes(database.userQB, { statements: schemaBuild.statements })
 +        .then(() => {
@@ -418,8 +465,7 @@ index ff59bf37e048955f06311123a89af83d401ef3a0..87696e596dd52e05e159c93789a76998
 +        common.logger.error({
 +            msg: "Background index build failed",
 +            error: err?.message ?? String(err),
-         });
--    }
++        });
 +    });
 +    // Best-effort: await background index build during shutdown so partially
 +    // built CONCURRENTLY indexes don't get orphaned as INVALID. IF NOT EXISTS
@@ -427,9 +473,9 @@ index ff59bf37e048955f06311123a89af83d401ef3a0..87696e596dd52e05e159c93789a76998
 +    common.shutdown.add(async () => {
 +        await indexBuildPromise;
 +    });
-     endClock = startClock();
-     await createTriggers(database.adminQB, { tables });
-     await createLiveQueryTriggers(database.adminQB, { namespaceBuild, tables });
+     if (namespaceBuild.viewsSchema !== undefined) {
+         const endClock = startClock();
+         await createViews(database.adminQB, { tables, views, namespaceBuild });
 diff --git a/dist/esm/sync-historical/index.js b/dist/esm/sync-historical/index.js
 index 3c0810be57bb1d6cf149485a1f34dd55540fc976..aeadc0821aa472baca4aab2883fe328fcf63ac97 100644
 --- a/dist/esm/sync-historical/index.js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   ponder@0.16.3:
-    hash: 07d5e98449f207b60b160c3f193fd2df2ba7342393d121e92124f0e4d6624bf9
+    hash: 54580658d53abdde0c8b0020cfdc46f671f1c0c91ee91385de3eb5c451f3b7ab
     path: patches/ponder@0.16.3.patch
 
 importers:
@@ -24,7 +24,7 @@ importers:
         version: 4.3.2
       ponder:
         specifier: 0.16.3
-        version: 0.16.3(patch_hash=07d5e98449f207b60b160c3f193fd2df2ba7342393d121e92124f0e4d6624bf9)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3))
+        version: 0.16.3(patch_hash=54580658d53abdde0c8b0020cfdc46f671f1c0c91ee91385de3eb5c451f3b7ab)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3))
       viem:
         specifier: 2.30.1
         version: 2.30.1(typescript@5.9.3)
@@ -4920,7 +4920,7 @@ snapshots:
       sonic-boom: 3.8.1
       thread-stream: 2.7.0
 
-  ponder@0.16.3(patch_hash=07d5e98449f207b60b160c3f193fd2df2ba7342393d121e92124f0e4d6624bf9)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3)):
+  ponder@0.16.3(patch_hash=54580658d53abdde0c8b0020cfdc46f671f1c0c91ee91385de3eb5c451f3b7ab)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3)):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@commander-js/extra-typings': 12.1.0(commander@12.1.0)

--- a/ponder.config.ts
+++ b/ponder.config.ts
@@ -37,7 +37,16 @@ export default createConfig({
     kind: "postgres",
     connectionString: process.env.DATABASE_URL,
     poolConfig: {
-      max: 100,
+      // Ponder splits this as: 2 internal + equal thirds for user/readonly/sync
+      // pools. max=100 risks overcommitting the shared 95-connection cluster
+      // (three indexers + read API); prod ran max=10 for a while, which starved
+      // the USER pool (all indexing reads/writes + the per-table commit_block
+      // stamps, ~193 UPDATEs/s at robinhood's block rate) down to 2 connections —
+      // measured commit_block avg was 47.5ms, almost all connection queue-wait.
+      // max=24 -> 7 conns per pool; cluster headroom verified at 33/95 in use.
+      // NOT part of the buildId (only ordering/contracts/accounts/blocks are
+      // hashed), so changing this is a plain-restart change, no re-index.
+      max: 24,
     },
   },
   ordering: "multichain",
@@ -73,6 +82,10 @@ export default createConfig({
     robinhood: {
       id: CHAIN_IDS.robinhood,
       rpc: process.env.PONDER_RPC_URL_4663,
+      // Robinhood produces ~10 blk/s; the default 1000ms head poll lets realtime
+      // fall behind in coarse 50-block (MAX_QUEUED_BLOCKS) ticks it can't recover
+      // from. Poll 4x more often so each reconcile tick is smaller and tracks tip.
+      pollingInterval: 250,
     },
   },
   blocks: {

--- a/src/indexer/indexer-dhook.ts
+++ b/src/indexer/indexer-dhook.ts
@@ -7,7 +7,6 @@ import { SwapOrchestrator, PriceService, MarketDataService } from "@app/core";
 import { getMulticallOptions } from "@app/core/utils/multicall";
 import { updateFifteenMinuteBucketUsd } from "@app/utils/time-buckets";
 import { chainConfigs } from "@app/config/chains";
-import { CHAIN_IDS } from "@app/config";
 import { pool, token } from "ponder:schema";
 import { getQuoteInfo } from "@app/utils/getQuoteInfo";
 import { computeReservesFromPositions } from "@app/utils/v4-utils/computeReservesFromPositions";
@@ -405,29 +404,14 @@ export async function processDHookSwap({
   );
 }
 
-onIndexerEvent("DopplerHookInitializer:Swap", async ({ event, context }) => {
-  // Robinhood dhook/rehype swaps are processed in PoolManager:Swap instead, which
-  // carries the post-swap sqrtPriceX96/tick and so avoids a getSlot0 RPC per swap —
-  // the realtime-throughput bottleneck on that high-block-rate chain. Skipping here
-  // avoids double-processing the same swap; other chains keep using this handler.
-  if (context.chain.id === CHAIN_IDS.robinhood) {
-    return;
-  }
-
-  const { sender, poolId, amount0, amount1 } = event.args;
-
-  await processDHookSwap({
-    context,
-    poolAddress: (poolId as string).toLowerCase() as `0x${string}`,
-    sender,
-    amount0,
-    amount1,
-    timestamp: event.block.timestamp,
-    transactionHash: event.transaction.hash,
-    transactionFrom: event.transaction.from,
-    blockNumber: event.block.number,
-  });
-});
+// NOTE: there is intentionally no DopplerHookInitializer:Swap handler. Dhook/rehype
+// swaps on EVERY chain are processed in PoolManager:Swap (indexer-v4.ts), which
+// carries the post-swap sqrtPriceX96/tick in the event itself and so avoids a
+// getSlot0 RPC round-trip per swap (originally robinhood-only, #79; extended to all
+// chains when base's rehype swaps became the top indexing cost). Every hook Swap has
+// a PoolManager:Swap twin in the same tx by v4 architecture — all pool swaps go
+// through PoolManager.swap; the hook event is a re-emit from afterSwap. Dropping the
+// handler also stops Ponder fetching/enqueuing these logs entirely.
 
 onIndexerEvent("DopplerHookInitializer:ModifyLiquidity", async ({ event, context }) => {
   const { key: poolKeyTuple } = event.args;

--- a/src/indexer/indexer-dhook.ts
+++ b/src/indexer/indexer-dhook.ts
@@ -1,7 +1,7 @@
 import { onIndexerEvent } from "./entrypoint";
 import { getPoolId } from "@app/utils/v4-utils";
 import { insertTokenIfNotExists } from "./shared/entities/token";
-import { insertPoolIfNotExistsDHook, updatePool } from "./shared/entities/pool";
+import { insertPoolIfNotExistsDHook, updatePool, updatePoolDirect } from "./shared/entities/pool";
 import { insertAssetIfNotExists, updateAsset } from "./shared/entities/asset";
 import { SwapOrchestrator, PriceService, MarketDataService } from "@app/core";
 import { getMulticallOptions } from "@app/core/utils/multicall";
@@ -126,6 +126,11 @@ onIndexerEvent("DopplerHookInitializer:Create", async ({ event, context }) => {
     context,
     beneficiaries,
     initializerAddress,
+    // Reuse values already computed above to skip a totalSupply RPC + a
+    // getQuoteInfo (with its own DB finds) inside insertPoolIfNotExistsDHook.
+    // Same numeraire (event arg == pool quote currency) and same base token.
+    totalSupply,
+    quoteInfo,
   });
 
   const price = poolEntity.price;
@@ -167,7 +172,8 @@ onIndexerEvent("DopplerHookInitializer:Create", async ({ event, context }) => {
       quoteDecimals: quoteInfo.quoteDecimals,
     });
 
-    await updatePool({
+    // Pool was just inserted above, so skip the redundant existence find.
+    await updatePoolDirect({
       poolAddress,
       context,
       update: {
@@ -361,7 +367,9 @@ export async function processDHookSwap({
   };
 
   const entityUpdaters = {
-    updatePool,
+    // poolEntity was already fetched and existence-checked above (:239/:244),
+    // so use updatePoolDirect to skip the redundant db.find inside updatePool.
+    updatePool: updatePoolDirect,
     updateFifteenMinuteBucketUsd,
     updateAsset,
   };

--- a/src/indexer/indexer-dhook.ts
+++ b/src/indexer/indexer-dhook.ts
@@ -7,6 +7,7 @@ import { SwapOrchestrator, PriceService, MarketDataService } from "@app/core";
 import { getMulticallOptions } from "@app/core/utils/multicall";
 import { updateFifteenMinuteBucketUsd } from "@app/utils/time-buckets";
 import { chainConfigs } from "@app/config/chains";
+import { CHAIN_IDS } from "@app/config";
 import { pool, token } from "ponder:schema";
 import { getQuoteInfo } from "@app/utils/getQuoteInfo";
 import { computeReservesFromPositions } from "@app/utils/v4-utils/computeReservesFromPositions";
@@ -18,7 +19,7 @@ import { isPrecompileAddress } from "@app/utils/validation";
 import { updateCumulatedFees } from "./shared/cumulatedFees";
 import { Context } from "ponder:registry";
 import { transferPoolBeneficiary } from "./shared/entities/multicurve/poolBeneficiary";
-import { decodeAbiParameters } from "viem";
+import { decodeAbiParameters, Address } from "viem";
 
 // keccak256("ModifyLiquidity(bytes32,address,int24,int24,int256,bytes32)") — v4 PoolManager.
 const POOL_MANAGER_MODIFY_LIQUIDITY_TOPIC =
@@ -236,12 +237,41 @@ onIndexerEvent("DopplerHookInitializer:UpdateBeneficiary", async ({ event, conte
   });
 });
 
-onIndexerEvent("DopplerHookInitializer:Swap", async ({ event, context }) => {
-  const { sender, poolId, amount0, amount1 } = event.args;
-  const timestamp = event.block.timestamp;
+/**
+ * Processes a Doppler-hook (dhook/rehype) pool swap: recomputes price, reserves,
+ * market cap and dollar liquidity, then writes the pool / asset / 15-min-bucket
+ * updates (this path never persists a swap row and never uses `sender`).
+ *
+ * `priceData` supplies the post-swap sqrtPriceX96 and tick. When omitted (the
+ * DopplerHookInitializer:Swap path used on non-robinhood chains) we read them with a
+ * getSlot0 RPC. On robinhood the caller (PoolManager:Swap) passes them straight from
+ * the event, eliminating that per-swap RPC — the realtime-throughput bottleneck on
+ * that high-block-rate chain.
+ */
+export async function processDHookSwap({
+  context,
+  poolAddress,
+  sender,
+  amount0,
+  amount1,
+  timestamp,
+  transactionHash,
+  transactionFrom,
+  blockNumber,
+  priceData,
+}: {
+  context: Context;
+  poolAddress: `0x${string}`;
+  sender: Address;
+  amount0: bigint;
+  amount1: bigint;
+  timestamp: bigint;
+  transactionHash: `0x${string}`;
+  transactionFrom: Address;
+  blockNumber: bigint;
+  priceData?: { sqrtPriceX96: bigint; currentTick: number };
+}): Promise<void> {
   const { chain, client, db } = context;
-
-  const poolAddress = (poolId as string).toLowerCase() as `0x${string}`;
 
   const poolEntity = await db.find(pool, {
     address: poolAddress,
@@ -263,15 +293,19 @@ onIndexerEvent("DopplerHookInitializer:Swap", async ({ event, context }) => {
     return;
   }
 
+  // On chains that don't supply the post-swap price in the event, read it once here,
+  // concurrently with the ledger / quote / token reads below.
   const { stateView } = chainConfigs[chain.name].addresses.v4;
+  const slot0Promise = priceData
+    ? null
+    : client.readContract({
+        abi: StateViewABI,
+        address: stateView,
+        functionName: "getSlot0",
+        args: [poolAddress],
+      });
 
-  const [slot0, onChainPositions, quoteInfo, tokenEntity] = await Promise.all([
-    client.readContract({
-      abi: StateViewABI,
-      address: stateView,
-      functionName: "getSlot0",
-      args: [poolId],
-    }),
+  const [onChainPositions, quoteInfo, tokenEntity] = await Promise.all([
     getPositionsForPool({ poolId: poolAddress, context }),
     getQuoteInfo(poolEntity.quoteToken, timestamp, context),
     db.find(token, {
@@ -285,7 +319,16 @@ onIndexerEvent("DopplerHookInitializer:Swap", async ({ event, context }) => {
     return;
   }
 
-  const [sqrtPriceX96, currentTick] = slot0;
+  let sqrtPriceX96: bigint;
+  let currentTick: number;
+  if (priceData) {
+    sqrtPriceX96 = priceData.sqrtPriceX96;
+    currentTick = priceData.currentTick;
+  } else {
+    const slot0 = await slot0Promise!;
+    sqrtPriceX96 = slot0[0];
+    currentTick = slot0[1];
+  }
 
   const price = PriceService.computePriceFromSqrtPriceX96({
     sqrtPriceX96,
@@ -335,9 +378,9 @@ onIndexerEvent("DopplerHookInitializer:Swap", async ({ event, context }) => {
   const swapData = SwapOrchestrator.createSwapData({
     poolAddress,
     sender,
-    transactionHash: event.transaction.hash,
-    transactionFrom: event.transaction.from,
-    blockNumber: event.block.number,
+    transactionHash,
+    transactionFrom,
+    blockNumber,
     timestamp,
     assetAddress: poolEntity.baseToken,
     quoteAddress: poolEntity.quoteToken,
@@ -405,6 +448,30 @@ onIndexerEvent("DopplerHookInitializer:Swap", async ({ event, context }) => {
       context,
     }),
   ]);
+}
+
+onIndexerEvent("DopplerHookInitializer:Swap", async ({ event, context }) => {
+  // Robinhood dhook/rehype swaps are processed in PoolManager:Swap instead, which
+  // carries the post-swap sqrtPriceX96/tick and so avoids a getSlot0 RPC per swap —
+  // the realtime-throughput bottleneck on that high-block-rate chain. Skipping here
+  // avoids double-processing the same swap; other chains keep using this handler.
+  if (context.chain.id === CHAIN_IDS.robinhood) {
+    return;
+  }
+
+  const { sender, poolId, amount0, amount1 } = event.args;
+
+  await processDHookSwap({
+    context,
+    poolAddress: (poolId as string).toLowerCase() as `0x${string}`,
+    sender,
+    amount0,
+    amount1,
+    timestamp: event.block.timestamp,
+    transactionHash: event.transaction.hash,
+    transactionFrom: event.transaction.from,
+    blockNumber: event.block.number,
+  });
 });
 
 onIndexerEvent("DopplerHookInitializer:ModifyLiquidity", async ({ event, context }) => {

--- a/src/indexer/indexer-shared.ts
+++ b/src/indexer/indexer-shared.ts
@@ -261,15 +261,9 @@ onIndexerEvent("DERC20:Transfer", async ({ event, context }) => {
     holderCountDelta -= 1;
   }
 
-  // Build update promises array, conditionally including user update and pool operations
+  // Build update promises array, conditionally including holder-count, user,
+  // and pool operations.
   const updatePromises: Promise<unknown>[] = [
-    updateToken({
-      tokenAddress: assetId,
-      context,
-      update: {
-        holderCount: tokenData.holderCount + holderCountDelta,
-      },
-    }),
     updateUserAsset({
       userId: toId,
       assetId: assetId,
@@ -290,6 +284,22 @@ onIndexerEvent("DERC20:Transfer", async ({ event, context }) => {
     }),
   ];
 
+  // holderCount only changes when a wallet crosses 0<->positive. On the vast
+  // majority of transfers holderCountDelta === 0, so the token holderCount write
+  // (and the pool find + write below) would set the identical value — pure no-op
+  // round-trips. Skip them unless the count actually changed.
+  if (holderCountDelta !== 0) {
+    updatePromises.push(
+      updateToken({
+        tokenAddress: assetId,
+        context,
+        update: {
+          holderCount: tokenData.holderCount + holderCountDelta,
+        },
+      })
+    );
+  }
+
   // Only update user lastSeenAt if it changed
   if (fromUser.lastSeenAt !== timestamp) {
     updatePromises.push(
@@ -303,8 +313,10 @@ onIndexerEvent("DERC20:Transfer", async ({ event, context }) => {
     );
   }
 
-  // Only query and update pool if tokenData.pool exists
-  if (tokenData.pool && tokenData.pool !== zeroAddress) {
+  // Only query and update pool if the holder count changed AND the token has a
+  // pool. When holderCountDelta === 0 this whole block (a db.find + a no-op
+  // holderCount write) is skippable — the pool's holderCount is unchanged.
+  if (holderCountDelta !== 0 && tokenData.pool && tokenData.pool !== zeroAddress) {
     updatePromises.push(
       (async () => {
         const poolEntity = await db.find(pool, {

--- a/src/indexer/indexer-v4.ts
+++ b/src/indexer/indexer-v4.ts
@@ -30,7 +30,6 @@ import { computeGraduationPercentage } from "@app/utils/v4-utils";
 import { updateFifteenMinuteBucketUsd } from "@app/utils/time-buckets";
 import { UniswapV4MulticurveInitializerABI } from "@app/abis/multicurve-abis/UniswapV4MulticurveInitializerABI";
 import { chainConfigs } from "@app/config/chains";
-import { CHAIN_IDS } from "@app/config";
 import { processDHookSwap } from "./indexer-dhook";
 import { insertMulticurvePoolV4Optimized } from "./shared/entities/multicurve/pool";
 import { pool, token } from "ponder:schema";
@@ -624,30 +623,30 @@ onIndexerEvent("PoolManager:Swap", async ({ event, context }) => {
     await initializeV4MigrationPoolCache(context);
   }
 
-  // Robinhood dhook/rehype pools: process the swap here rather than in
-  // DopplerHookInitializer:Swap. PoolManager:Swap carries the post-swap sqrtPriceX96
-  // and tick, so we avoid a getSlot0 RPC round-trip per swap — the realtime
-  // throughput bottleneck on that high-block-rate chain. Other chains keep using the
-  // DopplerHookInitializer:Swap handler.
-  if (chain.id === CHAIN_IDS.robinhood) {
-    if (!isDHookPoolCacheInitialized()) {
-      await initializeDHookPoolCache(context);
-    }
-    if (isKnownDHookPool(chain.id, poolId as string)) {
-      await processDHookSwap({
-        context,
-        poolAddress: (poolId as string).toLowerCase() as `0x${string}`,
-        sender: sender.toLowerCase() as Address,
-        amount0: BigInt(amount0),
-        amount1: BigInt(amount1),
-        timestamp,
-        transactionHash: txHash,
-        transactionFrom: txFrom,
-        blockNumber: event.block.number,
-        priceData: { sqrtPriceX96, currentTick: Number(tick) },
-      });
-      return;
-    }
+  // Dhook/rehype pools (all chains): process the swap here rather than in a
+  // DopplerHookInitializer:Swap handler. PoolManager:Swap carries the post-swap
+  // sqrtPriceX96 and tick, so we avoid a getSlot0 RPC round-trip per swap.
+  // Originally robinhood-only (the realtime throughput bottleneck there, #79);
+  // extended to every chain once base's rehype swaps became the top absolute
+  // indexing cost via the same per-swap getSlot0. The dhook pool cache is
+  // chain-agnostic (loads all dhook/rehype pools, keyed by chainId:poolId).
+  if (!isDHookPoolCacheInitialized()) {
+    await initializeDHookPoolCache(context);
+  }
+  if (isKnownDHookPool(chain.id, poolId as string)) {
+    await processDHookSwap({
+      context,
+      poolAddress: (poolId as string).toLowerCase() as `0x${string}`,
+      sender: sender.toLowerCase() as Address,
+      amount0: BigInt(amount0),
+      amount1: BigInt(amount1),
+      timestamp,
+      transactionHash: txHash,
+      transactionFrom: txFrom,
+      blockNumber: event.block.number,
+      priceData: { sqrtPriceX96, currentTick: Number(tick) },
+    });
+    return;
   }
 
   if (!isKnownV4MigrationPool(chain.id, poolId as string)) {

--- a/src/indexer/indexer-v4.ts
+++ b/src/indexer/indexer-v4.ts
@@ -30,6 +30,8 @@ import { computeGraduationPercentage } from "@app/utils/v4-utils";
 import { updateFifteenMinuteBucketUsd } from "@app/utils/time-buckets";
 import { UniswapV4MulticurveInitializerABI } from "@app/abis/multicurve-abis/UniswapV4MulticurveInitializerABI";
 import { chainConfigs } from "@app/config/chains";
+import { CHAIN_IDS } from "@app/config";
+import { processDHookSwap } from "./indexer-dhook";
 import { insertMulticurvePoolV4Optimized } from "./shared/entities/multicurve/pool";
 import { pool, token } from "ponder:schema";
 import { handleOptimizedSwap } from "./shared/swap-optimizer";
@@ -628,6 +630,32 @@ onIndexerEvent("PoolManager:Swap", async ({ event, context }) => {
 
   if (!isV4MigrationPoolCacheInitialized()) {
     await initializeV4MigrationPoolCache(context);
+  }
+
+  // Robinhood dhook/rehype pools: process the swap here rather than in
+  // DopplerHookInitializer:Swap. PoolManager:Swap carries the post-swap sqrtPriceX96
+  // and tick, so we avoid a getSlot0 RPC round-trip per swap — the realtime
+  // throughput bottleneck on that high-block-rate chain. Other chains keep using the
+  // DopplerHookInitializer:Swap handler.
+  if (chain.id === CHAIN_IDS.robinhood) {
+    if (!isDHookPoolCacheInitialized()) {
+      await initializeDHookPoolCache(context);
+    }
+    if (isKnownDHookPool(chain.id, poolId as string)) {
+      await processDHookSwap({
+        context,
+        poolAddress: (poolId as string).toLowerCase() as `0x${string}`,
+        sender: sender.toLowerCase() as Address,
+        amount0: BigInt(amount0),
+        amount1: BigInt(amount1),
+        timestamp,
+        transactionHash: txHash,
+        transactionFrom: txFrom,
+        blockNumber: event.block.number,
+        priceData: { sqrtPriceX96, currentTick: Number(tick) },
+      });
+      return;
+    }
   }
 
   if (!isKnownV4MigrationPool(chain.id, poolId as string)) {

--- a/src/indexer/shared/entities/pool.ts
+++ b/src/indexer/shared/entities/pool.ts
@@ -488,6 +488,8 @@ export const insertPoolIfNotExistsDHook = async ({
   context,
   beneficiaries,
   initializerAddress,
+  totalSupply: totalSupplyOverride,
+  quoteInfo: quoteInfoOverride,
 }: {
   poolAddress: Address;
   timestamp: bigint;
@@ -496,6 +498,10 @@ export const insertPoolIfNotExistsDHook = async ({
   poolData: DHookPoolData;
   beneficiaries?: readonly { beneficiary: `0x${string}`; shares: bigint }[] | null;
   initializerAddress?: Address;
+  // Optional pre-computed values from the caller (the DHook Create handler already
+  // has both), letting us skip the redundant totalSupply RPC and getQuoteInfo call.
+  totalSupply?: bigint;
+  quoteInfo?: QuoteInfo;
 }): Promise<typeof pool.$inferSelect> => {
   const { db, chain, client } = context;
   const address = poolAddress.toLowerCase() as `0x${string}`;
@@ -528,13 +534,15 @@ export const insertPoolIfNotExistsDHook = async ({
   }
 
   const [totalSupply, assetData, quoteInfo] = await Promise.all([
-    client.readContract({
+    // Reuse the caller-supplied totalSupply / quoteInfo when present (0n is a
+    // valid supply, so `??` is correct — it only falls through on undefined).
+    totalSupplyOverride ?? client.readContract({
       address: assetAddr,
       abi: DERC20ABI,
       functionName: "totalSupply",
     }),
     getAssetData(assetAddr, context),
-    getQuoteInfo(numeraireAddr, timestamp, context)
+    quoteInfoOverride ?? getQuoteInfo(numeraireAddr, timestamp, context)
   ]);
 
   const dollarLiquidity = MarketDataService.calculateLiquidity({

--- a/src/indexer/shared/entities/swap.ts
+++ b/src/indexer/shared/entities/swap.ts
@@ -25,7 +25,7 @@ export const insertSwapIfNotExists = async ({
     amountIn: bigint;
     amountOut: bigint;
     swapValueUsd: bigint;
-}): Promise<typeof swap.$inferSelect> => {
+}): Promise<void> => {
     const { db, chain } = context;
 
     const lowerTxHash = txHash.toLowerCase() as `0x${string}`;
@@ -33,16 +33,10 @@ export const insertSwapIfNotExists = async ({
     const lowerAsset = asset.toLowerCase() as `0x${string}`;
     const lowerUser = user.toLowerCase() as `0x${string}`;
 
-    const existingSwap = await db.find(swap, {
-        txHash: lowerTxHash,
-        chainId: chain.id,
-    });
-
-    if (existingSwap) {
-        return existingSwap;
-    }
-
-    return await db.insert(swap).values({
+    // Dedup on the (txHash, chainId) primary key in a single write. Replaces the
+    // previous find-then-insert, so every swap costs one DB round-trip instead
+    // of two. Callers discard the return, so we no longer return the row.
+    await db.insert(swap).values({
         txHash: lowerTxHash,
         timestamp,
         pool: lowerPool,
@@ -53,5 +47,5 @@ export const insertSwapIfNotExists = async ({
         amountIn,
         amountOut,
         swapValueUsd,
-    });
+    }).onConflictDoNothing();
 };

--- a/src/indexer/shared/entities/token.ts
+++ b/src/indexer/shared/entities/token.ts
@@ -133,39 +133,39 @@ export const insertTokenIfNotExists = async ({
       isDerc20: false,
     });
   } else {
+    // Fetch the base ERC-20 metadata and the DERC20 vesting / balance-limit data
+    // in a SINGLE multicall round-trip. Previously these were two sequential
+    // multicalls to the same contract; the vesting calls have no dependency on the
+    // base ones, so they are merged into one. The vesting/limit results are only
+    // consumed when isDerc20 — for a non-DERC20 token those calls simply fail
+    // (allowFailure) and are ignored, so the merge is a pure round-trip saving.
     const [
       nameResult,
       symbolResult,
       decimalsResult,
       totalSupplyResult,
       tokenURIResult,
+      vestingStartResult,
+      vestingDurationResult,
+      vestedTotalAmountResult,
+      isBalanceLimitActiveResult,
+      balanceLimitEndResult,
+      maxBalanceLimitResult,
+      balanceLimitControllerResult,
     ] = await context.client.multicall({
       contracts: [
-        {
-          abi: DERC20ABI,
-          address,
-          functionName: "name",
-        },
-        {
-          abi: DERC20ABI,
-          address,
-          functionName: "symbol",
-        },
-        {
-          abi: DERC20ABI,
-          address,
-          functionName: "decimals",
-        },
-        {
-          abi: DERC20ABI,
-          address,
-          functionName: "totalSupply",
-        },
-        {
-          abi: DERC20ABI,
-          address,
-          functionName: "tokenURI",
-        },
+        { abi: DERC20ABI, address, functionName: "name" },
+        { abi: DERC20ABI, address, functionName: "symbol" },
+        { abi: DERC20ABI, address, functionName: "decimals" },
+        { abi: DERC20ABI, address, functionName: "totalSupply" },
+        { abi: DERC20ABI, address, functionName: "tokenURI" },
+        { abi: DERC20ABI, address, functionName: "vestingStart" },
+        { abi: DERC20ABI, address, functionName: "vestingDuration" },
+        { abi: DERC20ABI, address, functionName: "vestedTotalAmount" },
+        { abi: DERC20ABI, address, functionName: "isBalanceLimitActive" },
+        { abi: DERC20ABI, address, functionName: "balanceLimitEnd" },
+        { abi: DERC20ABI, address, functionName: "maxBalanceLimit" },
+        { abi: DERC20ABI, address, functionName: "controller" },
       ],
       ...multicallOptions,
     });
@@ -180,56 +180,6 @@ export const insertTokenIfNotExists = async ({
     let balanceLimitController: Address | undefined;
 
     if (isDerc20) {
-      const [
-        vestingStartResult,
-        vestingDurationResult,
-        vestedTotalAmountResult,
-        isBalanceLimitActiveResult,
-        balanceLimitEndResult,
-        maxBalanceLimitResult,
-        balanceLimitControllerResult,
-      ] =
-        await context.client.multicall({
-          contracts: [
-            {
-              abi: DERC20ABI,
-              address,
-              functionName: "vestingStart",
-            },
-            {
-              abi: DERC20ABI,
-              address,
-              functionName: "vestingDuration",
-            },
-            {
-              abi: DERC20ABI,
-              address,
-              functionName: "vestedTotalAmount",
-            },
-            {
-              abi: DERC20ABI,
-              address,
-              functionName: "isBalanceLimitActive",
-            },
-            {
-              abi: DERC20ABI,
-              address,
-              functionName: "balanceLimitEnd",
-            },
-            {
-              abi: DERC20ABI,
-              address,
-              functionName: "maxBalanceLimit",
-            },
-            {
-              abi: DERC20ABI,
-              address,
-              functionName: "controller",
-            },
-          ],
-          ...multicallOptions,
-        });
-
       if (vestingStartResult?.status === "success") {
         vestingStart = vestingStartResult.result;
       }

--- a/src/utils/getQuoteInfo.ts
+++ b/src/utils/getQuoteInfo.ts
@@ -84,8 +84,13 @@ export async function getQuoteInfo(quoteAddress: Address, timestamp: bigint | nu
   const isQuoteBankr = quoteAddress != zeroAddress && quoteAddress === bankrAddress;
   
   let creatorCoinInfo;
-  if (!(isQuoteZora || isQuoteFxh || isQuoteNoice || isQuoteMon || isQuoteUsdc || isQuoteUsdt || isQuoteUsdg || isQuoteEurc || isQuoteBankr)) {
-    creatorCoinInfo = await getCreatorCoinInfo(quoteAddress, context);    
+  // isQuoteEth is excluded here too: WETH / native ETH can never be a creator
+  // coin, and the ETH branches below (quoteToken/decimals and the price path)
+  // never read creatorCoinInfo — so skipping this db.find(token) is a pure
+  // round-trip saving with no change in result. WETH is robinhood's numeraire,
+  // so this fires on the majority of its swaps.
+  if (!(isQuoteEth || isQuoteZora || isQuoteFxh || isQuoteNoice || isQuoteMon || isQuoteUsdc || isQuoteUsdt || isQuoteUsdg || isQuoteEurc || isQuoteBankr)) {
+    creatorCoinInfo = await getCreatorCoinInfo(quoteAddress, context);
   } else {
     creatorCoinInfo = {
       isQuoteCreatorCoin: false,


### PR DESCRIPTION
## What & why

Makes robinhood (~10 blk/s, previously ~0% indexing margin, chronic divergence) hold tip, via three layers of fixes found by profiling: per-swap RPC elimination, handler DB round-trip shaves, and a DB connection-pool fix for the commit path. Targets came from per-handler profiling plus a windowed DB-method breakdown.

Targets `main` directly; supersedes #79 (its commits are included here).

## Commits

### `deb0f83` — robinhood dhook repoint (formerly #79)
The `DopplerHookInitializer:Swap` event carries only swap inputs, so pricing each swap needed a `getSlot0` eth_call — the per-swap bottleneck on a 10 blk/s chain. Robinhood dhook/rehype swaps are repointed to `PoolManager:Swap`, which carries the post-swap `sqrtPriceX96`/`tick` in the event itself. Verified on-chain: every hook Swap has a same-tx PoolManager:Swap twin with byte-identical amounts. Swap handler avg: 51ms → 4.4ms.

### `789e96c` — handler shaves (Tier 1/2/4)
**Shared swap path (every swap, all chains):**
- **S1** `insertSwapIfNotExists`: fold `find`+`insert` into one `onConflictDoNothing()` — −1 DB read/swap, all swap handlers.
- **S2** `getQuoteInfo`: skip `getCreatorCoinInfo` for WETH-quoted pools (WETH can't be a creator coin; ETH paths never read the result) — −1 DB read/swap.
- **S3** dhook swap path: `updatePoolDirect` (pool already fetched+guarded) — −1 redundant find/swap.

**DERC20:Transfer (biggest pre-shave slice ~25%):**
- **T1** gate token+pool `holderCount` writes (and the pool find) on `holderCountDelta !== 0` — no-op writes eliminated on the majority of transfers.

**DopplerHookInitializer:Create (~900ms/call):**
- `updatePoolDirect` post-insert; **C1** merge two sequential DERC20 multicalls into one; **C3/C5** reuse caller's `totalSupply`+`quoteInfo`. Measured ~900→~400ms.

### `37f5084` — extend the repoint to all chains
Post-shave profiling showed base's rehype swaps became the top absolute cost (~60ms `getSlot0` each). Dhook/rehype swaps on **every chain** now process in `PoolManager:Swap`; the `DopplerHookInitializer:Swap` handler is removed entirely (Ponder also stops fetching those logs). Accepted nuance: compound rehype txs keep the PM (user) leg in the (txHash, chainId)-deduped swap row.

### `81bf410` — DB pool 10→24, robinhood pollingInterval 250ms
With handlers down to ~125 ms/s (12.5% of thread), the measured bottleneck moved to the DB commit path: `commit_block` (per-table-per-block checkpoint stamps, ~193 UPDATEs/s) averaged **47.5ms — almost all connection queue-wait** on the user pool, which `max=10` starved to 2 connections. `max=24` → 7 conns/pool (cluster verified 33/95 in use; `max=100` would risk the shared 95-conn cluster). Not part of the buildId → restart-only. This was the change that got robinhood holding tip.

### `a31870c` — ponder patch hazard fixes
The non-blocking `CREATE INDEX CONCURRENTLY` patch had two bugs: a **cluster-wide** INVALID-index sweep that could drop another app's in-progress CIC on the shared Postgres (now schema-scoped), and a trigger-creation/CIC lock-conflict deadlock window on restart (triggers now complete before the background build starts). Verified live: `/ready` 81ms after backfill vs ~5m40s serial barrier before.

### `9ef4ad5` — grafana fixes
The avg-ms panel multiplied an already-milliseconds metric by 1000 (made ~0.9s Creates read as ~6–15min). Added a 100%-stacked share panel and an absolute thread-cost panel (comparable across restarts — the one to judge optimizations by).

## Deliberately not included
- **Z1 (Zora `getPoolCoin` cache):** rejected — those pools emit ~13 `ModifyLiquidity`/block; an incremental cache double-counts and a position-ledger adds ~13 DB upserts/block/pool. Snapshot-per-swap is the right design there.
- **C2/C4:** low value on the rare Create path; C4 unsafe with Ponder's closure-based `onConflictDoUpdate`.

## Verification
- `pnpm typecheck` clean; `pnpm test:run` 49/49 pass.
- Live post-deploy: all 4 chains at tip; handler total 125 ms/s; robinhood holding tip.
- Deploying from a fresh checkout requires the usual fresh-schema re-index (buildId changes); the ponder_sync RPC cache is reused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)