### PR TITLE
perf(patch): reuse WASM SQL parser and memoize isReadonlySQLQuery

### DIFF
--- a/patches/ponder@0.16.3.patch
+++ b/patches/ponder@0.16.3.patch
@@ -57,7 +57,7 @@ index cd8df0b2352161ca01104b4b3e4882fe6ff25a03..6cc76d99b4219ce890b085121db9ba38
                      }
                  }
 diff --git a/dist/esm/database/actions.js b/dist/esm/database/actions.js
-index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..a450841ab7f46243d4af0a2d6a647bb66200906f 100644
+index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..69e369f0a5c64bf359d3a7653f28679cf936f4f9 100644
 --- a/dist/esm/database/actions.js
 +++ b/dist/esm/database/actions.js
 @@ -6,13 +6,95 @@ import { and, eq, getTableColumns, getTableName, getViewName, lte, sql, } from "
@@ -231,7 +231,7 @@ index 058794bde30e72c2a61ee1fe1af61d8d4cdb74fa..a450841ab7f46243d4af0a2d6a647bb6
          const notifyProcedure = getLiveQueryNotifyProcedureName();
          const channel = getLiveQueryChannelName(namespaceBuild.viewsSchema);
          await tx.wrap((tx) => tx.execute(`
-@@ -397,6 +499,73 @@ export const commitBlock = async (qb, { checkpoint, table, preBuild, }, context)
+@@ -397,6 +513,73 @@ export const commitBlock = async (qb, { checkpoint, table, preBuild, }, context)
      }
      await qb.wrap({ label: "commit_block" }, (db) => db.update(reorgTable).set({ checkpoint }).where(whereClause), context);
  };
@@ -453,7 +453,7 @@ index 8b37dc75bc572b1a1ac33b5c0e4522dad8a480f2..462fc8b466b1dafcdf62d7bb40f026d7
                  hostname: "custom_transport",
              },
 diff --git a/dist/esm/runtime/isolated.js b/dist/esm/runtime/isolated.js
-index a92d741a2e0f3ca3e69f12e6537eca13b3d4c62f..4ee6f3fa6cb82d1739bfb8b4bfa3512e8143528e 100644
+index a92d741a2e0f3ca3e69f12e6537eca13b3d4c62f..d7e4514c0ee16db52bb76aae011d8463e0a8a4a8 100644
 --- a/dist/esm/runtime/isolated.js
 +++ b/dist/esm/runtime/isolated.js
 @@ -1,4 +1,4 @@
@@ -516,7 +516,7 @@ index a92d741a2e0f3ca3e69f12e6537eca13b3d4c62f..4ee6f3fa6cb82d1739bfb8b4bfa3512e
                  indexingCache.clear();
                  common.logger.info({
 diff --git a/dist/esm/runtime/multichain.js b/dist/esm/runtime/multichain.js
-index c5efbc3bf913959800f5e62c9bf98fdc76a3ba37..ec19995b47792689ab7f5d913ed3781eb1b231c1 100644
+index c5efbc3bf913959800f5e62c9bf98fdc76a3ba37..d1176ad57c1c11a20b99d4a07f1e090b1c47d7c9 100644
 --- a/dist/esm/runtime/multichain.js
 +++ b/dist/esm/runtime/multichain.js
 @@ -1,4 +1,4 @@
@@ -638,7 +638,7 @@ index c5efbc3bf913959800f5e62c9bf98fdc76a3ba37..ec19995b47792689ab7f5d913ed3781e
                  indexingCache.clear();
                  common.logger.info({
 diff --git a/dist/esm/runtime/omnichain.js b/dist/esm/runtime/omnichain.js
-index ff59bf37e048955f06311123a89af83d401ef3a0..727bb08b680b8b3aa008801d7620b28c4b637e74 100644
+index ff59bf37e048955f06311123a89af83d401ef3a0..244e5f6d7bffae80ba3150ba6064b9b431fb3d9a 100644
 --- a/dist/esm/runtime/omnichain.js
 +++ b/dist/esm/runtime/omnichain.js
 @@ -1,4 +1,4 @@
@@ -812,3 +812,101 @@ index 3e021c47fc1298e8f16b773cd437ca5f2cf4cba3..d8a82ca27db0a9e814614d1c56589937
              }
          }
      }
+diff --git a/dist/esm/utils/sql-parse.js b/dist/esm/utils/sql-parse.js
+index a74c2129674e71232a0e00d95c1ed52e08cf41c8..6aacc6c5a9f9701ddcbd557d1c12c73ce4091112 100644
+--- a/dist/esm/utils/sql-parse.js
++++ b/dist/esm/utils/sql-parse.js
+@@ -1,13 +1,22 @@
+ const getNodeType = (node) => Object.keys(node)[0];
+ const ALLOW_CACHE = new Map();
+ const RELATIONS_CACHE = new Map();
++const READONLY_CACHE = new Map();
++// Instantiate the pg-query-emscripten WASM module ONCE and reuse it.
++// Parser.default() builds a fresh emscripten heap (several MB, ~5ms+) on
++// every call; on the indexing-store raw-SQL path that ran per db.sql call,
++// which profiled at ~35% of process CPU plus most of the GC load during
++// event-dense periods. parse() itself is stateless, so a shared instance
++// is safe.
++let PARSER_PROMISE;
+ export const parseSQLQuery = async (sql) => {
+     // @ts-ignore
+     const Parser = await import(/* webpackIgnore: true */ "pg-query-emscripten");
+     if (sql.length > 5000) {
+         throw new Error("Invalid query");
+     }
+-    const { parse } = await Parser.default();
++    PARSER_PROMISE ??= Parser.default();
++    const { parse } = await PARSER_PROMISE;
+     const parseResult = parse(sql);
+     if (parseResult.error !== null) {
+         throw new Error(parseResult.error);
+@@ -84,30 +93,50 @@ export const validateAllowableSQLQuery = async (sql) => {
+  * @param sql - SQL query
+  */
+ export const isReadonlySQLQuery = async (sql) => {
+-    let root;
+-    try {
+-        root = await parseSQLQuery(sql);
+-    }
+-    catch {
+-        return false;
++    // Memoize by query text. This runs on the indexing-store raw-SQL path
++    // for EVERY db.sql call in handlers; drizzle emits parameterized SQL so
++    // the text is stable per call site, making the hit rate ~100%. Mirrors
++    // the LRU pattern of RELATIONS_CACHE/ALLOW_CACHE.
++    if (READONLY_CACHE.has(sql)) {
++        const result = READONLY_CACHE.get(sql);
++        READONLY_CACHE.delete(sql);
++        READONLY_CACHE.set(sql, result);
++        return result;
+     }
+-    const validate = (node) => {
+-        if (ALLOW_LIST.has(getNodeType(node)) === false) {
+-            throw new Error(`${getNodeType(node)} not supported`);
++    const compute = async () => {
++        let root;
++        try {
++            root = await parseSQLQuery(sql);
+         }
+-        for (const child of ALLOW_LIST.get(getNodeType(node)).children(
+-        // @ts-ignore
+-        node[getNodeType(node)])) {
+-            validate(child);
++        catch {
++            return false;
++        }
++        const validate = (node) => {
++            if (ALLOW_LIST.has(getNodeType(node)) === false) {
++                throw new Error(`${getNodeType(node)} not supported`);
++            }
++            for (const child of ALLOW_LIST.get(getNodeType(node)).children(
++            // @ts-ignore
++            node[getNodeType(node)])) {
++                validate(child);
++            }
++        };
++        try {
++            validate(root);
++            return true;
++        }
++        catch {
++            return false;
+         }
+     };
+-    try {
+-        validate(root);
+-        return true;
+-    }
+-    catch {
+-        return false;
++    const result = await compute();
++    READONLY_CACHE.set(sql, result);
++    if (READONLY_CACHE.size > 10000) {
++        const firstKey = READONLY_CACHE.keys().next().value;
++        if (firstKey !== undefined)
++            READONLY_CACHE.delete(firstKey);
+     }
++    return result;
+ };
+ /**
+  * Find all referenced relations in a SQL query.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   ponder@0.16.3:
-    hash: b70e84f968d316ae15e604daef665dad346789aecefd2d4e4a5fa8806d7dda05
+    hash: ed90fad48e04e1e9d0128e3f4dc2f16f1f10ba02523fb04e5343a66c75b4d587
     path: patches/ponder@0.16.3.patch
 
 importers:
@@ -24,7 +24,7 @@ importers:
         version: 4.3.2
       ponder:
         specifier: 0.16.3
-        version: 0.16.3(patch_hash=b70e84f968d316ae15e604daef665dad346789aecefd2d4e4a5fa8806d7dda05)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3))
+        version: 0.16.3(patch_hash=ed90fad48e04e1e9d0128e3f4dc2f16f1f10ba02523fb04e5343a66c75b4d587)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3))
       viem:
         specifier: 2.30.1
         version: 2.30.1(typescript@5.9.3)
@@ -4920,7 +4920,7 @@ snapshots:
       sonic-boom: 3.8.1
       thread-stream: 2.7.0
 
-  ponder@0.16.3(patch_hash=b70e84f968d316ae15e604daef665dad346789aecefd2d4e4a5fa8806d7dda05)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3)):
+  ponder@0.16.3(patch_hash=ed90fad48e04e1e9d0128e3f4dc2f16f1f10ba02523fb04e5343a66c75b4d587)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3)):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@commander-js/extra-typings': 12.1.0(commander@12.1.0)


### PR DESCRIPTION
## Problem

During tonight's token-launch frenzy (~1,400 swaps/min on robinhood, 60–90 events/block), a CPU profile of the live indexer showed **34.8% of process CPU inside `pg-query-emscripten`** (the PostgreSQL C parser compiled to WASM) and **31% in the garbage collector**, with only 7% idle.

The trail: Ponder's indexing store validates every raw-SQL handler query (`db.sql`) with `isReadonlySQLQuery` — which has **no cache** — and `parseSQLQuery` calls `Parser.default()` **per invocation**, instantiating a fresh multi-MB emscripten WASM heap that becomes instant garbage (that's the GC share). Our hot handler paths (`getVolumeForLastNDays` time-bucket reads, position-ledger reads, pool-beneficiary reads) issue `db.sql` queries per swap, so during surges this ran at tens of instantiate+parse cycles per second. This was the dominant share of the ~20–35ms/event handler cost — invisible until the reorg/commit/finalize overheads were eliminated (#83/#85/#86).

## Fix (ponder pnpm patch, `utils/sql-parse.js` only)

1. Instantiate the WASM parser **once** behind a module-level promise and reuse it (`parse()` is stateless; the shared instance is what the `/sql` endpoint path effectively assumes anyway).
2. Memoize `isReadonlySQLQuery` by query text, using the identical LRU pattern as the existing `RELATIONS_CACHE`/`ALLOW_CACHE` (drizzle emits parameterized SQL, so the text is byte-stable per call site — hit rate ~100%). `getSQLQueryRelations` was already cached; `parseSQLQuery`'s instance reuse also makes its cold path ~100x cheaper.

## Measured (patched module, this host)

| path | latency |
|---|---|
| cold (instantiate + parse) — what prod paid per `db.sql` call | 217ms |
| warm parser, unseen SQL | 1.8ms |
| cached verdict (steady state) | 0.01ms |

Expected effect: removes roughly a third of steady-state CPU and most GC pressure during event surges, directly cutting per-swap handler cost. Deploy: restart-only, no re-index (patch content does not enter the buildId).

🤖 Generated with [Claude Code](https://claude.com/claude-code)