### PR TITLE
perf(patch): replace per-reorg trigger DDL with a transaction-local GUC gate

### DIFF
--- a/monitoring/grafana/provisioning/dashboards/indexer-prod.json
+++ b/monitoring/grafana/provisioning/dashboards/indexer-prod.json
@@ -1,8 +1,8 @@
 {
-  "title": "Indexer — prod",
+  "title": "Indexer \u2014 prod",
   "uid": "indexer-prod",
   "schemaVersion": 39,
-  "version": 6,
+  "version": 7,
   "refresh": "30s",
   "time": {
     "from": "now-1h",
@@ -228,7 +228,7 @@
       "id": 19,
       "type": "heatmap",
       "title": "/sql/* latency distribution",
-      "description": "Heatmap of request rate per latency bucket. Bright cells near the top (>= the 500000 ms top bucket) are requests overflowing the histogram cap — those are truly stuck/timed-out.",
+      "description": "Heatmap of request rate per latency bucket. Bright cells near the top (>= the 500000 ms top bucket) are requests overflowing the histogram cap \u2014 those are truly stuck/timed-out.",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -395,7 +395,7 @@
       "id": 13,
       "type": "timeseries",
       "title": "Indexing function avg ms (top 10)",
-      "description": "Metric ponder_indexing_function_duration is already in milliseconds (bucket le values run 0.001..100000 ms), so avg = rate(sum)/rate(count) with NO scaling. (Was previously multiplied by 1000, which inflated every value 1000x — e.g. made DopplerHookInitializer:Create's ~0.9s look like ~6-15 min.)",
+      "description": "Metric ponder_indexing_function_duration is already in milliseconds (bucket le values run 0.001..100000 ms), so avg = rate(sum)/rate(count) with NO scaling. (Was previously multiplied by 1000, which inflated every value 1000x \u2014 e.g. made DopplerHookInitializer:Create's ~0.9s look like ~6-15 min.)",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -442,6 +442,65 @@
       ]
     },
     {
+      "id": 23,
+      "type": "timeseries",
+      "title": "RPC avg latency by chain/method",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (chain, method) (rate(ponder_rpc_request_duration_sum{indexer=\"prod-indexer\",chain=~\"$chain\",method=~\"eth_getLogs|eth_getBlockByNumber|eth_call|eth_getTransactionReceipt\"}[5m])) / sum by (chain, method) (rate(ponder_rpc_request_duration_count{indexer=\"prod-indexer\",chain=~\"$chain\",method=~\"eth_getLogs|eth_getBlockByNumber|eth_call|eth_getTransactionReceipt\"}[5m]))",
+          "legendFormat": "{{chain}} {{method}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 24,
+      "type": "timeseries",
+      "title": "RPC latency p50/p90 by chain",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (chain, le) (rate(ponder_rpc_request_duration_bucket{indexer=\"prod-indexer\",chain=~\"$chain\"}[5m])))",
+          "legendFormat": "{{chain}} p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.90, sum by (chain, le) (rate(ponder_rpc_request_duration_bucket{indexer=\"prod-indexer\",chain=~\"$chain\"}[5m])))",
+          "legendFormat": "{{chain}} p90",
+          "refId": "B"
+        }
+      ]
+    },
+    {
       "id": 15,
       "type": "row",
       "title": "Process health (indexer + api)",
@@ -449,7 +508,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 47
       }
     },
     {
@@ -464,7 +523,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 41
+        "y": 48
       },
       "targets": [
         {
@@ -496,7 +555,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 41
+        "y": 48
       },
       "targets": [
         {
@@ -524,14 +583,14 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 48
+        "y": 55
       }
     },
     {
       "id": 20,
       "type": "timeseries",
       "title": "Indexing time share by event (% of total)",
-      "description": "Composition of indexing time. Each series is that event's share of total indexing time: 100 x rate(duration_sum for the event) / sum(rate(duration_sum for all events)). Bands are stacked so they fill to ~100% and each band's height is proportional to its share — and because the value IS the share, the tooltip number matches the band size. Watch how the mix shifts (e.g. DERC20:Transfer swelling). The widest bands are the shave targets. Complements the avg-ms panel — a cheap-but-frequent event (PoolManager:Swap) can out-total a slow-but-rare one (DopplerHookInitializer:Create). topk(12) hides a small long tail, so the stack tops out a hair under 100%.",
+      "description": "Composition of indexing time. Each series is that event's share of total indexing time: 100 x rate(duration_sum for the event) / sum(rate(duration_sum for all events)). Bands are stacked so they fill to ~100% and each band's height is proportional to its share \u2014 and because the value IS the share, the tooltip number matches the band size. Watch how the mix shifts (e.g. DERC20:Transfer swelling). The widest bands are the shave targets. Complements the avg-ms panel \u2014 a cheap-but-frequent event (PoolManager:Swap) can out-total a slow-but-rare one (DopplerHookInitializer:Create). topk(12) hides a small long tail, so the stack tops out a hair under 100%.",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -540,7 +599,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 49
+        "y": 56
       },
       "targets": [
         {
@@ -584,7 +643,7 @@
       "id": 22,
       "type": "timeseries",
       "title": "Indexing time cost by event (% of one indexing thread, absolute)",
-      "description": "ABSOLUTE cost companion to the share panel above: 0.1 x rate(ponder_indexing_function_duration_sum[5m]) = ms of handler time per wall-second, expressed as % of one indexing thread (100% = thread saturated by that event alone). Unlike the normalized share panel, this is comparable ACROSS restarts and load levels — use it to judge whether a handler optimization actually reduced total time. Stack height ~= total indexing-thread utilization by these events.",
+      "description": "ABSOLUTE cost companion to the share panel above: 0.1 x rate(ponder_indexing_function_duration_sum[5m]) = ms of handler time per wall-second, expressed as % of one indexing thread (100% = thread saturated by that event alone). Unlike the normalized share panel, this is comparable ACROSS restarts and load levels \u2014 use it to judge whether a handler optimization actually reduced total time. Stack height ~= total indexing-thread utilization by these events.",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -593,7 +652,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 61
+        "y": 68
       },
       "targets": [
         {

--- a/patches/ponder@0.16.3.patch
+++ b/patches/ponder@0.16.3.patch
@@ -57,7 +57,7 @@ index cd8df0b2352161ca01104b4b3e4882fe6ff25a03..6cc76d99b4219ce890b085121db9ba38
                      }
                  }
 diff --git a/dist/esm/database/actions.js b/dist/esm/database/actions.js
-index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..01d272e5f1f71c32f3ec3855e7c3475c3728c5d7 100644
+index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..a450841ab7f46243d4af0a2d6a647bb66200906f 100644
 --- a/dist/esm/database/actions.js
 +++ b/dist/esm/database/actions.js
 @@ -6,13 +6,95 @@ import { and, eq, getTableColumns, getTableName, getViewName, lte, sql, } from "
@@ -162,7 +162,22 @@ index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..01d272e5f1f71c32f3ec3855e7c3475c
  };
  export const createTriggers = async (qb, { tables, chainId }, context) => {
      await qb.transaction(async (tx) => {
-@@ -54,6 +136,14 @@ export const dropTriggers = async (qb, { tables, chainId }, context) => {
+@@ -24,6 +106,14 @@ export const createTriggers = async (qb, { tables, chainId }, context) => {
+   CREATE OR REPLACE FUNCTION "${schema}".${getReorgProcedureName(table)}
+   RETURNS TRIGGER AS $$
+   BEGIN
++  -- Reorg-log suppression gate. The realtime reorg path sets this
++  -- transaction-local GUC (SET LOCAL ponder.suppress_reorg_log = '1') so
++  -- revertMultichain's inverse DML is not re-logged into _reorg__*. This
++  -- replaces per-reorg DROP/CREATE TRIGGER DDL (~120 ACCESS EXCLUSIVE
++  -- statements) with one cheap session setting. current_setting(..., true)
++  -- returns NULL when unset, and NULL = '1' is not TRUE, so logging outside
++  -- the reorg transaction is byte-identical to before this gate.
++  IF current_setting('ponder.suppress_reorg_log', true) = '1' THEN RETURN NULL; END IF;
+   IF TG_OP = 'INSERT' THEN
+   INSERT INTO "${schema}"."${getReorgTableName(table)}" (${columnNames.join(",")}, operation, checkpoint)
+   VALUES (${columnNames.map((name) => `NEW.${name}`).join(",")}, 0, '${MAX_CHECKPOINT_STRING}');
+@@ -54,6 +144,14 @@ export const dropTriggers = async (qb, { tables, chainId }, context) => {
      }, undefined, context);
  };
  export const createLiveQueryTriggers = async (qb, { namespaceBuild, tables, chainId, }, context) => {
@@ -177,7 +192,7 @@ index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..01d272e5f1f71c32f3ec3855e7c3475c
      await qb.transaction(async (tx) => {
          const notifyProcedure = getLiveQueryNotifyProcedureName();
          const notifyTrigger = getLiveQueryNotifyTriggerName();
-@@ -86,6 +176,11 @@ export const dropLiveQueryTriggers = async (qb, { namespaceBuild, tables, chainI
+@@ -86,6 +184,11 @@ export const dropLiveQueryTriggers = async (qb, { namespaceBuild, tables, chainI
      }, undefined, context);
  };
  export const createLiveQueryProcedures = async (qb, { namespaceBuild }, context) => {
@@ -189,7 +204,20 @@ index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..01d272e5f1f71c32f3ec3855e7c3475c
      await qb.transaction(async (tx) => {
          const schema = namespaceBuild.schema;
          const procedure = getLiveQueryProcedureName();
-@@ -147,6 +242,13 @@ export const createViews = async (qb, { tables, views, namespaceBuild, }, contex
+@@ -94,6 +197,12 @@ CREATE OR REPLACE FUNCTION "${schema}".${procedure}
+ RETURNS TRIGGER LANGUAGE plpgsql
+ AS $$
+ BEGIN
++  -- Same reorg-log suppression gate as the per-table reorg trigger. When the
++  -- realtime reorg path sets ponder.suppress_reorg_log = '1', revert DML must
++  -- not enqueue live-query notifications either (previously achieved by
++  -- dropping/recreating the live-query triggers per reorg). Only reached when
++  -- live queries are enabled (PONDER_DISABLE_LIVE_QUERY unset); no-op in prod.
++  IF current_setting('ponder.suppress_reorg_log', true) = '1' THEN RETURN NULL; END IF;
+   INSERT INTO ${getLiveQueryTempTableName()} (table_name)
+   VALUES (TG_TABLE_NAME)
+   ON CONFLICT (table_name) DO NOTHING;
+@@ -147,6 +256,13 @@ export const createViews = async (qb, { tables, views, namespaceBuild, }, contex
          await tx.wrap((tx) => tx.execute(`DROP VIEW IF EXISTS "${namespaceBuild.viewsSchema}"."${PONDER_CHECKPOINT_TABLE_NAME}"`));
          await tx.wrap((tx) => tx.execute(`CREATE VIEW "${namespaceBuild.viewsSchema}"."${PONDER_META_TABLE_NAME}" AS SELECT * FROM "${namespaceBuild.schema}"."${PONDER_META_TABLE_NAME}"`));
          await tx.wrap((tx) => tx.execute(`CREATE VIEW "${namespaceBuild.viewsSchema}"."${PONDER_CHECKPOINT_TABLE_NAME}" AS SELECT * FROM "${namespaceBuild.schema}"."${PONDER_CHECKPOINT_TABLE_NAME}"`));
@@ -351,7 +379,7 @@ index 8b37dc75bc572b1a1ac33b5c0e4522dad8a480f2..462fc8b466b1dafcdf62d7bb40f026d7
                  hostname: "custom_transport",
              },
 diff --git a/dist/esm/runtime/isolated.js b/dist/esm/runtime/isolated.js
-index a92d741a2e0f3ca3e69f12e6537eca13b3d4c62f..12777975f212d72a51e2d8413603727e58366ce4 100644
+index a92d741a2e0f3ca3e69f12e6537eca13b3d4c62f..4ee6f3fa6cb82d1739bfb8b4bfa3512e8143528e 100644
 --- a/dist/esm/runtime/isolated.js
 +++ b/dist/esm/runtime/isolated.js
 @@ -320,7 +320,14 @@ export async function runIsolated({ common, preBuild, namespaceBuild, schemaBuil
@@ -370,8 +398,36 @@ index a92d741a2e0f3ca3e69f12e6537eca13b3d4c62f..12777975f212d72a51e2d8413603727e
                      }
                      else {
                          await tx.wrap((tx) => tx.execute(`CREATE TEMP TABLE IF NOT EXISTS ${getLiveQueryTempTableName()} (table_name TEXT PRIMARY KEY)`), context);
+@@ -403,8 +410,16 @@ export async function runIsolated({ common, preBuild, namespaceBuild, schemaBuil
+                 // Note: `_ponder_checkpoint` is not called here, instead it is called
+                 // in the `block` case.
+                 await database.userQB.transaction(async (tx) => {
+-                    await dropTriggers(tx, { tables, chainId: chain.id }, context);
+-                    await dropLiveQueryTriggers(tx, { namespaceBuild, tables, chainId: chain.id }, context);
++                    // Suppress reorg-log (and live-query) triggers for the duration of
++                    // the revert via a transaction-local GUC instead of dropping and
++                    // recreating the per-chain triggers per reorg. The per-table reorg
++                    // trigger function and the live-query trigger function both RETURN
++                    // NULL when ponder.suppress_reorg_log = '1' (see database/actions.js),
++                    // so revertIsolated's inverse DML is not re-logged into _reorg__* and
++                    // fires no notifications. SET LOCAL auto-resets at COMMIT/ROLLBACK, so
++                    // normal logging resumes with zero cleanup. This replaces the
++                    // ACCESS EXCLUSIVE-locking DDL per reorg that inflated read latencies.
++                    await tx.wrap((tx) => tx.execute(`SET LOCAL ponder.suppress_reorg_log = '1'`), context);
+                     const counts = await revertIsolated(tx, {
+                         checkpoint: event.checkpoint,
+                         tables,
+@@ -418,8 +433,6 @@ export async function runIsolated({ common, preBuild, namespaceBuild, schemaBuil
+                             row_count: counts[index],
+                         });
+                     }
+-                    await createTriggers(tx, { tables, chainId: chain.id }, context);
+-                    await createLiveQueryTriggers(tx, { namespaceBuild, tables, chainId: chain.id }, context);
+                 }, undefined, context);
+                 indexingCache.clear();
+                 common.logger.info({
 diff --git a/dist/esm/runtime/multichain.js b/dist/esm/runtime/multichain.js
-index c5efbc3bf913959800f5e62c9bf98fdc76a3ba37..82ae2bca30b68b658608e87a004fcf2971d01b2b 100644
+index c5efbc3bf913959800f5e62c9bf98fdc76a3ba37..ec19995b47792689ab7f5d913ed3781eb1b231c1 100644
 --- a/dist/esm/runtime/multichain.js
 +++ b/dist/esm/runtime/multichain.js
 @@ -307,15 +307,13 @@ export async function runMultichain({ common, preBuild, namespaceBuild, schemaBu
@@ -449,8 +505,36 @@ index c5efbc3bf913959800f5e62c9bf98fdc76a3ba37..82ae2bca30b68b658608e87a004fcf29
                      }
                      else {
                          await tx.wrap((tx) => tx.execute(`CREATE TEMP TABLE IF NOT EXISTS ${getLiveQueryTempTableName()} (table_name TEXT PRIMARY KEY)`), context);
+@@ -454,8 +488,16 @@ export async function runMultichain({ common, preBuild, namespaceBuild, schemaBu
+                 // Note: `_ponder_checkpoint` is not called here, instead it is called
+                 // in the `block` case.
+                 await database.userQB.transaction(async (tx) => {
+-                    await dropTriggers(tx, { tables }, context);
+-                    await dropLiveQueryTriggers(tx, { namespaceBuild, tables }, context);
++                    // Suppress reorg-log (and live-query) triggers for the duration of
++                    // the revert via a transaction-local GUC instead of dropping and
++                    // recreating ~120 triggers per reorg. The per-table reorg trigger
++                    // function and the live-query trigger function both RETURN NULL when
++                    // ponder.suppress_reorg_log = '1' (see database/actions.js), so
++                    // revertMultichain's inverse DML is not re-logged into _reorg__* and
++                    // fires no notifications. SET LOCAL auto-resets at COMMIT/ROLLBACK, so
++                    // normal logging resumes with zero cleanup. This replaces 1-6s of
++                    // ACCESS EXCLUSIVE-locking DDL per reorg that inflated read latencies.
++                    await tx.wrap((tx) => tx.execute(`SET LOCAL ponder.suppress_reorg_log = '1'`), context);
+                     const counts = await revertMultichain(tx, {
+                         checkpoint: event.checkpoint,
+                         tables,
+@@ -467,8 +509,6 @@ export async function runMultichain({ common, preBuild, namespaceBuild, schemaBu
+                             row_count: counts[index],
+                         });
+                     }
+-                    await createTriggers(tx, { tables }, context);
+-                    await createLiveQueryTriggers(tx, { namespaceBuild, tables }, context);
+                 }, undefined, context);
+                 indexingCache.clear();
+                 common.logger.info({
 diff --git a/dist/esm/runtime/omnichain.js b/dist/esm/runtime/omnichain.js
-index ff59bf37e048955f06311123a89af83d401ef3a0..6c80d41133130bf438fe553f4c95e68a00fbdf34 100644
+index ff59bf37e048955f06311123a89af83d401ef3a0..727bb08b680b8b3aa008801d7620b28c4b637e74 100644
 --- a/dist/esm/runtime/omnichain.js
 +++ b/dist/esm/runtime/omnichain.js
 @@ -314,15 +314,13 @@ export async function runOmnichain({ common, preBuild, namespaceBuild, schemaBui
@@ -528,6 +612,34 @@ index ff59bf37e048955f06311123a89af83d401ef3a0..6c80d41133130bf438fe553f4c95e68a
                      }
                      else {
                          await tx.wrap((tx) => tx.execute(`CREATE TEMP TABLE IF NOT EXISTS ${getLiveQueryTempTableName()} (table_name TEXT PRIMARY KEY)`), context);
+@@ -464,8 +498,16 @@ export async function runOmnichain({ common, preBuild, namespaceBuild, schemaBui
+                 // Note: `_ponder_checkpoint` is not called here, instead it is called
+                 // in the `block` case.
+                 await database.userQB.transaction(async (tx) => {
+-                    await dropTriggers(tx, { tables }, context);
+-                    await dropLiveQueryTriggers(tx, { namespaceBuild, tables }, context);
++                    // Suppress reorg-log (and live-query) triggers for the duration of
++                    // the revert via a transaction-local GUC instead of dropping and
++                    // recreating ~120 triggers per reorg. The per-table reorg trigger
++                    // function and the live-query trigger function both RETURN NULL when
++                    // ponder.suppress_reorg_log = '1' (see database/actions.js), so
++                    // revertOmnichain's inverse DML is not re-logged into _reorg__* and
++                    // fires no notifications. SET LOCAL auto-resets at COMMIT/ROLLBACK, so
++                    // normal logging resumes with zero cleanup. This replaces 1-6s of
++                    // ACCESS EXCLUSIVE-locking DDL per reorg that inflated read latencies.
++                    await tx.wrap((tx) => tx.execute(`SET LOCAL ponder.suppress_reorg_log = '1'`), context);
+                     const counts = await revertOmnichain(tx, {
+                         tables,
+                         checkpoint: event.checkpoint,
+@@ -477,8 +519,6 @@ export async function runOmnichain({ common, preBuild, namespaceBuild, schemaBui
+                             row_count: counts[index],
+                         });
+                     }
+-                    await createTriggers(tx, { tables }, context);
+-                    await createLiveQueryTriggers(tx, { namespaceBuild, tables }, context);
+                 });
+                 indexingCache.clear();
+                 common.logger.info({
 diff --git a/dist/esm/sync-historical/index.js b/dist/esm/sync-historical/index.js
 index 3c0810be57bb1d6cf149485a1f34dd55540fc976..aeadc0821aa472baca4aab2883fe328fcf63ac97 100644
 --- a/dist/esm/sync-historical/index.js

--- a/patches/ponder@0.16.3.patch
+++ b/patches/ponder@0.16.3.patch
@@ -350,8 +350,28 @@ index 8b37dc75bc572b1a1ac33b5c0e4522dad8a480f2..462fc8b466b1dafcdf62d7bb40f026d7
                  }).request,
                  hostname: "custom_transport",
              },
+diff --git a/dist/esm/runtime/isolated.js b/dist/esm/runtime/isolated.js
+index a92d741a2e0f3ca3e69f12e6537eca13b3d4c62f..12777975f212d72a51e2d8413603727e58366ce4 100644
+--- a/dist/esm/runtime/isolated.js
++++ b/dist/esm/runtime/isolated.js
+@@ -320,7 +320,14 @@ export async function runIsolated({ common, preBuild, namespaceBuild, schemaBuil
+                 ]);
+                 await database.userQB.transaction(async (tx) => {
+                     if (database.userQB.$dialect === "postgres") {
+-                        await tx.wrap((tx) => tx.execute(`CREATE TEMP TABLE ${getLiveQueryTempTableName()} (table_name TEXT PRIMARY KEY) ON COMMIT DROP`), context);
++                        // Gate: when PONDER_DISABLE_LIVE_QUERY=1, no live-query trigger writes to
++                        // this temp table and no notify procedure reads it (see createLiveQueryTriggers
++                        // and createLiveQueryProcedures), so skip creating it. A per-block
++                        // CREATE TEMP TABLE ... ON COMMIT DROP churns pg_class/pg_attribute and
++                        // progressively degrades long-lived pooled backends (~+1-2ms per 1k blocks).
++                        if (process.env.PONDER_DISABLE_LIVE_QUERY !== "1") {
++                            await tx.wrap((tx) => tx.execute(`CREATE TEMP TABLE ${getLiveQueryTempTableName()} (table_name TEXT PRIMARY KEY) ON COMMIT DROP`), context);
++                        }
+                     }
+                     else {
+                         await tx.wrap((tx) => tx.execute(`CREATE TEMP TABLE IF NOT EXISTS ${getLiveQueryTempTableName()} (table_name TEXT PRIMARY KEY)`), context);
 diff --git a/dist/esm/runtime/multichain.js b/dist/esm/runtime/multichain.js
-index c5efbc3bf913959800f5e62c9bf98fdc76a3ba37..5bef0b7abb89968d74258223c0379816a9717b21 100644
+index c5efbc3bf913959800f5e62c9bf98fdc76a3ba37..82ae2bca30b68b658608e87a004fcf2971d01b2b 100644
 --- a/dist/esm/runtime/multichain.js
 +++ b/dist/esm/runtime/multichain.js
 @@ -307,15 +307,13 @@ export async function runMultichain({ common, preBuild, namespaceBuild, schemaBu
@@ -413,8 +433,24 @@ index c5efbc3bf913959800f5e62c9bf98fdc76a3ba37..5bef0b7abb89968d74258223c0379816
      if (namespaceBuild.viewsSchema !== undefined) {
          const endClock = startClock();
          await createViews(database.adminQB, { tables, views, namespaceBuild });
+@@ -371,7 +398,14 @@ export async function runMultichain({ common, preBuild, namespaceBuild, schemaBu
+                 ]);
+                 await database.userQB.transaction(async (tx) => {
+                     if (database.userQB.$dialect === "postgres") {
+-                        await tx.wrap((tx) => tx.execute(`CREATE TEMP TABLE ${getLiveQueryTempTableName()} (table_name TEXT PRIMARY KEY) ON COMMIT DROP`), context);
++                        // Gate: when PONDER_DISABLE_LIVE_QUERY=1, no live-query trigger writes to
++                        // this temp table and no notify procedure reads it (see createLiveQueryTriggers
++                        // and createLiveQueryProcedures), so skip creating it. A per-block
++                        // CREATE TEMP TABLE ... ON COMMIT DROP churns pg_class/pg_attribute and
++                        // progressively degrades long-lived pooled backends (~+1-2ms per 1k blocks).
++                        if (process.env.PONDER_DISABLE_LIVE_QUERY !== "1") {
++                            await tx.wrap((tx) => tx.execute(`CREATE TEMP TABLE ${getLiveQueryTempTableName()} (table_name TEXT PRIMARY KEY) ON COMMIT DROP`), context);
++                        }
+                     }
+                     else {
+                         await tx.wrap((tx) => tx.execute(`CREATE TEMP TABLE IF NOT EXISTS ${getLiveQueryTempTableName()} (table_name TEXT PRIMARY KEY)`), context);
 diff --git a/dist/esm/runtime/omnichain.js b/dist/esm/runtime/omnichain.js
-index ff59bf37e048955f06311123a89af83d401ef3a0..4e50de4d8dee15ed4a2c0722cb427cd74259153a 100644
+index ff59bf37e048955f06311123a89af83d401ef3a0..6c80d41133130bf438fe553f4c95e68a00fbdf34 100644
 --- a/dist/esm/runtime/omnichain.js
 +++ b/dist/esm/runtime/omnichain.js
 @@ -314,15 +314,13 @@ export async function runOmnichain({ common, preBuild, namespaceBuild, schemaBui
@@ -476,6 +512,22 @@ index ff59bf37e048955f06311123a89af83d401ef3a0..4e50de4d8dee15ed4a2c0722cb427cd7
      if (namespaceBuild.viewsSchema !== undefined) {
          const endClock = startClock();
          await createViews(database.adminQB, { tables, views, namespaceBuild });
+@@ -379,7 +406,14 @@ export async function runOmnichain({ common, preBuild, namespaceBuild, schemaBui
+                 ]);
+                 await database.userQB.transaction(async (tx) => {
+                     if (database.userQB.$dialect === "postgres") {
+-                        await tx.wrap((tx) => tx.execute(`CREATE TEMP TABLE ${getLiveQueryTempTableName()} (table_name TEXT PRIMARY KEY) ON COMMIT DROP`), context);
++                        // Gate: when PONDER_DISABLE_LIVE_QUERY=1, no live-query trigger writes to
++                        // this temp table and no notify procedure reads it (see createLiveQueryTriggers
++                        // and createLiveQueryProcedures), so skip creating it. A per-block
++                        // CREATE TEMP TABLE ... ON COMMIT DROP churns pg_class/pg_attribute and
++                        // progressively degrades long-lived pooled backends (~+1-2ms per 1k blocks).
++                        if (process.env.PONDER_DISABLE_LIVE_QUERY !== "1") {
++                            await tx.wrap((tx) => tx.execute(`CREATE TEMP TABLE ${getLiveQueryTempTableName()} (table_name TEXT PRIMARY KEY) ON COMMIT DROP`), context);
++                        }
+                     }
+                     else {
+                         await tx.wrap((tx) => tx.execute(`CREATE TEMP TABLE IF NOT EXISTS ${getLiveQueryTempTableName()} (table_name TEXT PRIMARY KEY)`), context);
 diff --git a/dist/esm/sync-historical/index.js b/dist/esm/sync-historical/index.js
 index 3c0810be57bb1d6cf149485a1f34dd55540fc976..aeadc0821aa472baca4aab2883fe328fcf63ac97 100644
 --- a/dist/esm/sync-historical/index.js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   ponder@0.16.3:
-    hash: 54580658d53abdde0c8b0020cfdc46f671f1c0c91ee91385de3eb5c451f3b7ab
+    hash: 75f9d90e0effcfa19e71c9bb059069a58c13cb712ba5b3d91a02f19d9203ff40
     path: patches/ponder@0.16.3.patch
 
 importers:
@@ -24,7 +24,7 @@ importers:
         version: 4.3.2
       ponder:
         specifier: 0.16.3
-        version: 0.16.3(patch_hash=54580658d53abdde0c8b0020cfdc46f671f1c0c91ee91385de3eb5c451f3b7ab)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3))
+        version: 0.16.3(patch_hash=75f9d90e0effcfa19e71c9bb059069a58c13cb712ba5b3d91a02f19d9203ff40)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3))
       viem:
         specifier: 2.30.1
         version: 2.30.1(typescript@5.9.3)
@@ -4920,7 +4920,7 @@ snapshots:
       sonic-boom: 3.8.1
       thread-stream: 2.7.0
 
-  ponder@0.16.3(patch_hash=54580658d53abdde0c8b0020cfdc46f671f1c0c91ee91385de3eb5c451f3b7ab)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3)):
+  ponder@0.16.3(patch_hash=75f9d90e0effcfa19e71c9bb059069a58c13cb712ba5b3d91a02f19d9203ff40)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3)):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@commander-js/extra-typings': 12.1.0(commander@12.1.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   ponder@0.16.3:
-    hash: 75f9d90e0effcfa19e71c9bb059069a58c13cb712ba5b3d91a02f19d9203ff40
+    hash: aeed132cd6377083f60435ec4496d3a4533d5c179a545b25218cee8135b912f9
     path: patches/ponder@0.16.3.patch
 
 importers:
@@ -24,7 +24,7 @@ importers:
         version: 4.3.2
       ponder:
         specifier: 0.16.3
-        version: 0.16.3(patch_hash=75f9d90e0effcfa19e71c9bb059069a58c13cb712ba5b3d91a02f19d9203ff40)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3))
+        version: 0.16.3(patch_hash=aeed132cd6377083f60435ec4496d3a4533d5c179a545b25218cee8135b912f9)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3))
       viem:
         specifier: 2.30.1
         version: 2.30.1(typescript@5.9.3)
@@ -4920,7 +4920,7 @@ snapshots:
       sonic-boom: 3.8.1
       thread-stream: 2.7.0
 
-  ponder@0.16.3(patch_hash=75f9d90e0effcfa19e71c9bb059069a58c13cb712ba5b3d91a02f19d9203ff40)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3)):
+  ponder@0.16.3(patch_hash=aeed132cd6377083f60435ec4496d3a4533d5c179a545b25218cee8135b912f9)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3)):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@commander-js/extra-typings': 12.1.0(commander@12.1.0)


### PR DESCRIPTION
## Problem

At tip, robinhood (chain 4663, ~10 blk/s) reorgs in bursts of 1–4 every ~90s. Ponder's realtime reorg handler runs ~120 DDL statements per reorg inside one transaction (DROP TRIGGER + CREATE OR REPLACE TRIGGER across ~30 tables, twice over with live-query triggers) — each taking ACCESS EXCLUSIVE locks. Measured on prod (2026-07-22): 1–6+ seconds of summed DDL per reorg, indexer DB read latency inflating ~3x during reorg windows (cache `find` avg 7→19ms), and robinhood oscillating 1–2 minutes behind tip as a result. The trigger churn exists only so `revertMultichain`'s inverse DML doesn't get re-logged into the `_reorg__*` tables.

## Fix (ponder pnpm patch, commit 28d5133)

Gate the trigger *functions* instead of dropping the triggers:

- The per-table reorg-log function body now starts with `IF current_setting('ponder.suppress_reorg_log', true) = '1' THEN RETURN NULL; END IF;` (unset GUC → NULL → normal logging, so steady-state behavior is byte-identical). Same guard added to the live-query notify-collection procedure.
- The reorg transaction in all three runtimes (multichain/omnichain/isolated) now issues a single `SET LOCAL ponder.suppress_reorg_log = '1'` instead of the four drop/create calls. `SET LOCAL` resets automatically at commit/rollback — no cleanup path needed, and `revertMultichain`'s savepoint keeps it in scope.
- All other `dropTriggers`/`createTriggers` call sites (startup, crash recovery, isolated per-chain setup) are untouched.

`session_replication_role` would have been the standard tool but is denied on DigitalOcean managed Postgres; custom two-part GUCs via `SET LOCAL` are allowed without superuser (verified against the prod cluster with a session-local test).

## Deployment

Restart-only, self-migrating: startup runs `CREATE OR REPLACE FUNCTION` for every table's reorg procedure (before realtime begins), which installs the gated body into the live schema. No re-index. Verify after deploy: `_reorg__*` tables receive no rows during a reorg, reorg transactions drop from seconds to revert-only time, and the reorg-window read-latency spikes disappear.

## Note on base

This branch is based on `perf/indexer-handler-shave` @ c19a11b, so the PR also carries two commits main is currently missing (`065d03d` per-block live-query temp-table gate — the fix for the multi-hour post-restart decay — and `c19a11b` per-chain/method RPC latency dashboard panels). Prod already runs both; merging this closes that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)