### PR TITLE
perf(patch): cache isReadonlySQLQuery and reuse the pg-query parser instance

### DIFF
--- a/patches/ponder@0.16.3.patch
+++ b/patches/ponder@0.16.3.patch
@@ -842,3 +842,86 @@ index 3e021c47fc1298e8f16b773cd437ca5f2cf4cba3..d8a82ca27db0a9e814614d1c56589937
              }
          }
      }
+diff --git a/dist/esm/utils/sql-parse.js b/dist/esm/utils/sql-parse.js
+index a74c2129674e71232a0e00d95c1ed52e08cf41c8..36b415d39d5c136421cb709911365bb501b6019b 100644
+--- a/dist/esm/utils/sql-parse.js
++++ b/dist/esm/utils/sql-parse.js
+@@ -1,13 +1,30 @@
+ const getNodeType = (node) => Object.keys(node)[0];
+ const ALLOW_CACHE = new Map();
+ const RELATIONS_CACHE = new Map();
++const READONLY_CACHE = new Map();
++// Instantiating the pg-query-emscripten module costs ~18ms and allocates
++// heavily. Upstream re-instantiates it on every parseSQLQuery call, which on
++// the indexing hot path (db.sql -> isReadonlySQLQuery, which has no cache of
++// its own) dominated CPU and GC. Instantiate once and reuse.
++let PARSER_PROMISE;
++const getParser = () => {
++    if (PARSER_PROMISE === undefined) {
++        PARSER_PROMISE = import(/* webpackIgnore: true */ "pg-query-emscripten")
++            // @ts-ignore
++            .then((Parser) => Parser.default())
++            .catch((error) => {
++                // Don't cache a failed instantiation.
++                PARSER_PROMISE = undefined;
++                throw error;
++            });
++    }
++    return PARSER_PROMISE;
++};
+ export const parseSQLQuery = async (sql) => {
+-    // @ts-ignore
+-    const Parser = await import(/* webpackIgnore: true */ "pg-query-emscripten");
+     if (sql.length > 5000) {
+         throw new Error("Invalid query");
+     }
+-    const { parse } = await Parser.default();
++    const { parse } = await getParser();
+     const parseResult = parse(sql);
+     if (parseResult.error !== null) {
+         throw new Error(parseResult.error);
+@@ -84,12 +101,30 @@ export const validateAllowableSQLQuery = async (sql) => {
+  * @param sql - SQL query
+  */
+ export const isReadonlySQLQuery = async (sql) => {
++    // The verdict is a pure function of the SQL text, and this is called on
++    // every db.sql query from an indexing function. Cache it like ALLOW_CACHE
++    // and RELATIONS_CACHE already do, otherwise every call re-parses.
++    const cached = READONLY_CACHE.get(sql);
++    if (cached !== undefined) {
++        READONLY_CACHE.delete(sql);
++        READONLY_CACHE.set(sql, cached);
++        return cached;
++    }
++    const remember = (result) => {
++        READONLY_CACHE.set(sql, result);
++        if (READONLY_CACHE.size > 10000) {
++            const firstKey = READONLY_CACHE.keys().next().value;
++            if (firstKey !== undefined)
++                READONLY_CACHE.delete(firstKey);
++        }
++        return result;
++    };
+     let root;
+     try {
+         root = await parseSQLQuery(sql);
+     }
+     catch {
+-        return false;
++        return remember(false);
+     }
+     const validate = (node) => {
+         if (ALLOW_LIST.has(getNodeType(node)) === false) {
+@@ -103,10 +138,10 @@ export const isReadonlySQLQuery = async (sql) => {
+     };
+     try {
+         validate(root);
+-        return true;
++        return remember(true);
+     }
+     catch {
+-        return false;
++        return remember(false);
+     }
+ };
+ /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   ponder@0.16.3:
-    hash: 89588111155fbc99dba8d26578ec9997fbf6de9f95fe3e8faf882fc1fa6a1001
+    hash: da91a6481c5c39bec64d85e1ceec9a469dd23fd4c86fa9d29b8de78e64aef1d9
     path: patches/ponder@0.16.3.patch
 
 importers:
@@ -24,7 +24,7 @@ importers:
         version: 4.3.2
       ponder:
         specifier: 0.16.3
-        version: 0.16.3(patch_hash=89588111155fbc99dba8d26578ec9997fbf6de9f95fe3e8faf882fc1fa6a1001)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3))
+        version: 0.16.3(patch_hash=da91a6481c5c39bec64d85e1ceec9a469dd23fd4c86fa9d29b8de78e64aef1d9)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3))
       viem:
         specifier: 2.30.1
         version: 2.30.1(typescript@5.9.3)
@@ -4920,7 +4920,7 @@ snapshots:
       sonic-boom: 3.8.1
       thread-stream: 2.7.0
 
-  ponder@0.16.3(patch_hash=89588111155fbc99dba8d26578ec9997fbf6de9f95fe3e8faf882fc1fa6a1001)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3)):
+  ponder@0.16.3(patch_hash=da91a6481c5c39bec64d85e1ceec9a469dd23fd4c86fa9d29b8de78e64aef1d9)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3)):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@commander-js/extra-typings': 12.1.0(commander@12.1.0)


### PR DESCRIPTION
## Problem

Every `db.sql` call from an indexing function goes through `isReadonlySQLQuery` (`indexing-store/index.js:401`). Unlike its two siblings in the same file — `validateAllowableSQLQuery` (has `ALLOW_CACHE`) and `getSQLQueryRelations` (has `RELATIONS_CACHE`) — it has **no cache**, so it calls `parseSQLQuery` on every invocation. `parseSQLQuery` in turn does `await Parser.default()`, which **re-instantiates the entire `pg-query-emscripten` WASM module every call**.

We hit this on the robinhood staging backfill, where `getPositionsForPool` issues one `db.sql` select per processed swap. A 30s CPU profile of the running indexer:

| | share of CPU |
|---|---:|
| `pg-query-emscripten` (SQL parser) | **39.0%** |
| garbage collector | **34.0%** |
| idle | 5.5% |

Roughly two-thirds of all CPU was parsing SQL and collecting the garbage the WASM instantiation produced — to decide that a `SELECT` is read-only.

## Fix

Two changes to `dist/esm/utils/sql-parse.js`:

1. **Memoize the emscripten module** in a module-level promise so it is instantiated once rather than per parse. Benefits all three callers of `parseSQLQuery`. A failed instantiation is not cached, so it retries.
2. **Add `READONLY_CACHE` to `isReadonlySQLQuery`**, using the same delete/re-set LRU refresh pattern as `ALLOW_CACHE`, capped at 10k entries. The verdict is a pure function of the SQL text.

## Measurements

Parser cost per call:

```
instantiate + parse (before)   17.93 ms
memoized parser instance        0.91 ms
cached verdict (after)          0.002 ms
```

CPU profile after the patch: `pg-query-emscripten` **0.0%**, GC **2.5%**, main thread **39% idle** — no longer CPU-bound.

Per-event handler cost on staging:

| handler | before | after |
|---|---:|---:|
| `PoolManager:Swap` | 9.07 ms | **2.80 ms** |
| `DopplerHookInitializer:ModifyLiquidity` | 47.80 ms | **7.03 ms** |
| `DopplerHookInitializer:Create` | 203.68 ms | **72.94 ms** |
| raw `db.sql` call | 5.92 ms | **1.89 ms** |

End-to-end: **113 → 409 events/s (3.6x)**. Everything touching `db.sql` improved, as expected from fixing a shared path rather than one handler.

## Correctness

Verified the patched module against the unpatched one on 12 cases — plain selects, joins, the real `position_ledger` query, `insert`/`update`/`delete`/`drop`/`truncate`, CTEs, `pg_sleep`, malformed SQL, and multi-statement input. **Every verdict identical.** `getSQLQueryRelations` output also unchanged.

## Notes

- This is an upstream Ponder bug (0.16.3), not something specific to this repo — it affects anyone calling `db.sql` from a hot indexing handler. Worth reporting upstream separately.
- Only the patch file and the regenerated `patch_hash` in `pnpm-lock.yaml` change; no application code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)