### PR TITLE
perf(patch): batch per-block reorg-checkpoint UPDATEs into one round trip

### DIFF
--- a/patches/ponder@0.16.3.patch
+++ b/patches/ponder@0.16.3.patch
@@ -231,6 +231,80 @@ index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..a450841ab7f46243d4af0a2d6a647bb6
          const notifyProcedure = getLiveQueryNotifyProcedureName();
          const channel = getLiveQueryChannelName(namespaceBuild.viewsSchema);
          await tx.wrap((tx) => tx.execute(`
+@@ -397,6 +499,73 @@ export const commitBlock = async (qb, { checkpoint, table, preBuild, }, context)
+     }
+     await qb.wrap({ label: "commit_block" }, (db) => db.update(reorgTable).set({ checkpoint }).where(whereClause), context);
+ };
++// Batched variant of `commitBlock`: stamps the real checkpoint on the reorg
++// log of EVERY onchain table in a SINGLE database round trip instead of one
++// UPDATE per table. The per-block realtime path issues ~1 statement per table
++// (~30 tables) on the SAME transaction connection, which node-postgres
++// serializes into ~30 sequential round trips per block. At ~13 blk/s across
++// chains that is ~400 round trips/s and, measured, the #1 DB method by summed
++// time (commit_block). Batching collapses it to one round trip per block.
++//
++// Mechanism: drizzle's `db.execute()` uses the pg *extended* query protocol,
++// which cannot run multiple statements in one message. So we build a single
++// semicolon-joined multi-statement string (identical UPDATE semantics to
++// `commitBlock`, one statement per table, in `tables` order) and send it via
++// the pg *simple* query protocol on the transaction's own connection
++// (`qb.$client`, i.e. `tx.session.client`). Being on the block transaction's
++// connection, the implicit transaction of a multi-statement simple query is
++// simply part of that block transaction — semantics match today's behavior.
++//
++// Multi-statement simple queries cannot carry $n bind parameters, so the
++// checkpoint is inlined as a SQL literal. The checkpoint is an internal
++// fixed-format all-digits string (see encodeCheckpoint); we assert /^[0-9]+$/
++// before inlining so a quote/semicolon can never reach the string. The other
++// inlined values are the module constant MAX_CHECKPOINT_STRING (all 9s) and,
++// for isolated ordering, a numeric chain_id.
++export const commitBlockBatch = async (qb, { checkpoint, tables, preBuild, }, context) => {
++    if (tables.length === 0)
++        return;
++    // PGlite executes via the extended protocol and cannot run multi-statement
++    // query strings; keep the original per-table path for it. Postgres only for
++    // the batched fast path.
++    if (qb.$dialect !== "postgres") {
++        await Promise.all(tables.map((table) => commitBlock(qb, { checkpoint, table, preBuild }, context)));
++        return;
++    }
++    // Structurally prevent SQL injection: the checkpoint must be the internal
++    // all-digits encoded form before it is inlined as a literal.
++    if (typeof checkpoint !== "string" || /^[0-9]+$/.test(checkpoint) === false) {
++        throw new Error(`commitBlockBatch: refusing to inline non-numeric checkpoint literal: ${String(checkpoint)}`);
++    }
++    const isIsolated = preBuild.ordering === "experimental_isolated";
++    // Note: Query must include `chain_id` because it's possible for multiple
++    // chains to be indexing in parallel (mirrors commitBlock).
++    let chainId;
++    if (isIsolated) {
++        chainId = Number(decodeCheckpoint(checkpoint).chainId);
++        if (Number.isInteger(chainId) === false) {
++            throw new Error(`commitBlockBatch: invalid chain_id ${String(chainId)}`);
++        }
++    }
++    const statements = tables.map((table) => {
++        // Mirror getReorgTable's schema-qualification: schema-qualified name
++        // only when a non-public schema is set, otherwise the bare name.
++        const schema = getTableConfig(table).schema;
++        const qualified = schema && schema !== "public"
++            ? `"${schema}"."${getReorgTableName(table)}"`
++            : `"${getReorgTableName(table)}"`;
++        const whereClause = isIsolated
++            ? `(${qualified}."checkpoint" = '${MAX_CHECKPOINT_STRING}' and chain_id = ${chainId})`
++            : `${qualified}."checkpoint" = '${MAX_CHECKPOINT_STRING}'`;
++        return `update ${qualified} set "checkpoint" = '${checkpoint}' where ${whereClause}`;
++    });
++    const batchedSql = statements.join(";\n");
++    // Run on the transaction's own connection via the simple query protocol
++    // (a plain string to node-postgres' client.query uses simple protocol and
++    // supports multiple statements). Record a single commit_block observation
++    // per block (dashboards use sum-of-rate, so this is expected).
++    await qb.wrap({ label: "commit_block" }, () => qb.$client.query(batchedSql), context);
++};
+ export const crashRecovery = async (qb, { table }, context) => {
+     const primaryKeyColumns = getPrimaryKeyColumns(table);
+     const schema = getTableConfig(table).schema ?? "public";
 diff --git a/dist/esm/database/queryBuilder.js b/dist/esm/database/queryBuilder.js
 index dddf085491df24a37bb1da1dcb43f76c31d0e0bb..8fefde11e9766cb645853733360bd582dba0f56c 100644
 --- a/dist/esm/database/queryBuilder.js
@@ -382,6 +456,12 @@ diff --git a/dist/esm/runtime/isolated.js b/dist/esm/runtime/isolated.js
 index a92d741a2e0f3ca3e69f12e6537eca13b3d4c62f..4ee6f3fa6cb82d1739bfb8b4bfa3512e8143528e 100644
 --- a/dist/esm/runtime/isolated.js
 +++ b/dist/esm/runtime/isolated.js
+@@ -1,4 +1,4 @@
+-import { commitBlock, createLiveQueryTriggers, createTriggers, dropLiveQueryTriggers, dropTriggers, finalizeIsolated, revertIsolated, } from '../database/actions.js';
++import { commitBlockBatch, createLiveQueryTriggers, createTriggers, dropLiveQueryTriggers, dropTriggers, finalizeIsolated, revertIsolated, } from '../database/actions.js';
+ import { getPonderCheckpointTable } from '../database/index.js';
+ import { getLiveQueryTempTableName } from '../drizzle/onchain.js';
+ import { createIndexingCache } from '../indexing-store/cache.js';
 @@ -320,7 +320,14 @@ export async function runIsolated({ common, preBuild, namespaceBuild, schemaBuil
                  ]);
                  await database.userQB.transaction(async (tx) => {
@@ -398,6 +478,15 @@ index a92d741a2e0f3ca3e69f12e6537eca13b3d4c62f..4ee6f3fa6cb82d1739bfb8b4bfa3512e
                      }
                      else {
                          await tx.wrap((tx) => tx.execute(`CREATE TEMP TABLE IF NOT EXISTS ${getLiveQueryTempTableName()} (table_name TEXT PRIMARY KEY)`), context);
+@@ -349,7 +356,7 @@ export async function runIsolated({ common, preBuild, namespaceBuild, schemaBuil
+                             });
+                             indexingStore.isProcessingEvents = false;
+                             await indexingCache.flush();
+-                            await Promise.all(tables.map((table) => commitBlock(tx, { table, checkpoint, preBuild }, context)));
++                            await commitBlockBatch(tx, { tables, checkpoint, preBuild }, context);
+                             cachedViemClient.clear();
+                             common.logger.trace({
+                                 msg: "Committed reorg data for block",
 @@ -403,8 +410,16 @@ export async function runIsolated({ common, preBuild, namespaceBuild, schemaBuil
                  // Note: `_ponder_checkpoint` is not called here, instead it is called
                  // in the `block` case.
@@ -430,6 +519,12 @@ diff --git a/dist/esm/runtime/multichain.js b/dist/esm/runtime/multichain.js
 index c5efbc3bf913959800f5e62c9bf98fdc76a3ba37..ec19995b47792689ab7f5d913ed3781eb1b231c1 100644
 --- a/dist/esm/runtime/multichain.js
 +++ b/dist/esm/runtime/multichain.js
+@@ -1,4 +1,4 @@
+-import { commitBlock, createIndexes, createLiveQueryTriggers, createTriggers, createViews, dropLiveQueryTriggers, dropTriggers, finalizeMultichain, revertMultichain, } from '../database/actions.js';
++import { commitBlockBatch, createIndexes, createLiveQueryTriggers, createTriggers, createViews, dropLiveQueryTriggers, dropTriggers, finalizeMultichain, revertMultichain, } from '../database/actions.js';
+ import { getPonderCheckpointTable, getPonderMetaTable, } from '../database/index.js';
+ import { getLiveQueryTempTableName } from '../drizzle/onchain.js';
+ import { createIndexingCache } from '../indexing-store/cache.js';
 @@ -307,15 +307,13 @@ export async function runMultichain({ common, preBuild, namespaceBuild, schemaBu
      const tables = Object.values(schemaBuild.schema).filter(isTable);
      const views = Object.values(schemaBuild.schema).filter(isView);
@@ -505,6 +600,15 @@ index c5efbc3bf913959800f5e62c9bf98fdc76a3ba37..ec19995b47792689ab7f5d913ed3781e
                      }
                      else {
                          await tx.wrap((tx) => tx.execute(`CREATE TEMP TABLE IF NOT EXISTS ${getLiveQueryTempTableName()} (table_name TEXT PRIMARY KEY)`), context);
+@@ -401,7 +435,7 @@ export async function runMultichain({ common, preBuild, namespaceBuild, schemaBu
+                             });
+                             indexingStore.isProcessingEvents = false;
+                             await indexingCache.flush();
+-                            await Promise.all(tables.map((table) => commitBlock(tx, { table, checkpoint, preBuild }, context)));
++                            await commitBlockBatch(tx, { tables, checkpoint, preBuild }, context);
+                             cachedViemClient.clear();
+                             common.logger.trace({
+                                 msg: "Committed reorg data for block",
 @@ -454,8 +488,16 @@ export async function runMultichain({ common, preBuild, namespaceBuild, schemaBu
                  // Note: `_ponder_checkpoint` is not called here, instead it is called
                  // in the `block` case.
@@ -537,6 +641,12 @@ diff --git a/dist/esm/runtime/omnichain.js b/dist/esm/runtime/omnichain.js
 index ff59bf37e048955f06311123a89af83d401ef3a0..727bb08b680b8b3aa008801d7620b28c4b637e74 100644
 --- a/dist/esm/runtime/omnichain.js
 +++ b/dist/esm/runtime/omnichain.js
+@@ -1,4 +1,4 @@
+-import { commitBlock, createIndexes, createLiveQueryTriggers, createTriggers, createViews, dropLiveQueryTriggers, dropTriggers, finalizeOmnichain, revertOmnichain, } from '../database/actions.js';
++import { commitBlockBatch, createIndexes, createLiveQueryTriggers, createTriggers, createViews, dropLiveQueryTriggers, dropTriggers, finalizeOmnichain, revertOmnichain, } from '../database/actions.js';
+ import { getPonderCheckpointTable, getPonderMetaTable, } from '../database/index.js';
+ import { getLiveQueryTempTableName } from '../drizzle/onchain.js';
+ import { createIndexingCache } from '../indexing-store/cache.js';
 @@ -314,15 +314,13 @@ export async function runOmnichain({ common, preBuild, namespaceBuild, schemaBui
      const tables = Object.values(schemaBuild.schema).filter(isTable);
      const views = Object.values(schemaBuild.schema).filter(isView);
@@ -612,6 +722,15 @@ index ff59bf37e048955f06311123a89af83d401ef3a0..727bb08b680b8b3aa008801d7620b28c
                      }
                      else {
                          await tx.wrap((tx) => tx.execute(`CREATE TEMP TABLE IF NOT EXISTS ${getLiveQueryTempTableName()} (table_name TEXT PRIMARY KEY)`), context);
+@@ -409,7 +443,7 @@ export async function runOmnichain({ common, preBuild, namespaceBuild, schemaBui
+                             });
+                             indexingStore.isProcessingEvents = false;
+                             await indexingCache.flush();
+-                            await Promise.all(tables.map((table) => commitBlock(tx, { table, checkpoint, preBuild }, context), context));
++                            await commitBlockBatch(tx, { tables, checkpoint, preBuild }, context);
+                             cachedViemClient.clear();
+                             common.logger.trace({
+                                 msg: "Committed reorg data for block",
 @@ -464,8 +498,16 @@ export async function runOmnichain({ common, preBuild, namespaceBuild, schemaBui
                  // Note: `_ponder_checkpoint` is not called here, instead it is called
                  // in the `block` case.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   ponder@0.16.3:
-    hash: aeed132cd6377083f60435ec4496d3a4533d5c179a545b25218cee8135b912f9
+    hash: b70e84f968d316ae15e604daef665dad346789aecefd2d4e4a5fa8806d7dda05
     path: patches/ponder@0.16.3.patch
 
 importers:
@@ -24,7 +24,7 @@ importers:
         version: 4.3.2
       ponder:
         specifier: 0.16.3
-        version: 0.16.3(patch_hash=aeed132cd6377083f60435ec4496d3a4533d5c179a545b25218cee8135b912f9)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3))
+        version: 0.16.3(patch_hash=b70e84f968d316ae15e604daef665dad346789aecefd2d4e4a5fa8806d7dda05)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3))
       viem:
         specifier: 2.30.1
         version: 2.30.1(typescript@5.9.3)
@@ -4920,7 +4920,7 @@ snapshots:
       sonic-boom: 3.8.1
       thread-stream: 2.7.0
 
-  ponder@0.16.3(patch_hash=aeed132cd6377083f60435ec4496d3a4533d5c179a545b25218cee8135b912f9)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3)):
+  ponder@0.16.3(patch_hash=b70e84f968d316ae15e604daef665dad346789aecefd2d4e4a5fa8806d7dda05)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3)):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@commander-js/extra-typings': 12.1.0(commander@12.1.0)


### PR DESCRIPTION
Stacked on #83 (reorg GUC gate) — review only the top commit `31b33a4`.

## Problem

Ponder's realtime block-commit path stamps a reorg-log checkpoint on every onchain table for every block: `Promise.all(tables.map(commitBlock(tx, ...)))` inside the per-block transaction. With ~30 tables all on the same transaction connection, node-postgres serializes them into ~30 sequential round trips per block — ~400 round trips/s at our ~13 blk/s across four chains. `commit_block` is the #1 DB method by summed time on prod (3,500–9,000 ms/s under load).

## Fix (ponder pnpm patch)

New `commitBlockBatch` in `database/actions.js`: builds one semicolon-joined multi-statement string (per-table SQL byte-identical to what drizzle's `commitBlock` emits, including the `chain_id` filter for `experimental_isolated`) and executes it in a single `tx.wrap({label: "commit_block"})` round trip. All three runtimes (multichain/omnichain/isolated) call it in the per-block path; the original `commitBlock` remains for the PGlite dialect, which can't run multi-statement strings (extended protocol) and keeps the per-table path.

Multi-statement strings can't use bind parameters, so the checkpoint is inlined as a quoted literal behind a strict `/^[0-9]+$/` assertion (`encodeCheckpoint` provably emits a fixed 75-digit string; anything else throws before touching SQL).

Note: the `commit_block` metric now records one observation per block instead of ~30 — summed-rate dashboard panels are unaffected; per-op averages change meaning.

## Conflict-resolution note

This branch and #83 both regenerate `patches/ponder@0.16.3.patch`; the rebase union was validated by a from-scratch `pnpm install` (patch re-applied cleanly), `node --check` on all four patched files, and hunk-presence greps for both change-sets plus all pre-existing hunks (CONCURRENTLY build, live-query gates, temp-table skip, invalid-index sweep). Lockfile hash = sha256 of the merged patch file, verified against the installed store path.

## Deployment

Restart-only, no re-index, no DB-side migration (pure client-side SQL batching). Watch after deploy: per-block wall time (empty-block "Indexed block" durations) should drop a few ms; first realtime reorg should revert cleanly (the batch's schema-qualified column references are semantically identical to drizzle's two-part form — flagged only for completeness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)