### PR TITLE
perf(patch): rewrite finalize min-operation-id scan as a join

### DIFF
--- a/patches/ponder@0.16.3.patch
+++ b/patches/ponder@0.16.3.patch
@@ -57,7 +57,7 @@ index cd8df0b2352161ca01104b4b3e4882fe6ff25a03..6cc76d99b4219ce890b085121db9ba38
                      }
                  }
 diff --git a/dist/esm/database/actions.js b/dist/esm/database/actions.js
-index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..a450841ab7f46243d4af0a2d6a647bb66200906f 100644
+index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..14aeeadd70a1bd6df14a7084a0fd8fd906af1ce1 100644
 --- a/dist/esm/database/actions.js
 +++ b/dist/esm/database/actions.js
 @@ -6,13 +6,95 @@ import { and, eq, getTableColumns, getTableName, getViewName, lte, sql, } from "
@@ -231,7 +231,37 @@ index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..a450841ab7f46243d4af0a2d6a647bb6
          const notifyProcedure = getLiveQueryNotifyProcedureName();
          const channel = getLiveQueryChannelName(namespaceBuild.viewsSchema);
          await tx.wrap((tx) => tx.execute(`
-@@ -397,6 +499,73 @@ export const commitBlock = async (qb, { checkpoint, table, preBuild, }, context)
+@@ -321,17 +437,23 @@ export const finalizeMultichain = async (qb, { checkpoint, tables, namespaceBuil
+             .update(PONDER_CHECKPOINT)
+             .set({ finalizedCheckpoint: checkpoint })
+             .where(eq(PONDER_CHECKPOINT.chainId, Number(decodeCheckpoint(checkpoint).chainId))));
++        // The original shape used a correlated scalar subquery
++        // (WHERE checkpoint > (SELECT finalized_checkpoint ... WHERE chain_id =
++        // SUBSTRING(checkpoint, ...))), which Postgres executes as a SubPlan —
++        // a scan of the checkpoint table PER ROW of each reorg table. Rewritten
++        // as a join so the checkpoint table is scanned once per reorg table
++        // instead. Semantics are identical: one checkpoint row per chain
++        // (invariant above), and rows for chains with no checkpoint row drop
++        // out of the join exactly as `checkpoint > NULL` filtered them before.
+         const minOperationId = await tx
+             .wrap((tx) => tx.execute(`
+ SELECT MIN(operation_id) AS operation_id FROM (
+ ${tables
+             .map((table) => `
+-SELECT MIN(operation_id) AS operation_id FROM "${getTableConfig(table).schema ?? "public"}"."${getTableName(getReorgTable(table))}"
+-WHERE checkpoint > (
+-  SELECT finalized_checkpoint 
+-  FROM "${getTableConfig(PONDER_CHECKPOINT).schema ?? "public"}"."${getTableName(PONDER_CHECKPOINT)}" 
+-  WHERE chain_id = SUBSTRING(checkpoint, 11, 16)::numeric
+-)`)
++SELECT MIN(r.operation_id) AS operation_id FROM "${getTableConfig(table).schema ?? "public"}"."${getTableName(getReorgTable(table))}" r
++JOIN "${getTableConfig(PONDER_CHECKPOINT).schema ?? "public"}"."${getTableName(PONDER_CHECKPOINT)}" c
++  ON c.chain_id = SUBSTRING(r.checkpoint, 11, 16)::numeric
++WHERE r.checkpoint > c.finalized_checkpoint`)
+             .join(" UNION ALL ")}) AS all_mins;`))
+             .then((result) => {
+             // @ts-ignore
+@@ -397,6 +519,73 @@ export const commitBlock = async (qb, { checkpoint, table, preBuild, }, context)
      }
      await qb.wrap({ label: "commit_block" }, (db) => db.update(reorgTable).set({ checkpoint }).where(whereClause), context);
  };
@@ -453,7 +483,7 @@ index 8b37dc75bc572b1a1ac33b5c0e4522dad8a480f2..462fc8b466b1dafcdf62d7bb40f026d7
                  hostname: "custom_transport",
              },
 diff --git a/dist/esm/runtime/isolated.js b/dist/esm/runtime/isolated.js
-index a92d741a2e0f3ca3e69f12e6537eca13b3d4c62f..4ee6f3fa6cb82d1739bfb8b4bfa3512e8143528e 100644
+index a92d741a2e0f3ca3e69f12e6537eca13b3d4c62f..d7e4514c0ee16db52bb76aae011d8463e0a8a4a8 100644
 --- a/dist/esm/runtime/isolated.js
 +++ b/dist/esm/runtime/isolated.js
 @@ -1,4 +1,4 @@
@@ -516,7 +546,7 @@ index a92d741a2e0f3ca3e69f12e6537eca13b3d4c62f..4ee6f3fa6cb82d1739bfb8b4bfa3512e
                  indexingCache.clear();
                  common.logger.info({
 diff --git a/dist/esm/runtime/multichain.js b/dist/esm/runtime/multichain.js
-index c5efbc3bf913959800f5e62c9bf98fdc76a3ba37..ec19995b47792689ab7f5d913ed3781eb1b231c1 100644
+index c5efbc3bf913959800f5e62c9bf98fdc76a3ba37..d1176ad57c1c11a20b99d4a07f1e090b1c47d7c9 100644
 --- a/dist/esm/runtime/multichain.js
 +++ b/dist/esm/runtime/multichain.js
 @@ -1,4 +1,4 @@
@@ -638,7 +668,7 @@ index c5efbc3bf913959800f5e62c9bf98fdc76a3ba37..ec19995b47792689ab7f5d913ed3781e
                  indexingCache.clear();
                  common.logger.info({
 diff --git a/dist/esm/runtime/omnichain.js b/dist/esm/runtime/omnichain.js
-index ff59bf37e048955f06311123a89af83d401ef3a0..727bb08b680b8b3aa008801d7620b28c4b637e74 100644
+index ff59bf37e048955f06311123a89af83d401ef3a0..244e5f6d7bffae80ba3150ba6064b9b431fb3d9a 100644
 --- a/dist/esm/runtime/omnichain.js
 +++ b/dist/esm/runtime/omnichain.js
 @@ -1,4 +1,4 @@

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   ponder@0.16.3:
-    hash: b70e84f968d316ae15e604daef665dad346789aecefd2d4e4a5fa8806d7dda05
+    hash: 89588111155fbc99dba8d26578ec9997fbf6de9f95fe3e8faf882fc1fa6a1001
     path: patches/ponder@0.16.3.patch
 
 importers:
@@ -24,7 +24,7 @@ importers:
         version: 4.3.2
       ponder:
         specifier: 0.16.3
-        version: 0.16.3(patch_hash=b70e84f968d316ae15e604daef665dad346789aecefd2d4e4a5fa8806d7dda05)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3))
+        version: 0.16.3(patch_hash=89588111155fbc99dba8d26578ec9997fbf6de9f95fe3e8faf882fc1fa6a1001)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3))
       viem:
         specifier: 2.30.1
         version: 2.30.1(typescript@5.9.3)
@@ -4920,7 +4920,7 @@ snapshots:
       sonic-boom: 3.8.1
       thread-stream: 2.7.0
 
-  ponder@0.16.3(patch_hash=b70e84f968d316ae15e604daef665dad346789aecefd2d4e4a5fa8806d7dda05)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3)):
+  ponder@0.16.3(patch_hash=89588111155fbc99dba8d26578ec9997fbf6de9f95fe3e8faf882fc1fa6a1001)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3)):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@commander-js/extra-typings': 12.1.0(commander@12.1.0)


### PR DESCRIPTION
Follow-up to #83/#85. After those landed, a pipeline-utilization measurement (sum of logged block/reorg/finalize durations per wall-second) showed `finalize` as the new #2 cost: **123 ms/s of the indexing thread, 224ms avg per finalize (p90 390ms)**.

## Root cause

Two compounding issues:

1. `finalizeMultichain`'s MIN(operation_id) probe uses a correlated scalar subquery, which Postgres executes as a **SubPlan — one scan of `_ponder_checkpoint` per row of each reorg table** (EXPLAIN ANALYZE on prod: `loops=583`, `loops=1625` on single tables; ~30 tables ≈ the observed 224ms).
2. `_ponder_checkpoint` was **432kB for 4 rows** — it's updated every block (~13/s) and default autovacuum thresholds never fire on a 4-row table, so each of those per-row subplan scans walked ~50 dead pages.

## Fix

- **Patch**: rewrite the probe as a hash join — checkpoint table scanned once per reorg table (4 rows hashed) instead of per-row. Verified on prod: plan collapses to `Hash Join`, and old vs new shapes return identical values. Semantics identical (one checkpoint row per chain is a documented invariant; chains without a checkpoint row drop out of the join exactly as `checkpoint > NULL` filtered them before).
- **Ops (already applied to prod, not in this diff)**: `VACUUM FULL prod_1._ponder_checkpoint` (432kB → 16kB) + per-table autovacuum pin (`scale_factor=0, threshold=50`) so it stays tight under its 13 updates/s.

Expected effect: finalize drops from ~123 ms/s to low-single-digit ms/s, lifting pipeline headroom from ~1.8x to ~2.3x current robinhood volume (and comfortably >1x the worst surge hour observed).

Restart-only; no re-index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)