### PR TITLE
feat(backfill): robinhood chain support + airlock Migrate factory event

### DIFF
--- a/scripts/backfill-airlock-creates.mjs
+++ b/scripts/backfill-airlock-creates.mjs
@@ -1,0 +1,426 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import process from "node:process";
+import { createPublicClient, http } from "viem";
+
+const CREATE_SELECTOR =
+  "0x68ff1cfcdcf76864161555fc0de1878d8f83ec6949bf351df74d8a4a1a2679ab";
+
+const DEFAULTS = {
+  8453: {
+    airlock: "0x660eaaedebc968f8f3694354fa8ec0b4c5ba8d12",
+    factoryId: 640791,
+  },
+};
+
+const RPC_ENV_BY_CHAIN = {
+  1: ["PONDER_RPC_URL_1", "MAINNET_RPC"],
+  130: ["PONDER_RPC_URL_130", "UNICHAIN_RPC"],
+  143: ["PONDER_RPC_URL_143", "MONAD_RPC"],
+  8453: ["PONDER_RPC_URL_8453", "BASE_RPC", "BASE_RPC_URL"],
+  57073: ["PONDER_RPC_URL_57073", "INK_RPC"],
+};
+
+function loadDotEnv(path) {
+  if (!existsSync(path)) return;
+  for (const rawLine of readFileSync(path, "utf8").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const m = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (!m) continue;
+    const [, key, rawValue] = m;
+    if (process.env[key] !== undefined) continue;
+    process.env[key] = rawValue.trim().replace(/^(['"])(.*)\1$/, "$2");
+  }
+}
+
+loadDotEnv(resolve(process.cwd(), ".env"));
+loadDotEnv(resolve(process.cwd(), ".env.local"));
+
+function parseArgs(argv) {
+  const args = {
+    apply: false,
+    chainId: 8453,
+    databaseUrl: process.env.DATABASE_URL,
+    rpcUrl: undefined,
+    airlock: undefined,
+    factoryId: undefined,
+    startBlock: undefined,
+    endBlock: undefined,
+    windowSize: 2000,
+    batchSize: 1000,
+    rpcConcurrency: 4,
+    pondersyncSchema: "ponder_sync",
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--") continue;
+    if (a === "--help" || a === "-h") args.help = true;
+    else if (a === "--apply") args.apply = true;
+    else if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const v = argv[++i];
+      if (v === undefined || v.startsWith("--"))
+        throw new Error(`Missing value for ${a}`);
+      if (key === "database-url") args.databaseUrl = v;
+      else if (key === "rpc-url") args.rpcUrl = v;
+      else if (key === "chain-id") args.chainId = Number(v);
+      else if (key === "airlock") args.airlock = v.toLowerCase();
+      else if (key === "factory-id") args.factoryId = Number(v);
+      else if (key === "start-block") args.startBlock = BigInt(v);
+      else if (key === "end-block") args.endBlock = BigInt(v);
+      else if (key === "window-size") args.windowSize = Number(v);
+      else if (key === "batch-size") args.batchSize = Number(v);
+      else if (key === "rpc-concurrency") args.rpcConcurrency = Number(v);
+      else if (key === "ponder-sync-schema") args.pondersyncSchema = v;
+      else throw new Error(`Unknown argument ${a}`);
+    } else throw new Error(`Unknown argument ${a}`);
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/backfill-airlock-creates.mjs [options]
+
+Re-fetches missing Airlock Create logs from RPC and inserts them into
+ponder_sync.factory_addresses and ponder_sync.logs. Does NOT touch
+ponder_sync.intervals.
+
+eth_getLogs windows are fetched with --rpc-concurrency in flight; results
+are handed to the DB writer in order so RPC and DB work overlap.
+
+Options:
+  --chain-id <id>            EVM chain id. Default 8453.
+  --airlock <0x...>          Airlock contract. Default per-chain.
+  --factory-id <n>           ponder_sync.factories.id for the DERC20
+                             subscription. Default per-chain.
+  --rpc-url <url>            RPC URL. Default \$BASE_RPC_URL etc.
+  --database-url <url>       Postgres URL. Default \$DATABASE_URL.
+  --start-block <n>          From block (inclusive). Default = 1 + max
+                             block_number already in factory_addresses
+                             for the chosen factory.
+  --end-block <n>            To block (inclusive). Default = current head.
+  --window-size <n>          Blocks per eth_getLogs request. Default 2000.
+  --batch-size <n>           Rows per DB INSERT batch. Default 1000.
+  --rpc-concurrency <n>      Window fetches in flight. Default 4.
+  --ponder-sync-schema <s>   Sync schema name. Default ponder_sync.
+  --apply                    Actually write. Default is dry-run.
+`);
+}
+
+function ql(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function lowerHex(value) {
+  return value == null ? null : String(value).toLowerCase();
+}
+
+function dataAddressAtOffset(data, byteOffset) {
+  const hex = data.startsWith("0x") ? data.slice(2) : data;
+  const start = byteOffset * 2 + 24;
+  const end = start + 40;
+  if (hex.length < end)
+    throw new Error(`data too short for address at offset ${byteOffset}`);
+  return `0x${hex.slice(start, end).toLowerCase()}`;
+}
+
+function resolveRpcUrl(chainId, override) {
+  if (override) return override;
+  for (const name of RPC_ENV_BY_CHAIN[chainId] ?? []) {
+    if (process.env[name]) return process.env[name];
+  }
+  throw new Error(
+    `No RPC URL found for chain ${chainId}. Set --rpc-url or one of ${(RPC_ENV_BY_CHAIN[chainId] ?? []).join(", ")}.`,
+  );
+}
+
+function resolveDefaults(chainId, airlockOverride, factoryIdOverride) {
+  const fallback = DEFAULTS[chainId];
+  const airlock = airlockOverride ?? fallback?.airlock?.toLowerCase();
+  const factoryId = factoryIdOverride ?? fallback?.factoryId;
+  if (!airlock)
+    throw new Error(`No --airlock and no default for chain ${chainId}`);
+  if (factoryId === undefined)
+    throw new Error(`No --factory-id and no default for chain ${chainId}`);
+  return { airlock, factoryId };
+}
+
+function makeWindows(fromBlock, toBlock, size) {
+  const sz = BigInt(size);
+  const out = [];
+  for (let f = fromBlock; f <= toBlock; f += sz) {
+    const t = f + sz - 1n > toBlock ? toBlock : f + sz - 1n;
+    out.push({ from: f, to: t });
+  }
+  return out;
+}
+
+async function* orderedPrefetch(items, fetcher, concurrency) {
+  const inflight = [];
+  let i = 0;
+  const start = (idx) => ({ item: items[idx], promise: fetcher(items[idx]) });
+  while (i < items.length && inflight.length < concurrency) {
+    inflight.push(start(i));
+    i++;
+  }
+  while (inflight.length > 0) {
+    const next = inflight.shift();
+    const result = await next.promise;
+    if (i < items.length) {
+      inflight.push(start(i));
+      i++;
+    }
+    yield { item: next.item, result };
+  }
+}
+
+async function fetchLogsRange(client, airlock, fromBlock, toBlock, attempts = 4) {
+  let lastErr;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      return await client.request({
+        method: "eth_getLogs",
+        params: [
+          {
+            address: airlock,
+            topics: [CREATE_SELECTOR],
+            fromBlock: `0x${fromBlock.toString(16)}`,
+            toBlock: `0x${toBlock.toString(16)}`,
+          },
+        ],
+      });
+    } catch (err) {
+      lastErr = err;
+      await new Promise((r) => setTimeout(r, 250 * 2 ** attempt));
+    }
+  }
+  throw lastErr;
+}
+
+function buildFactoryRowsValues(rows) {
+  return rows
+    .map(
+      (r) =>
+        `(${Number(r.factoryId)}, ${Number(r.chainId)}, ${r.blockNumber.toString()}, ${ql(r.address)})`,
+    )
+    .join(",\n");
+}
+
+function buildLogRowsValues(rows) {
+  return rows
+    .map(
+      (r) =>
+        `(${ql(r.address)}, ${ql(r.blockHash)}, ${r.blockNumber.toString()}, ${Number(r.chainId)}, ${ql(r.data)}, ${Number(r.logIndex)}, ${ql(r.topic0)}, ${r.topic1 ? ql(r.topic1) : "NULL"}, ${r.topic2 ? ql(r.topic2) : "NULL"}, ${r.topic3 ? ql(r.topic3) : "NULL"}, ${ql(r.transactionHash)}, ${Number(r.transactionIndex)})`,
+    )
+    .join(",\n");
+}
+
+function psqlReturning1(databaseUrl, sql) {
+  const stdout = execFileSync(
+    "psql",
+    [databaseUrl, "-X", "-A", "-t", "-v", "ON_ERROR_STOP=1", "-c", sql],
+    { encoding: "utf8", maxBuffer: 1024 * 1024 * 512 },
+  );
+  return stdout.split("\n").filter((line) => line.trim() === "1").length;
+}
+
+function insertFactoryBatch(databaseUrl, schema, rows) {
+  if (rows.length === 0) return 0;
+  const values = buildFactoryRowsValues(rows);
+  const sql = `
+with incoming(factory_id, chain_id, block_number, address) as (
+  values
+${values}
+)
+insert into ${schema}.factory_addresses (factory_id, chain_id, block_number, address)
+select i.factory_id, i.chain_id, i.block_number, i.address
+from incoming i
+where not exists (
+  select 1 from ${schema}.factory_addresses f
+  where f.factory_id = i.factory_id and f.chain_id = i.chain_id and lower(f.address) = lower(i.address)
+)
+returning 1;
+`;
+  return psqlReturning1(databaseUrl, sql);
+}
+
+function insertLogsBatch(databaseUrl, schema, rows) {
+  if (rows.length === 0) return 0;
+  const values = buildLogRowsValues(rows);
+  const sql = `
+insert into ${schema}.logs (address, block_hash, block_number, chain_id, data, log_index, topic0, topic1, topic2, topic3, transaction_hash, transaction_index)
+values
+${values}
+on conflict (chain_id, block_number, log_index) do nothing
+returning 1;
+`;
+  return psqlReturning1(databaseUrl, sql);
+}
+
+function findHighestKnownBlock(databaseUrl, schema, factoryId, chainId) {
+  const sql = `select coalesce(max(block_number), 0)::text from ${schema}.factory_addresses where factory_id = ${Number(factoryId)} and chain_id = ${Number(chainId)};`;
+  const out = execFileSync(
+    "psql",
+    [databaseUrl, "-X", "-A", "-t", "-v", "ON_ERROR_STOP=1", "-c", sql],
+    { encoding: "utf8" },
+  ).trim();
+  return BigInt(out || "0");
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) return printHelp();
+  if (!args.databaseUrl) throw new Error("Missing DATABASE_URL");
+
+  const rpcUrl = resolveRpcUrl(args.chainId, args.rpcUrl);
+  const { airlock, factoryId } = resolveDefaults(
+    args.chainId,
+    args.airlock,
+    args.factoryId,
+  );
+
+  const client = createPublicClient({
+    transport: http(rpcUrl, { timeout: 30_000, retryCount: 3 }),
+  });
+
+  const head = args.endBlock ?? (await client.getBlockNumber());
+  let startBlock = args.startBlock;
+  if (startBlock === undefined) {
+    const highest = findHighestKnownBlock(
+      args.databaseUrl,
+      args.pondersyncSchema,
+      factoryId,
+      args.chainId,
+    );
+    startBlock = highest + 1n;
+  }
+
+  if (startBlock > head) {
+    console.log(`Nothing to do: start_block ${startBlock} > head ${head}.`);
+    return;
+  }
+
+  console.log(
+    `Backfilling Airlock(${airlock}) Create logs on chain ${args.chainId}`,
+  );
+  console.log(`  range: blocks [${startBlock}, ${head}]`);
+  console.log(
+    `  factory_id=${factoryId}  apply=${args.apply}  rpc_concurrency=${args.rpcConcurrency}  window=${args.windowSize}`,
+  );
+
+  const windows = makeWindows(startBlock, head, args.windowSize);
+  console.log(`  windows=${windows.length}`);
+
+  let factoryBuffer = [];
+  let logsBuffer = [];
+  let totalCreates = 0;
+  let totalFactoryWritten = 0;
+  let totalLogsWritten = 0;
+  let lastReport = Date.now();
+  let windowsDone = 0;
+
+  const flushIfFull = () => {
+    if (!args.apply) {
+      factoryBuffer = [];
+      logsBuffer = [];
+      return;
+    }
+    while (factoryBuffer.length >= args.batchSize) {
+      const slice = factoryBuffer.splice(0, args.batchSize);
+      totalFactoryWritten += insertFactoryBatch(
+        args.databaseUrl,
+        args.pondersyncSchema,
+        slice,
+      );
+    }
+    while (logsBuffer.length >= args.batchSize) {
+      const slice = logsBuffer.splice(0, args.batchSize);
+      totalLogsWritten += insertLogsBatch(
+        args.databaseUrl,
+        args.pondersyncSchema,
+        slice,
+      );
+    }
+  };
+
+  const flushFinal = () => {
+    if (!args.apply) return;
+    while (factoryBuffer.length > 0) {
+      const slice = factoryBuffer.splice(0, args.batchSize);
+      totalFactoryWritten += insertFactoryBatch(
+        args.databaseUrl,
+        args.pondersyncSchema,
+        slice,
+      );
+    }
+    while (logsBuffer.length > 0) {
+      const slice = logsBuffer.splice(0, args.batchSize);
+      totalLogsWritten += insertLogsBatch(
+        args.databaseUrl,
+        args.pondersyncSchema,
+        slice,
+      );
+    }
+  };
+
+  const fetcher = (w) => fetchLogsRange(client, airlock, w.from, w.to);
+
+  for await (const { item: window, result: logs } of orderedPrefetch(
+    windows,
+    fetcher,
+    args.rpcConcurrency,
+  )) {
+    for (const log of logs) {
+      const asset = dataAddressAtOffset(log.data, 0);
+      const blockNumber = BigInt(log.blockNumber);
+      const logIndex = Number(log.logIndex);
+      factoryBuffer.push({
+        factoryId,
+        chainId: args.chainId,
+        blockNumber,
+        address: asset,
+      });
+      logsBuffer.push({
+        address: lowerHex(log.address),
+        blockHash: lowerHex(log.blockHash),
+        blockNumber,
+        chainId: args.chainId,
+        data: log.data,
+        logIndex,
+        topic0: lowerHex(log.topics[0] ?? null),
+        topic1: log.topics[1] ? lowerHex(log.topics[1]) : null,
+        topic2: log.topics[2] ? lowerHex(log.topics[2]) : null,
+        topic3: log.topics[3] ? lowerHex(log.topics[3]) : null,
+        transactionHash: lowerHex(log.transactionHash),
+        transactionIndex: Number(log.transactionIndex),
+      });
+      totalCreates++;
+    }
+    flushIfFull();
+    windowsDone++;
+
+    if (Date.now() - lastReport > 5000) {
+      console.log(
+        `  windows ${windowsDone}/${windows.length} (${((windowsDone / windows.length) * 100).toFixed(2)}%)  block=${window.to}  creates=${totalCreates}  fa_written=${totalFactoryWritten}  logs_written=${totalLogsWritten}`,
+      );
+      lastReport = Date.now();
+    }
+  }
+
+  flushFinal();
+
+  console.log(
+    `Done. creates_found=${totalCreates} factory_addresses_written=${totalFactoryWritten} logs_written=${totalLogsWritten}`,
+  );
+  if (!args.apply) console.log("Dry-run; re-run with --apply to write.");
+}
+
+main().catch((err) => {
+  console.error(err.stack || err.message || err);
+  process.exit(1);
+});

--- a/scripts/backfill-airlock-creates.mjs
+++ b/scripts/backfill-airlock-creates.mjs
@@ -223,8 +223,13 @@ function buildLogRowsValues(rows) {
 function psqlReturning1(databaseUrl, sql) {
   const stdout = execFileSync(
     "psql",
-    [databaseUrl, "-X", "-A", "-t", "-v", "ON_ERROR_STOP=1", "-c", sql],
-    { encoding: "utf8", maxBuffer: 1024 * 1024 * 512 },
+    [databaseUrl, "-X", "-A", "-t", "-v", "ON_ERROR_STOP=1"],
+    {
+      input: sql,
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024 * 512,
+      stdio: ["pipe", "pipe", "inherit"],
+    },
   );
   return stdout.split("\n").filter((line) => line.trim() === "1").length;
 }

--- a/scripts/backfill-airlock-creates.mjs
+++ b/scripts/backfill-airlock-creates.mjs
@@ -6,13 +6,42 @@ import { resolve } from "node:path";
 import process from "node:process";
 import { createPublicClient, http } from "viem";
 
-const CREATE_SELECTOR =
-  "0x68ff1cfcdcf76864161555fc0de1878d8f83ec6949bf351df74d8a4a1a2679ab";
+// Airlock events that register ponder factory children. `child` describes
+// where the child address lives in the log (must match the ponder factory
+// config's childAddressLocation for the target factory row).
+const EVENTS = {
+  create: {
+    // Create(address asset, address indexed numeraire, ...)
+    selector:
+      "0x68ff1cfcdcf76864161555fc0de1878d8f83ec6949bf351df74d8a4a1a2679ab",
+    child: { kind: "data", offset: 0 },
+  },
+  migrate: {
+    // Migrate(address indexed asset, address indexed pool)
+    selector:
+      "0x2a05bb717043f3a794e94382bf63f2e275ecafc41be9b63c34f16d58da9822ca",
+    child: { kind: "topic", index: 2 },
+  },
+};
 
 const DEFAULTS = {
   8453: {
-    airlock: "0x660eaaedebc968f8f3694354fa8ec0b4c5ba8d12",
-    factoryId: 640791,
+    create: {
+      airlock: "0x660eaaedebc968f8f3694354fa8ec0b4c5ba8d12",
+      factoryId: 640791,
+    },
+  },
+  4663: {
+    create: {
+      airlock: "0xeb7c034704ef8dcd2d32324c1545f62fb4ad0862",
+      factoryId: 827059,
+    },
+    migrate: {
+      airlock: "0xeb7c034704ef8dcd2d32324c1545f62fb4ad0862",
+      // No default factoryId: look it up in ponder_sync.intervals /
+      // ponder_sync.factories (fragment factory_log_4663_<airlock>_<Migrate
+      // selector>_topic2_...) and pass --factory-id.
+    },
   },
 };
 
@@ -20,8 +49,16 @@ const RPC_ENV_BY_CHAIN = {
   1: ["PONDER_RPC_URL_1", "MAINNET_RPC"],
   130: ["PONDER_RPC_URL_130", "UNICHAIN_RPC"],
   143: ["PONDER_RPC_URL_143", "MONAD_RPC"],
+  4663: ["PONDER_RPC_URL_4663", "ROBINHOOD_RPC"],
   8453: ["PONDER_RPC_URL_8453", "BASE_RPC", "BASE_RPC_URL"],
   57073: ["PONDER_RPC_URL_57073", "INK_RPC"],
+};
+
+// Last-resort public endpoints for chains where one exists. Rate-limited
+// (robinhood: 10k logs per eth_getLogs, aggressive 429s) — prefer a private
+// RPC via the env vars above for large backfills.
+const PUBLIC_RPC_BY_CHAIN = {
+  4663: "https://rpc.mainnet.chain.robinhood.com",
 };
 
 function loadDotEnv(path) {
@@ -44,6 +81,7 @@ function parseArgs(argv) {
   const args = {
     apply: false,
     chainId: 8453,
+    event: "create",
     databaseUrl: process.env.DATABASE_URL,
     rpcUrl: undefined,
     airlock: undefined,
@@ -69,6 +107,7 @@ function parseArgs(argv) {
       if (key === "database-url") args.databaseUrl = v;
       else if (key === "rpc-url") args.rpcUrl = v;
       else if (key === "chain-id") args.chainId = Number(v);
+      else if (key === "event") args.event = v.toLowerCase();
       else if (key === "airlock") args.airlock = v.toLowerCase();
       else if (key === "factory-id") args.factoryId = Number(v);
       else if (key === "start-block") args.startBlock = BigInt(v);
@@ -88,19 +127,24 @@ function printHelp() {
   console.log(`Usage:
   node scripts/backfill-airlock-creates.mjs [options]
 
-Re-fetches missing Airlock Create logs from RPC and inserts them into
-ponder_sync.factory_addresses and ponder_sync.logs. Does NOT touch
-ponder_sync.intervals.
+Re-fetches missing Airlock factory logs (Create or Migrate) from RPC and
+inserts them into ponder_sync.factory_addresses and ponder_sync.logs. Does
+NOT touch ponder_sync.intervals.
 
 eth_getLogs windows are fetched with --rpc-concurrency in flight; results
 are handed to the DB writer in order so RPC and DB work overlap.
 
 Options:
   --chain-id <id>            EVM chain id. Default 8453.
+  --event <create|migrate>   Which airlock factory event to backfill.
+                             create -> DERC20 children (asset, data word 0),
+                             migrate -> MigrationPool children (pool, topic2).
+                             Default create.
   --airlock <0x...>          Airlock contract. Default per-chain.
-  --factory-id <n>           ponder_sync.factories.id for the DERC20
-                             subscription. Default per-chain.
-  --rpc-url <url>            RPC URL. Default \$BASE_RPC_URL etc.
+  --factory-id <n>           ponder_sync.factories.id for the target factory
+                             subscription. Default per-chain per-event.
+  --rpc-url <url>            RPC URL. Default \$BASE_RPC_URL etc; falls back
+                             to a public endpoint where one is known.
   --database-url <url>       Postgres URL. Default \$DATABASE_URL.
   --start-block <n>          From block (inclusive). Default = 1 + max
                              block_number already in factory_addresses
@@ -141,24 +185,47 @@ function dataAddressAtOffset(data, byteOffset) {
   return `0x${hex.slice(start, end).toLowerCase()}`;
 }
 
+function topicToAddress(topic) {
+  const hex = topic.startsWith("0x") ? topic.slice(2) : topic;
+  return `0x${hex.slice(24).toLowerCase()}`;
+}
+
+function extractChildAddress(log, child) {
+  if (child.kind === "data") return dataAddressAtOffset(log.data, child.offset);
+  const topic = log.topics[child.index];
+  if (!topic)
+    throw new Error(`log ${log.transactionHash} missing topic${child.index}`);
+  return topicToAddress(topic);
+}
+
 function resolveRpcUrl(chainId, override) {
   if (override) return override;
   for (const name of RPC_ENV_BY_CHAIN[chainId] ?? []) {
     if (process.env[name]) return process.env[name];
+  }
+  if (PUBLIC_RPC_BY_CHAIN[chainId]) {
+    console.warn(
+      `No RPC env var set for chain ${chainId}; using rate-limited public endpoint ${PUBLIC_RPC_BY_CHAIN[chainId]}.`,
+    );
+    return PUBLIC_RPC_BY_CHAIN[chainId];
   }
   throw new Error(
     `No RPC URL found for chain ${chainId}. Set --rpc-url or one of ${(RPC_ENV_BY_CHAIN[chainId] ?? []).join(", ")}.`,
   );
 }
 
-function resolveDefaults(chainId, airlockOverride, factoryIdOverride) {
-  const fallback = DEFAULTS[chainId];
+function resolveDefaults(chainId, event, airlockOverride, factoryIdOverride) {
+  const fallback = DEFAULTS[chainId]?.[event];
   const airlock = airlockOverride ?? fallback?.airlock?.toLowerCase();
   const factoryId = factoryIdOverride ?? fallback?.factoryId;
   if (!airlock)
-    throw new Error(`No --airlock and no default for chain ${chainId}`);
+    throw new Error(
+      `No --airlock and no default for chain ${chainId} event ${event}`,
+    );
   if (factoryId === undefined)
-    throw new Error(`No --factory-id and no default for chain ${chainId}`);
+    throw new Error(
+      `No --factory-id and no default for chain ${chainId} event ${event}`,
+    );
   return { airlock, factoryId };
 }
 
@@ -191,7 +258,7 @@ async function* orderedPrefetch(items, fetcher, concurrency) {
   }
 }
 
-async function fetchLogsRange(client, airlock, fromBlock, toBlock, attempts = 4) {
+async function fetchLogsRange(client, airlock, selector, fromBlock, toBlock, attempts = 4) {
   let lastErr;
   for (let attempt = 0; attempt < attempts; attempt++) {
     try {
@@ -200,7 +267,7 @@ async function fetchLogsRange(client, airlock, fromBlock, toBlock, attempts = 4)
         params: [
           {
             address: airlock,
-            topics: [CREATE_SELECTOR],
+            topics: [selector],
             fromBlock: `0x${fromBlock.toString(16)}`,
             toBlock: `0x${toBlock.toString(16)}`,
           },
@@ -316,9 +383,16 @@ async function main() {
   if (args.help) return printHelp();
   if (!args.databaseUrl) throw new Error("Missing DATABASE_URL");
 
+  const event = EVENTS[args.event];
+  if (!event)
+    throw new Error(
+      `Unknown --event ${args.event}; expected one of ${Object.keys(EVENTS).join(", ")}`,
+    );
+
   const rpcUrl = resolveRpcUrl(args.chainId, args.rpcUrl);
   const { airlock, factoryId } = resolveDefaults(
     args.chainId,
+    args.event,
     args.airlock,
     args.factoryId,
   );
@@ -331,13 +405,18 @@ async function main() {
   let startBlock = args.startBlock;
   let startReason = "explicit --start-block";
   if (startBlock === undefined) {
-    const earliestGap = findEarliestMissingBlock(
-      args.databaseUrl,
-      args.pondersyncSchema,
-      args.schema,
-      factoryId,
-      args.chainId,
-    );
+    // The earliest-gap heuristic scans <schema>.token for DERC20 rows, which
+    // only maps to children of the Create factory.
+    const earliestGap =
+      args.event === "create"
+        ? findEarliestMissingBlock(
+            args.databaseUrl,
+            args.pondersyncSchema,
+            args.schema,
+            factoryId,
+            args.chainId,
+          )
+        : 0n;
     if (earliestGap > 0n) {
       startBlock = earliestGap;
       startReason = `earliest gap (DERC20 token in ${args.schema}.token missing from factory ${factoryId})`;
@@ -359,7 +438,7 @@ async function main() {
   }
 
   console.log(
-    `Backfilling Airlock(${airlock}) Create logs on chain ${args.chainId}`,
+    `Backfilling Airlock(${airlock}) ${args.event} logs on chain ${args.chainId}`,
   );
   console.log(`  range: blocks [${startBlock}, ${head}]  (start: ${startReason})`);
   console.log(
@@ -421,7 +500,8 @@ async function main() {
     }
   };
 
-  const fetcher = (w) => fetchLogsRange(client, airlock, w.from, w.to);
+  const fetcher = (w) =>
+    fetchLogsRange(client, airlock, event.selector, w.from, w.to);
 
   for await (const { item: window, result: logs } of orderedPrefetch(
     windows,
@@ -429,7 +509,7 @@ async function main() {
     args.rpcConcurrency,
   )) {
     for (const log of logs) {
-      const asset = dataAddressAtOffset(log.data, 0);
+      const asset = extractChildAddress(log, event.child);
       const blockNumber = BigInt(log.blockNumber);
       const logIndex = Number(log.logIndex);
       factoryBuffer.push({

--- a/scripts/backfill-airlock-creates.mjs
+++ b/scripts/backfill-airlock-creates.mjs
@@ -54,6 +54,7 @@ function parseArgs(argv) {
     batchSize: 1000,
     rpcConcurrency: 4,
     pondersyncSchema: "ponder_sync",
+    schema: "prod_1",
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -76,6 +77,7 @@ function parseArgs(argv) {
       else if (key === "batch-size") args.batchSize = Number(v);
       else if (key === "rpc-concurrency") args.rpcConcurrency = Number(v);
       else if (key === "ponder-sync-schema") args.pondersyncSchema = v;
+      else if (key === "schema") args.schema = v;
       else throw new Error(`Unknown argument ${a}`);
     } else throw new Error(`Unknown argument ${a}`);
   }
@@ -108,7 +110,17 @@ Options:
   --batch-size <n>           Rows per DB INSERT batch. Default 1000.
   --rpc-concurrency <n>      Window fetches in flight. Default 4.
   --ponder-sync-schema <s>   Sync schema name. Default ponder_sync.
+  --schema <name>            Materialized schema, used to detect gaps when
+                             --start-block is omitted. Default prod_1.
   --apply                    Actually write. Default is dry-run.
+
+Default --start-block:
+  Picks min(b.number) from ponder_sync.blocks for any DERC20 token in
+  <schema>.token whose address is missing from <ponder-sync-schema>.
+  factory_addresses for the chosen --factory-id (i.e. the earliest known
+  gap). Falls back to max(block_number) + 1 of factory_addresses when no
+  gaps are detected. Override with --start-block to force a specific
+  starting block.
 `);
 }
 
@@ -267,8 +279,30 @@ returning 1;
   return psqlReturning1(databaseUrl, sql);
 }
 
-function findHighestKnownBlock(databaseUrl, schema, factoryId, chainId) {
-  const sql = `select coalesce(max(block_number), 0)::text from ${schema}.factory_addresses where factory_id = ${Number(factoryId)} and chain_id = ${Number(chainId)};`;
+function findHighestKnownBlock(databaseUrl, pondersyncSchema, factoryId, chainId) {
+  const sql = `select coalesce(max(block_number), 0)::text from ${pondersyncSchema}.factory_addresses where factory_id = ${Number(factoryId)} and chain_id = ${Number(chainId)};`;
+  const out = execFileSync(
+    "psql",
+    [databaseUrl, "-X", "-A", "-t", "-v", "ON_ERROR_STOP=1", "-c", sql],
+    { encoding: "utf8" },
+  ).trim();
+  return BigInt(out || "0");
+}
+
+function findEarliestMissingBlock(databaseUrl, pondersyncSchema, schema, factoryId, chainId) {
+  const sql = `
+select coalesce(min(b.number), 0)::text
+from ${schema}.token t
+join ${pondersyncSchema}.blocks b
+  on b.chain_id = t.chain_id and b.timestamp::bigint = t.first_seen_at::bigint
+left join ${pondersyncSchema}.factory_addresses fa
+  on fa.factory_id = ${Number(factoryId)}
+ and fa.chain_id = t.chain_id
+ and lower(fa.address) = lower(t.address)
+where t.chain_id = ${Number(chainId)}
+  and t.is_derc20 = true
+  and fa.address is null;
+`;
   const out = execFileSync(
     "psql",
     [databaseUrl, "-X", "-A", "-t", "-v", "ON_ERROR_STOP=1", "-c", sql],
@@ -295,14 +329,28 @@ async function main() {
 
   const head = args.endBlock ?? (await client.getBlockNumber());
   let startBlock = args.startBlock;
+  let startReason = "explicit --start-block";
   if (startBlock === undefined) {
-    const highest = findHighestKnownBlock(
+    const earliestGap = findEarliestMissingBlock(
       args.databaseUrl,
       args.pondersyncSchema,
+      args.schema,
       factoryId,
       args.chainId,
     );
-    startBlock = highest + 1n;
+    if (earliestGap > 0n) {
+      startBlock = earliestGap;
+      startReason = `earliest gap (DERC20 token in ${args.schema}.token missing from factory ${factoryId})`;
+    } else {
+      const highest = findHighestKnownBlock(
+        args.databaseUrl,
+        args.pondersyncSchema,
+        factoryId,
+        args.chainId,
+      );
+      startBlock = highest + 1n;
+      startReason = `max(factory_addresses.block_number) + 1 (no gaps detected)`;
+    }
   }
 
   if (startBlock > head) {
@@ -313,7 +361,7 @@ async function main() {
   console.log(
     `Backfilling Airlock(${airlock}) Create logs on chain ${args.chainId}`,
   );
-  console.log(`  range: blocks [${startBlock}, ${head}]`);
+  console.log(`  range: blocks [${startBlock}, ${head}]  (start: ${startReason})`);
   console.log(
     `  factory_id=${factoryId}  apply=${args.apply}  rpc_concurrency=${args.rpcConcurrency}  window=${args.windowSize}`,
   );

--- a/scripts/backfill-derc20-materialize.mjs
+++ b/scripts/backfill-derc20-materialize.mjs
@@ -14,8 +14,22 @@ const RPC_ENV_BY_CHAIN = {
   1: ["PONDER_RPC_URL_1", "MAINNET_RPC"],
   130: ["PONDER_RPC_URL_130", "UNICHAIN_RPC"],
   143: ["PONDER_RPC_URL_143", "MONAD_RPC"],
+  4663: ["PONDER_RPC_URL_4663", "ROBINHOOD_RPC"],
   8453: ["PONDER_RPC_URL_8453", "BASE_RPC", "BASE_RPC_URL"],
   57073: ["PONDER_RPC_URL_57073", "INK_RPC"],
+};
+
+// Last-resort public endpoints for chains where one exists. Rate-limited
+// (robinhood: aggressive 429s) — prefer a private RPC via the env vars
+// above for large backfills.
+const PUBLIC_RPC_BY_CHAIN = {
+  4663: "https://rpc.mainnet.chain.robinhood.com",
+};
+
+// ponder_sync.factories.id of the airlock Create (DERC20 asset) factory.
+const FACTORY_ID_BY_CHAIN = {
+  8453: 640791,
+  4663: 827059,
 };
 
 function loadDotEnv(path) {
@@ -38,7 +52,7 @@ function parseArgs(argv) {
   const args = {
     apply: false,
     chainId: 8453,
-    factoryId: 640791,
+    factoryId: undefined,
     schema: "prod_1",
     pondersyncSchema: "ponder_sync",
     databaseUrl: process.env.DATABASE_URL,
@@ -75,6 +89,9 @@ function parseArgs(argv) {
       else throw new Error(`Unknown argument ${a}`);
     } else throw new Error(`Unknown argument ${a}`);
   }
+  args.factoryId ??= FACTORY_ID_BY_CHAIN[args.chainId];
+  if (!args.help && args.factoryId === undefined)
+    throw new Error(`No --factory-id and no default for chain ${args.chainId}`);
   return args;
 }
 
@@ -100,10 +117,12 @@ the next token's RPC timestamp fetch overlaps with this token's DB writes.
 
 Options:
   --chain-id <id>            EVM chain id. Default 8453.
-  --factory-id <n>           Source factory id. Default 640791.
+  --factory-id <n>           Source factory id. Default per-chain
+                             (8453 -> 640791, 4663 -> 827059).
   --schema <name>            Materialized indexer schema. Default prod_1.
   --ponder-sync-schema <s>   Sync schema name. Default ponder_sync.
-  --rpc-url <url>            RPC URL. Default \$BASE_RPC_URL.
+  --rpc-url <url>            RPC URL. Default \$BASE_RPC_URL etc; falls back
+                             to a public endpoint where one is known.
   --database-url <url>       Postgres URL. Default \$DATABASE_URL.
   --token-concurrency <n>    Tokens processed in parallel. Default 4.
   --rpc-concurrency <n>      eth_getBlockByNumber calls in flight per
@@ -130,6 +149,12 @@ function resolveRpcUrl(chainId, override) {
   if (override) return override;
   for (const name of RPC_ENV_BY_CHAIN[chainId] ?? []) {
     if (process.env[name]) return process.env[name];
+  }
+  if (PUBLIC_RPC_BY_CHAIN[chainId]) {
+    console.warn(
+      `No RPC env var set for chain ${chainId}; using rate-limited public endpoint ${PUBLIC_RPC_BY_CHAIN[chainId]}.`,
+    );
+    return PUBLIC_RPC_BY_CHAIN[chainId];
   }
   throw new Error(
     `No RPC URL found for chain ${chainId}. Set --rpc-url or one of ${(RPC_ENV_BY_CHAIN[chainId] ?? []).join(", ")}.`,

--- a/scripts/backfill-derc20-materialize.mjs
+++ b/scripts/backfill-derc20-materialize.mjs
@@ -384,12 +384,17 @@ function setHolderCounts(databaseUrl, schema, chainId, token, pool, holderCount)
 }
 
 async function buildPlanForToken(args, client, work) {
+  const log = (msg) => console.log(`  [${work.token}] ${msg}`);
+
+  log("fetching Transfer rows from ponder_sync.logs...");
+  const t0 = Date.now();
   const transfersSql = selectTransfersSql(
     args.pondersyncSchema,
     args.chainId,
     work.token,
   );
   const transfers = psqlRowsTsv(args.databaseUrl, transfersSql);
+  log(`fetched ${transfers.length} transfers (${Date.now() - t0}ms)`);
 
   if (transfers.length === 0) {
     return {
@@ -402,16 +407,25 @@ async function buildPlanForToken(args, client, work) {
     };
   }
 
+  log("replaying transfers...");
+  const t1 = Date.now();
   const { balances, firstSeen, lastInteraction } = replay(transfers);
+  log(
+    `replayed: ${balances.size} unique addresses (${Date.now() - t1}ms)`,
+  );
+
   const blockNumbers = new Set();
   for (const v of firstSeen.values()) blockNumbers.add(v);
   for (const v of lastInteraction.values()) blockNumbers.add(v);
 
+  log(`fetching ${blockNumbers.size} block timestamps via RPC...`);
+  const t2 = Date.now();
   const blockTimestamps = await fetchBlockTimestampsBulk(
     client,
     [...blockNumbers],
     args.rpcConcurrency,
   );
+  log(`fetched block timestamps (${Date.now() - t2}ms)`);
 
   return { work, transfers, balances, firstSeen, lastInteraction, blockTimestamps };
 }
@@ -452,22 +466,35 @@ async function applyPlan(args, plan) {
     });
   }
 
+  const log = (msg) => console.log(`  [${work.token}] ${msg}`);
+
   let usersWritten = 0;
   if (!args.skipUserUpsert) {
-    for (const slice of chunk(userRows, args.batchSize)) {
-      usersWritten += writeUsersBatch(args.databaseUrl, args.schema, slice);
+    const slices = chunk(userRows, args.batchSize);
+    log(`writing ${userRows.length} user rows in ${slices.length} batch(es)...`);
+    const t = Date.now();
+    for (let i = 0; i < slices.length; i++) {
+      usersWritten += writeUsersBatch(args.databaseUrl, args.schema, slices[i]);
     }
+    log(`wrote users (${Date.now() - t}ms)`);
   }
 
+  const uaSlices = chunk(userAssetRows, args.batchSize);
+  log(
+    `writing ${userAssetRows.length} user_asset rows in ${uaSlices.length} batch(es)...`,
+  );
+  const tUa = Date.now();
   let userAssetsWritten = 0;
-  for (const slice of chunk(userAssetRows, args.batchSize)) {
+  for (let i = 0; i < uaSlices.length; i++) {
     userAssetsWritten += writeUserAssetBatch(
       args.databaseUrl,
       args.schema,
-      slice,
+      uaSlices[i],
     );
   }
+  log(`wrote user_assets (${Date.now() - tUa}ms)`);
 
+  log(`updating holder_count to ${heldBy.length}...`);
   setHolderCounts(
     args.databaseUrl,
     args.schema,

--- a/scripts/backfill-derc20-materialize.mjs
+++ b/scripts/backfill-derc20-materialize.mjs
@@ -148,8 +148,13 @@ function psqlJson(databaseUrl, sql) {
 function psqlReturning1(databaseUrl, sql) {
   const stdout = execFileSync(
     "psql",
-    [databaseUrl, "-X", "-A", "-t", "-v", "ON_ERROR_STOP=1", "-c", sql],
-    { encoding: "utf8", maxBuffer: 1024 * 1024 * 512 },
+    [databaseUrl, "-X", "-A", "-t", "-v", "ON_ERROR_STOP=1"],
+    {
+      input: sql,
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024 * 512,
+      stdio: ["pipe", "pipe", "inherit"],
+    },
   );
   return stdout.split("\n").filter((line) => line.trim() === "1").length;
 }

--- a/scripts/backfill-derc20-materialize.mjs
+++ b/scripts/backfill-derc20-materialize.mjs
@@ -346,6 +346,7 @@ function writeUserAssetBatch(databaseUrl, schema, rows) {
   if (rows.length === 0) return 0;
   const values = buildUserAssetValues(rows);
   const sql = `
+set session_replication_role = replica;
 insert into ${schema}.user_asset (chain_id, user_id, asset_id, balance, created_at, last_interaction)
 values
 ${values}
@@ -361,6 +362,7 @@ function writeUsersBatch(databaseUrl, schema, rows) {
   if (rows.length === 0) return 0;
   const values = buildUserValues(rows);
   const sql = `
+set session_replication_role = replica;
 insert into ${schema}."user" (address, chain_id, created_at, last_seen_at)
 values
 ${values}
@@ -373,6 +375,7 @@ returning 1;
 
 function setHolderCounts(databaseUrl, schema, chainId, token, pool, holderCount) {
   const parts = [
+    "set session_replication_role = replica;",
     `update ${schema}.token set holder_count = ${Number(holderCount)} where lower(address) = ${ql(token)} and chain_id = ${Number(chainId)};`,
   ];
   if (pool) {

--- a/scripts/backfill-derc20-materialize.mjs
+++ b/scripts/backfill-derc20-materialize.mjs
@@ -1,0 +1,533 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import process from "node:process";
+import { createPublicClient, http } from "viem";
+
+const TRANSFER_SELECTOR =
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+const RPC_ENV_BY_CHAIN = {
+  1: ["PONDER_RPC_URL_1", "MAINNET_RPC"],
+  130: ["PONDER_RPC_URL_130", "UNICHAIN_RPC"],
+  143: ["PONDER_RPC_URL_143", "MONAD_RPC"],
+  8453: ["PONDER_RPC_URL_8453", "BASE_RPC", "BASE_RPC_URL"],
+  57073: ["PONDER_RPC_URL_57073", "INK_RPC"],
+};
+
+function loadDotEnv(path) {
+  if (!existsSync(path)) return;
+  for (const rawLine of readFileSync(path, "utf8").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const m = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (!m) continue;
+    const [, key, rawValue] = m;
+    if (process.env[key] !== undefined) continue;
+    process.env[key] = rawValue.trim().replace(/^(['"])(.*)\1$/, "$2");
+  }
+}
+
+loadDotEnv(resolve(process.cwd(), ".env"));
+loadDotEnv(resolve(process.cwd(), ".env.local"));
+
+function parseArgs(argv) {
+  const args = {
+    apply: false,
+    chainId: 8453,
+    factoryId: 640791,
+    schema: "prod_1",
+    pondersyncSchema: "ponder_sync",
+    databaseUrl: process.env.DATABASE_URL,
+    rpcUrl: undefined,
+    tokenConcurrency: 4,
+    rpcConcurrency: 8,
+    batchSize: 500,
+    limit: undefined,
+    token: undefined,
+    skipUserUpsert: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--") continue;
+    if (a === "--help" || a === "-h") args.help = true;
+    else if (a === "--apply") args.apply = true;
+    else if (a === "--skip-user-upsert") args.skipUserUpsert = true;
+    else if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const v = argv[++i];
+      if (v === undefined || v.startsWith("--"))
+        throw new Error(`Missing value for ${a}`);
+      if (key === "database-url") args.databaseUrl = v;
+      else if (key === "rpc-url") args.rpcUrl = v;
+      else if (key === "chain-id") args.chainId = Number(v);
+      else if (key === "factory-id") args.factoryId = Number(v);
+      else if (key === "schema") args.schema = v;
+      else if (key === "ponder-sync-schema") args.pondersyncSchema = v;
+      else if (key === "token-concurrency") args.tokenConcurrency = Number(v);
+      else if (key === "rpc-concurrency") args.rpcConcurrency = Number(v);
+      else if (key === "batch-size") args.batchSize = Number(v);
+      else if (key === "limit") args.limit = Number(v);
+      else if (key === "token") args.token = v.toLowerCase();
+      else throw new Error(`Unknown argument ${a}`);
+    } else throw new Error(`Unknown argument ${a}`);
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/backfill-derc20-materialize.mjs [options]
+
+Stage 2 of the DERC20 backfill. For each DERC20 contract with Transfer
+rows already present in ponder_sync.logs (left there by
+backfill-derc20-transfers.mjs), this script:
+
+  1. Selects all Transfer rows for the token from ponder_sync.logs
+     in (block_number, log_index) order.
+  2. Fetches block timestamps for the unique blocks touched (RPC,
+     header-only) — pipelined with the previous token's DB writes.
+  3. Replays the Transfer history offline to derive each address's
+     final balance, first_seen, and last_interaction.
+  4. UPSERTs prod_<schema>.user and prod_<schema>.user_asset, and
+     UPDATEs holder_count on prod_<schema>.token and prod_<schema>.pool.
+
+Tokens are processed in parallel (--token-concurrency); within a token,
+the next token's RPC timestamp fetch overlaps with this token's DB writes.
+
+Options:
+  --chain-id <id>            EVM chain id. Default 8453.
+  --factory-id <n>           Source factory id. Default 640791.
+  --schema <name>            Materialized indexer schema. Default prod_1.
+  --ponder-sync-schema <s>   Sync schema name. Default ponder_sync.
+  --rpc-url <url>            RPC URL. Default \$BASE_RPC_URL.
+  --database-url <url>       Postgres URL. Default \$DATABASE_URL.
+  --token-concurrency <n>    Tokens processed in parallel. Default 4.
+  --rpc-concurrency <n>      eth_getBlockByNumber calls in flight per
+                             token. Default 8.
+  --batch-size <n>           Rows per DB INSERT batch. Default 500.
+  --limit <n>                Process at most N tokens (after filtering).
+  --token <0x...>            Process exactly one token (ignores filters).
+  --skip-user-upsert         Skip prod_<schema>.user upserts (faster;
+                             holder_count + user_asset still get written).
+  --apply                    Actually write. Default is dry-run.
+`);
+}
+
+function ql(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function topicToAddress(topic) {
+  const hex = topic.startsWith("0x") ? topic.slice(2) : topic;
+  return `0x${hex.slice(24).toLowerCase()}`;
+}
+
+function resolveRpcUrl(chainId, override) {
+  if (override) return override;
+  for (const name of RPC_ENV_BY_CHAIN[chainId] ?? []) {
+    if (process.env[name]) return process.env[name];
+  }
+  throw new Error(
+    `No RPC URL found for chain ${chainId}. Set --rpc-url or one of ${(RPC_ENV_BY_CHAIN[chainId] ?? []).join(", ")}.`,
+  );
+}
+
+function psqlJson(databaseUrl, sql) {
+  const out = execFileSync(
+    "psql",
+    [databaseUrl, "-X", "-A", "-t", "-v", "ON_ERROR_STOP=1", "-c", sql],
+    { encoding: "utf8", maxBuffer: 1024 * 1024 * 512 },
+  ).trim();
+  return JSON.parse(out || "[]");
+}
+
+function psqlReturning1(databaseUrl, sql) {
+  const stdout = execFileSync(
+    "psql",
+    [databaseUrl, "-X", "-A", "-t", "-v", "ON_ERROR_STOP=1", "-c", sql],
+    { encoding: "utf8", maxBuffer: 1024 * 1024 * 512 },
+  );
+  return stdout.split("\n").filter((line) => line.trim() === "1").length;
+}
+
+function psqlExec(databaseUrl, sql) {
+  execFileSync("psql", [databaseUrl, "-X", "-v", "ON_ERROR_STOP=1"], {
+    input: sql,
+    encoding: "utf8",
+    stdio: ["pipe", "inherit", "inherit"],
+  });
+}
+
+function selectWorkingSetSql(args) {
+  const fa = `${args.pondersyncSchema}.factory_addresses`;
+  const tok = `${args.schema}.token`;
+  const ua = `${args.schema}.user_asset`;
+  const logs = `${args.pondersyncSchema}.logs`;
+
+  if (args.token) {
+    return `
+select coalesce(json_agg(q), '[]'::json) from (
+  select lower(t.address) as token,
+         t.chain_id::int as chain_id,
+         lower(t.pool) as pool
+  from ${tok} t
+  where lower(t.address) = ${ql(args.token)} and t.chain_id = ${Number(args.chainId)}
+) q;`;
+  }
+
+  const limit = args.limit ? `limit ${Number(args.limit)}` : "";
+  return `
+select coalesce(json_agg(q), '[]'::json) from (
+  select lower(t.address) as token,
+         t.chain_id::int as chain_id,
+         lower(t.pool) as pool
+  from ${fa} fa
+  join ${tok} t
+    on lower(t.address) = lower(fa.address) and t.chain_id = fa.chain_id
+  where fa.factory_id = ${Number(args.factoryId)}
+    and fa.chain_id = ${Number(args.chainId)}
+    and exists (
+      select 1 from ${logs} l
+      where l.chain_id = fa.chain_id
+        and lower(l.address) = lower(fa.address)
+        and l.topic0 = ${ql(TRANSFER_SELECTOR)}
+    )
+    and not exists (
+      select 1 from ${ua} ua
+      where lower(ua.asset_id) = lower(t.address) and ua.chain_id = t.chain_id
+    )
+  order by fa.block_number
+  ${limit}
+) q;`;
+}
+
+function selectTransfersSql(schema, chainId, token) {
+  return `
+select coalesce(json_agg(q order by (q->>'block_number')::numeric, (q->>'log_index')::int), '[]'::json) from (
+  select block_number::text as block_number,
+         log_index,
+         topic1,
+         topic2,
+         data
+  from ${schema}.logs
+  where chain_id = ${Number(chainId)}
+    and lower(address) = ${ql(token)}
+    and topic0 = ${ql(TRANSFER_SELECTOR)}
+) q;`;
+}
+
+async function* orderedPrefetch(items, fetcher, concurrency) {
+  const inflight = [];
+  let i = 0;
+  const start = (idx) => ({ item: items[idx], promise: fetcher(items[idx]) });
+  while (i < items.length && inflight.length < concurrency) {
+    inflight.push(start(i));
+    i++;
+  }
+  while (inflight.length > 0) {
+    const next = inflight.shift();
+    const result = await next.promise;
+    if (i < items.length) {
+      inflight.push(start(i));
+      i++;
+    }
+    yield { item: next.item, result };
+  }
+}
+
+async function fetchBlockTimestamp(client, blockNumber, attempts = 4) {
+  let lastErr;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      const block = await client.request({
+        method: "eth_getBlockByNumber",
+        params: [`0x${BigInt(blockNumber).toString(16)}`, false],
+      });
+      if (!block) throw new Error(`block ${blockNumber} not found`);
+      return BigInt(block.timestamp);
+    } catch (err) {
+      lastErr = err;
+      await new Promise((r) => setTimeout(r, 200 * 2 ** attempt));
+    }
+  }
+  throw lastErr;
+}
+
+async function fetchBlockTimestampsBulk(client, blockNumbers, concurrency) {
+  const map = new Map();
+  const unique = [...new Set(blockNumbers.map((b) => b.toString()))];
+  const items = unique.map((s) => BigInt(s));
+  const fetcher = (bn) => fetchBlockTimestamp(client, bn);
+  for await (const { item, result } of orderedPrefetch(
+    items,
+    fetcher,
+    concurrency,
+  )) {
+    map.set(item.toString(), result);
+  }
+  return map;
+}
+
+function replay(transfers) {
+  const balances = new Map();
+  const firstSeen = new Map();
+  const lastInteraction = new Map();
+  for (const t of transfers) {
+    const from = topicToAddress(t.topic1);
+    const to = topicToAddress(t.topic2);
+    const value = BigInt(t.data);
+    const block = t.block_number;
+    if (from !== ZERO_ADDRESS) {
+      balances.set(from, (balances.get(from) ?? 0n) - value);
+      lastInteraction.set(from, block);
+      if (!firstSeen.has(from)) firstSeen.set(from, block);
+    }
+    if (to !== ZERO_ADDRESS) {
+      balances.set(to, (balances.get(to) ?? 0n) + value);
+      lastInteraction.set(to, block);
+      if (!firstSeen.has(to)) firstSeen.set(to, block);
+    }
+  }
+  return { balances, firstSeen, lastInteraction };
+}
+
+function chunk(array, size) {
+  const out = [];
+  for (let i = 0; i < array.length; i += size) out.push(array.slice(i, i + size));
+  return out;
+}
+
+function buildUserAssetValues(rows) {
+  return rows
+    .map(
+      (r) =>
+        `(${Number(r.chainId)}, ${ql(r.userId)}, ${ql(r.assetId)}, ${r.balance.toString()}, ${r.createdAt.toString()}, ${r.lastInteraction.toString()})`,
+    )
+    .join(",\n");
+}
+
+function buildUserValues(rows) {
+  return rows
+    .map(
+      (r) =>
+        `(${ql(r.address)}, ${Number(r.chainId)}, ${r.createdAt.toString()}, ${r.lastSeenAt.toString()})`,
+    )
+    .join(",\n");
+}
+
+function writeUserAssetBatch(databaseUrl, schema, rows) {
+  if (rows.length === 0) return 0;
+  const values = buildUserAssetValues(rows);
+  const sql = `
+insert into ${schema}.user_asset (chain_id, user_id, asset_id, balance, created_at, last_interaction)
+values
+${values}
+on conflict (user_id, asset_id, chain_id) do update set
+  balance = excluded.balance,
+  last_interaction = greatest(${schema}.user_asset.last_interaction, excluded.last_interaction)
+returning 1;
+`;
+  return psqlReturning1(databaseUrl, sql);
+}
+
+function writeUsersBatch(databaseUrl, schema, rows) {
+  if (rows.length === 0) return 0;
+  const values = buildUserValues(rows);
+  const sql = `
+insert into ${schema}."user" (address, chain_id, created_at, last_seen_at)
+values
+${values}
+on conflict (address, chain_id) do update set
+  last_seen_at = greatest(${schema}."user".last_seen_at, excluded.last_seen_at)
+returning 1;
+`;
+  return psqlReturning1(databaseUrl, sql);
+}
+
+function setHolderCounts(databaseUrl, schema, chainId, token, pool, holderCount) {
+  const parts = [
+    `update ${schema}.token set holder_count = ${Number(holderCount)} where lower(address) = ${ql(token)} and chain_id = ${Number(chainId)};`,
+  ];
+  if (pool) {
+    parts.push(
+      `update ${schema}.pool set holder_count = ${Number(holderCount)} where lower(address) = ${ql(pool)} and chain_id = ${Number(chainId)};`,
+    );
+  }
+  psqlExec(databaseUrl, parts.join("\n"));
+}
+
+async function buildPlanForToken(args, client, work) {
+  const transfersSql = selectTransfersSql(
+    args.pondersyncSchema,
+    args.chainId,
+    work.token,
+  );
+  const transfers = psqlJson(args.databaseUrl, transfersSql);
+
+  if (transfers.length === 0) {
+    return {
+      work,
+      transfers,
+      balances: new Map(),
+      firstSeen: new Map(),
+      lastInteraction: new Map(),
+      blockTimestamps: new Map(),
+    };
+  }
+
+  const { balances, firstSeen, lastInteraction } = replay(transfers);
+  const blockNumbers = new Set();
+  for (const v of firstSeen.values()) blockNumbers.add(v);
+  for (const v of lastInteraction.values()) blockNumbers.add(v);
+
+  const blockTimestamps = await fetchBlockTimestampsBulk(
+    client,
+    [...blockNumbers],
+    args.rpcConcurrency,
+  );
+
+  return { work, transfers, balances, firstSeen, lastInteraction, blockTimestamps };
+}
+
+async function applyPlan(args, plan) {
+  const { work, balances, firstSeen, lastInteraction, blockTimestamps } = plan;
+  const heldBy = [...balances.entries()].filter(([, b]) => b > 0n).map(([a]) => a);
+
+  if (!args.apply) {
+    return {
+      token: work.token,
+      transferCount: plan.transfers.length,
+      holderCount: heldBy.length,
+      uniqueAddresses: balances.size,
+    };
+  }
+
+  const userRows = [];
+  const userAssetRows = [];
+  for (const [addr, bal] of balances.entries()) {
+    const fb = firstSeen.get(addr);
+    const lb = lastInteraction.get(addr);
+    const createdAt = blockTimestamps.get(String(fb)) ?? 0n;
+    const lastTs = blockTimestamps.get(String(lb)) ?? createdAt;
+    userRows.push({
+      address: addr,
+      chainId: args.chainId,
+      createdAt,
+      lastSeenAt: lastTs,
+    });
+    userAssetRows.push({
+      chainId: args.chainId,
+      userId: addr,
+      assetId: work.token,
+      balance: bal,
+      createdAt,
+      lastInteraction: lastTs,
+    });
+  }
+
+  let usersWritten = 0;
+  if (!args.skipUserUpsert) {
+    for (const slice of chunk(userRows, args.batchSize)) {
+      usersWritten += writeUsersBatch(args.databaseUrl, args.schema, slice);
+    }
+  }
+
+  let userAssetsWritten = 0;
+  for (const slice of chunk(userAssetRows, args.batchSize)) {
+    userAssetsWritten += writeUserAssetBatch(
+      args.databaseUrl,
+      args.schema,
+      slice,
+    );
+  }
+
+  setHolderCounts(
+    args.databaseUrl,
+    args.schema,
+    args.chainId,
+    work.token,
+    work.pool,
+    heldBy.length,
+  );
+
+  return {
+    token: work.token,
+    transferCount: plan.transfers.length,
+    holderCount: heldBy.length,
+    uniqueAddresses: balances.size,
+    usersWritten,
+    userAssetsWritten,
+  };
+}
+
+async function tokenPipeline(args, client, workingSet) {
+  const builder = (work) => buildPlanForToken(args, client, work);
+
+  let processed = 0;
+  let failed = 0;
+  const totals = {
+    transfers: 0,
+    holders: 0,
+    userAssets: 0,
+    users: 0,
+  };
+
+  for await (const { result: plan } of orderedPrefetch(
+    workingSet,
+    builder,
+    args.tokenConcurrency,
+  )) {
+    try {
+      const start = Date.now();
+      const res = await applyPlan(args, plan);
+      processed++;
+      totals.transfers += res.transferCount;
+      totals.holders += res.holderCount;
+      totals.userAssets += res.userAssetsWritten ?? 0;
+      totals.users += res.usersWritten ?? 0;
+      const ms = Date.now() - start;
+      console.log(
+        `${plan.work.token}  transfers=${res.transferCount}  holders=${res.holderCount}  user_assets=${res.userAssetsWritten ?? "-"}  ${ms}ms  (${processed}/${workingSet.length})`,
+      );
+    } catch (err) {
+      failed++;
+      console.error(`${plan.work.token} FAILED: ${err.message || err}`);
+    }
+  }
+
+  return { processed, failed, totals };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) return printHelp();
+  if (!args.databaseUrl) throw new Error("Missing DATABASE_URL");
+
+  const rpcUrl = resolveRpcUrl(args.chainId, args.rpcUrl);
+  const client = createPublicClient({
+    transport: http(rpcUrl, { timeout: 30_000, retryCount: 3 }),
+  });
+
+  const workingSet = psqlJson(args.databaseUrl, selectWorkingSetSql(args));
+  console.log(`Selected ${workingSet.length} token(s) to materialize.`);
+  if (workingSet.length === 0) return;
+  if (!args.apply) console.log("(dry-run; pass --apply to actually write)");
+
+  const { processed, failed, totals } = await tokenPipeline(
+    args,
+    client,
+    workingSet,
+  );
+  console.log(
+    `Done. processed=${processed} failed=${failed} transfers=${totals.transfers} holders=${totals.holders} user_assets=${totals.userAssets} users=${totals.users}`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err.stack || err.message || err);
+  process.exit(1);
+});

--- a/scripts/backfill-derc20-materialize.mjs
+++ b/scripts/backfill-derc20-materialize.mjs
@@ -212,7 +212,7 @@ select coalesce(json_agg(q), '[]'::json) from (
 
 function selectTransfersSql(schema, chainId, token) {
   return `
-select coalesce(json_agg(q order by (q->>'block_number')::numeric, (q->>'log_index')::int), '[]'::json) from (
+select coalesce(json_agg(q), '[]'::json) from (
   select block_number::text as block_number,
          log_index,
          topic1,
@@ -222,6 +222,7 @@ select coalesce(json_agg(q order by (q->>'block_number')::numeric, (q->>'log_ind
   where chain_id = ${Number(chainId)}
     and lower(address) = ${ql(token)}
     and topic0 = ${ql(TRANSFER_SELECTOR)}
+  order by block_number, log_index
 ) q;`;
 }
 

--- a/scripts/backfill-derc20-materialize.mjs
+++ b/scripts/backfill-derc20-materialize.mjs
@@ -212,18 +212,35 @@ select coalesce(json_agg(q), '[]'::json) from (
 
 function selectTransfersSql(schema, chainId, token) {
   return `
-select coalesce(json_agg(q), '[]'::json) from (
-  select block_number::text as block_number,
-         log_index,
-         topic1,
-         topic2,
-         data
-  from ${schema}.logs
-  where chain_id = ${Number(chainId)}
-    and lower(address) = ${ql(token)}
-    and topic0 = ${ql(TRANSFER_SELECTOR)}
-  order by block_number, log_index
-) q;`;
+select block_number::text || E'\\t' || log_index::text || E'\\t' || topic1 || E'\\t' || topic2 || E'\\t' || data
+from ${schema}.logs
+where chain_id = ${Number(chainId)}
+  and lower(address) = ${ql(token)}
+  and topic0 = ${ql(TRANSFER_SELECTOR)}
+order by block_number, log_index;`;
+}
+
+function psqlRowsTsv(databaseUrl, sql) {
+  const stdout = execFileSync(
+    "psql",
+    [databaseUrl, "-X", "-A", "-t", "-v", "ON_ERROR_STOP=1", "-c", sql],
+    { encoding: "utf8", maxBuffer: 1024 * 1024 * 1024 },
+  );
+  const lines = stdout.split("\n");
+  const rows = [];
+  for (const line of lines) {
+    if (!line) continue;
+    const parts = line.split("\t");
+    if (parts.length < 5) continue;
+    rows.push({
+      block_number: parts[0],
+      log_index: Number(parts[1]),
+      topic1: parts[2],
+      topic2: parts[3],
+      data: parts[4],
+    });
+  }
+  return rows;
 }
 
 async function* orderedPrefetch(items, fetcher, concurrency) {
@@ -372,7 +389,7 @@ async function buildPlanForToken(args, client, work) {
     args.chainId,
     work.token,
   );
-  const transfers = psqlJson(args.databaseUrl, transfersSql);
+  const transfers = psqlRowsTsv(args.databaseUrl, transfersSql);
 
   if (transfers.length === 0) {
     return {

--- a/scripts/backfill-derc20-materialize.mjs
+++ b/scripts/backfill-derc20-materialize.mjs
@@ -346,7 +346,8 @@ function writeUserAssetBatch(databaseUrl, schema, rows) {
   if (rows.length === 0) return 0;
   const values = buildUserAssetValues(rows);
   const sql = `
-set session_replication_role = replica;
+begin;
+alter table ${schema}.user_asset disable trigger user;
 insert into ${schema}.user_asset (chain_id, user_id, asset_id, balance, created_at, last_interaction)
 values
 ${values}
@@ -354,6 +355,8 @@ on conflict (user_id, asset_id, chain_id) do update set
   balance = excluded.balance,
   last_interaction = greatest(${schema}.user_asset.last_interaction, excluded.last_interaction)
 returning 1;
+alter table ${schema}.user_asset enable trigger user;
+commit;
 `;
   return psqlReturning1(databaseUrl, sql);
 }
@@ -362,27 +365,35 @@ function writeUsersBatch(databaseUrl, schema, rows) {
   if (rows.length === 0) return 0;
   const values = buildUserValues(rows);
   const sql = `
-set session_replication_role = replica;
+begin;
+alter table ${schema}."user" disable trigger user;
 insert into ${schema}."user" (address, chain_id, created_at, last_seen_at)
 values
 ${values}
 on conflict (address, chain_id) do update set
   last_seen_at = greatest(${schema}."user".last_seen_at, excluded.last_seen_at)
 returning 1;
+alter table ${schema}."user" enable trigger user;
+commit;
 `;
   return psqlReturning1(databaseUrl, sql);
 }
 
 function setHolderCounts(databaseUrl, schema, chainId, token, pool, holderCount) {
   const parts = [
-    "set session_replication_role = replica;",
+    "begin;",
+    `alter table ${schema}.token disable trigger user;`,
     `update ${schema}.token set holder_count = ${Number(holderCount)} where lower(address) = ${ql(token)} and chain_id = ${Number(chainId)};`,
+    `alter table ${schema}.token enable trigger user;`,
   ];
   if (pool) {
     parts.push(
+      `alter table ${schema}.pool disable trigger user;`,
       `update ${schema}.pool set holder_count = ${Number(holderCount)} where lower(address) = ${ql(pool)} and chain_id = ${Number(chainId)};`,
+      `alter table ${schema}.pool enable trigger user;`,
     );
   }
+  parts.push("commit;");
   psqlExec(databaseUrl, parts.join("\n"));
 }
 

--- a/scripts/backfill-derc20-transfers.mjs
+++ b/scripts/backfill-derc20-transfers.mjs
@@ -1,0 +1,399 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import process from "node:process";
+import { createPublicClient, http } from "viem";
+
+const TRANSFER_SELECTOR =
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+const RPC_ENV_BY_CHAIN = {
+  1: ["PONDER_RPC_URL_1", "MAINNET_RPC"],
+  130: ["PONDER_RPC_URL_130", "UNICHAIN_RPC"],
+  143: ["PONDER_RPC_URL_143", "MONAD_RPC"],
+  8453: ["PONDER_RPC_URL_8453", "BASE_RPC", "BASE_RPC_URL"],
+  57073: ["PONDER_RPC_URL_57073", "INK_RPC"],
+};
+
+function loadDotEnv(path) {
+  if (!existsSync(path)) return;
+  for (const rawLine of readFileSync(path, "utf8").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const m = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (!m) continue;
+    const [, key, rawValue] = m;
+    if (process.env[key] !== undefined) continue;
+    process.env[key] = rawValue.trim().replace(/^(['"])(.*)\1$/, "$2");
+  }
+}
+
+loadDotEnv(resolve(process.cwd(), ".env"));
+loadDotEnv(resolve(process.cwd(), ".env.local"));
+
+function parseArgs(argv) {
+  const args = {
+    apply: false,
+    chainId: 8453,
+    factoryId: 640791,
+    schema: "prod_1",
+    pondersyncSchema: "ponder_sync",
+    databaseUrl: process.env.DATABASE_URL,
+    rpcUrl: undefined,
+    windowSize: 5000,
+    rpcConcurrency: 4,
+    tokenConcurrency: 4,
+    batchSize: 1000,
+    limit: undefined,
+    token: undefined,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--") continue;
+    if (a === "--help" || a === "-h") args.help = true;
+    else if (a === "--apply") args.apply = true;
+    else if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const v = argv[++i];
+      if (v === undefined || v.startsWith("--"))
+        throw new Error(`Missing value for ${a}`);
+      if (key === "database-url") args.databaseUrl = v;
+      else if (key === "rpc-url") args.rpcUrl = v;
+      else if (key === "chain-id") args.chainId = Number(v);
+      else if (key === "factory-id") args.factoryId = Number(v);
+      else if (key === "schema") args.schema = v;
+      else if (key === "ponder-sync-schema") args.pondersyncSchema = v;
+      else if (key === "window-size") args.windowSize = Number(v);
+      else if (key === "rpc-concurrency") args.rpcConcurrency = Number(v);
+      else if (key === "token-concurrency") args.tokenConcurrency = Number(v);
+      else if (key === "batch-size") args.batchSize = Number(v);
+      else if (key === "limit") args.limit = Number(v);
+      else if (key === "token") args.token = v.toLowerCase();
+      else throw new Error(`Unknown argument ${a}`);
+    } else throw new Error(`Unknown argument ${a}`);
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/backfill-derc20-transfers.mjs [options]
+
+Stage 1 of the DERC20 backfill. For each DERC20 contract present in
+ponder_sync.factory_addresses but with no Transfer rows yet in
+ponder_sync.logs, this script:
+
+  1. Looks up the deploy block from factory_addresses.
+  2. Fetches all Transfer logs from RPC in --window-size chunks, with
+     --rpc-concurrency in flight (per token). Windows stream into the DB
+     writer in order so the next RPC window is fetched while the previous
+     window's INSERTs are in flight.
+  3. INSERTs raw logs into ponder_sync.logs (idempotent on PK).
+
+Does NOT touch any prod_<schema> table. Run backfill-derc20-materialize.mjs
+afterwards to derive holder_count / user / user_asset from the now-present
+Transfer rows.
+
+Options:
+  --chain-id <id>            EVM chain id. Default 8453.
+  --factory-id <n>           Source factory id. Default 640791.
+  --schema <name>            Materialized indexer schema. Default prod_1.
+  --ponder-sync-schema <s>   Sync schema name. Default ponder_sync.
+  --rpc-url <url>            RPC URL. Default \$BASE_RPC_URL etc.
+  --database-url <url>       Postgres URL. Default \$DATABASE_URL.
+  --window-size <n>          Blocks per eth_getLogs request. Default 5000.
+  --rpc-concurrency <n>      Window fetches in flight per token. Default 4.
+  --token-concurrency <n>    Tokens processed in parallel. Default 4.
+  --batch-size <n>           Rows per DB INSERT batch. Default 1000.
+  --limit <n>                Process at most N tokens (after filtering).
+  --token <0x...>            Process exactly one token (ignores filters).
+  --apply                    Actually write. Default is dry-run.
+`);
+}
+
+function ql(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function lowerHex(value) {
+  return value == null ? null : String(value).toLowerCase();
+}
+
+function topicToAddress(topic) {
+  const hex = topic.startsWith("0x") ? topic.slice(2) : topic;
+  return `0x${hex.slice(24).toLowerCase()}`;
+}
+
+function resolveRpcUrl(chainId, override) {
+  if (override) return override;
+  for (const name of RPC_ENV_BY_CHAIN[chainId] ?? []) {
+    if (process.env[name]) return process.env[name];
+  }
+  throw new Error(
+    `No RPC URL found for chain ${chainId}. Set --rpc-url or one of ${(RPC_ENV_BY_CHAIN[chainId] ?? []).join(", ")}.`,
+  );
+}
+
+function psqlJson(databaseUrl, sql) {
+  const out = execFileSync(
+    "psql",
+    [databaseUrl, "-X", "-A", "-t", "-v", "ON_ERROR_STOP=1", "-c", sql],
+    { encoding: "utf8", maxBuffer: 1024 * 1024 * 512 },
+  ).trim();
+  return JSON.parse(out || "[]");
+}
+
+function psqlReturning1(databaseUrl, sql) {
+  const stdout = execFileSync(
+    "psql",
+    [databaseUrl, "-X", "-A", "-t", "-v", "ON_ERROR_STOP=1", "-c", sql],
+    { encoding: "utf8", maxBuffer: 1024 * 1024 * 512 },
+  );
+  return stdout.split("\n").filter((line) => line.trim() === "1").length;
+}
+
+function selectWorkingSetSql(args) {
+  const fa = `${args.pondersyncSchema}.factory_addresses`;
+  const tok = `${args.schema}.token`;
+  const logs = `${args.pondersyncSchema}.logs`;
+
+  if (args.token) {
+    return `
+select coalesce(json_agg(q), '[]'::json) from (
+  select lower(t.address) as token,
+         t.chain_id::int as chain_id,
+         coalesce(fa.block_number, 0)::text as deploy_block,
+         lower(t.pool) as pool
+  from ${tok} t
+  left join ${fa} fa
+    on fa.factory_id = ${Number(args.factoryId)}
+   and fa.chain_id = t.chain_id
+   and lower(fa.address) = lower(t.address)
+  where lower(t.address) = ${ql(args.token)} and t.chain_id = ${Number(args.chainId)}
+) q;`;
+  }
+
+  const limit = args.limit ? `limit ${Number(args.limit)}` : "";
+  return `
+select coalesce(json_agg(q), '[]'::json) from (
+  select lower(t.address) as token,
+         t.chain_id::int as chain_id,
+         fa.block_number::text as deploy_block,
+         lower(t.pool) as pool
+  from ${fa} fa
+  join ${tok} t
+    on lower(t.address) = lower(fa.address) and t.chain_id = fa.chain_id
+  where fa.factory_id = ${Number(args.factoryId)}
+    and fa.chain_id = ${Number(args.chainId)}
+    and not exists (
+      select 1 from ${logs} l
+      where l.chain_id = fa.chain_id
+        and lower(l.address) = lower(fa.address)
+        and l.topic0 = ${ql(TRANSFER_SELECTOR)}
+    )
+  order by fa.block_number
+  ${limit}
+) q;`;
+}
+
+function makeWindows(fromBlock, toBlock, size) {
+  const sz = BigInt(size);
+  const out = [];
+  for (let f = fromBlock; f <= toBlock; f += sz) {
+    const t = f + sz - 1n > toBlock ? toBlock : f + sz - 1n;
+    out.push({ from: f, to: t });
+  }
+  return out;
+}
+
+async function* orderedPrefetch(items, fetcher, concurrency) {
+  const inflight = [];
+  let i = 0;
+  const start = (idx) => ({ item: items[idx], promise: fetcher(items[idx]) });
+  while (i < items.length && inflight.length < concurrency) {
+    inflight.push(start(i));
+    i++;
+  }
+  while (inflight.length > 0) {
+    const next = inflight.shift();
+    const result = await next.promise;
+    if (i < items.length) {
+      inflight.push(start(i));
+      i++;
+    }
+    yield { item: next.item, result };
+  }
+}
+
+async function fetchTransferRange(client, token, fromBlock, toBlock, attempts = 4) {
+  let lastErr;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      return await client.request({
+        method: "eth_getLogs",
+        params: [
+          {
+            address: token,
+            topics: [TRANSFER_SELECTOR],
+            fromBlock: `0x${fromBlock.toString(16)}`,
+            toBlock: `0x${toBlock.toString(16)}`,
+          },
+        ],
+      });
+    } catch (err) {
+      lastErr = err;
+      await new Promise((r) => setTimeout(r, 300 * 2 ** attempt));
+    }
+  }
+  throw lastErr;
+}
+
+function buildLogRowsValues(rows) {
+  return rows
+    .map(
+      (r) =>
+        `(${ql(r.address)}, ${ql(r.blockHash)}, ${r.blockNumber.toString()}, ${Number(r.chainId)}, ${ql(r.data)}, ${Number(r.logIndex)}, ${ql(r.topic0)}, ${r.topic1 ? ql(r.topic1) : "NULL"}, ${r.topic2 ? ql(r.topic2) : "NULL"}, ${r.topic3 ? ql(r.topic3) : "NULL"}, ${ql(r.transactionHash)}, ${Number(r.transactionIndex)})`,
+    )
+    .join(",\n");
+}
+
+function insertLogsBatch(databaseUrl, schema, rows) {
+  if (rows.length === 0) return 0;
+  const values = buildLogRowsValues(rows);
+  const sql = `
+insert into ${schema}.logs (address, block_hash, block_number, chain_id, data, log_index, topic0, topic1, topic2, topic3, transaction_hash, transaction_index)
+values
+${values}
+on conflict (chain_id, block_number, log_index) do nothing
+returning 1;
+`;
+  return psqlReturning1(databaseUrl, sql);
+}
+
+async function processToken(args, client, work) {
+  const head = await client.getBlockNumber();
+  const deployBlock = BigInt(work.deploy_block);
+  if (deployBlock === 0n) {
+    throw new Error(`Token ${work.token} has no deploy_block in factory_addresses; run airlock backfill first.`);
+  }
+  const windows = makeWindows(deployBlock, head, args.windowSize);
+
+  let buffer = [];
+  let transferCount = 0;
+  let logsWritten = 0;
+
+  const fetcher = (w) => fetchTransferRange(client, work.token, w.from, w.to);
+
+  const flushIfFull = () => {
+    if (!args.apply) {
+      buffer = [];
+      return;
+    }
+    while (buffer.length >= args.batchSize) {
+      const slice = buffer.splice(0, args.batchSize);
+      logsWritten += insertLogsBatch(args.databaseUrl, args.pondersyncSchema, slice);
+    }
+  };
+
+  const flushFinal = () => {
+    if (!args.apply) return;
+    while (buffer.length > 0) {
+      const slice = buffer.splice(0, args.batchSize);
+      logsWritten += insertLogsBatch(args.databaseUrl, args.pondersyncSchema, slice);
+    }
+  };
+
+  for await (const { result: logs } of orderedPrefetch(
+    windows,
+    fetcher,
+    args.rpcConcurrency,
+  )) {
+    for (const log of logs) {
+      transferCount++;
+      buffer.push({
+        address: lowerHex(log.address),
+        blockHash: lowerHex(log.blockHash),
+        blockNumber: BigInt(log.blockNumber),
+        chainId: args.chainId,
+        data: log.data,
+        logIndex: Number(log.logIndex),
+        topic0: lowerHex(log.topics[0]),
+        topic1: log.topics[1] ? lowerHex(log.topics[1]) : null,
+        topic2: log.topics[2] ? lowerHex(log.topics[2]) : null,
+        topic3: log.topics[3] ? lowerHex(log.topics[3]) : null,
+        transactionHash: lowerHex(log.transactionHash),
+        transactionIndex: Number(log.transactionIndex),
+      });
+    }
+    flushIfFull();
+  }
+
+  flushFinal();
+
+  return {
+    token: work.token,
+    transferCount,
+    logsWritten,
+    windows: windows.length,
+  };
+}
+
+async function tokenPool(args, client, workingSet, concurrency) {
+  let processed = 0;
+  let failed = 0;
+  let totalTransfers = 0;
+  let totalLogs = 0;
+  const queue = workingSet.slice();
+
+  async function worker(id) {
+    while (queue.length > 0) {
+      const work = queue.shift();
+      if (!work) return;
+      try {
+        const start = Date.now();
+        const result = await processToken(args, client, work);
+        processed++;
+        totalTransfers += result.transferCount;
+        totalLogs += result.logsWritten;
+        const ms = Date.now() - start;
+        console.log(
+          `[w${id}] ${work.token}  transfers=${result.transferCount}  logs_written=${result.logsWritten}  windows=${result.windows}  ${ms}ms  (${processed}/${workingSet.length})`,
+        );
+      } catch (err) {
+        failed++;
+        console.error(`[w${id}] ${work.token} FAILED: ${err.message || err}`);
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: concurrency }, (_, i) => worker(i)));
+  return { processed, failed, totalTransfers, totalLogs };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) return printHelp();
+  if (!args.databaseUrl) throw new Error("Missing DATABASE_URL");
+
+  const rpcUrl = resolveRpcUrl(args.chainId, args.rpcUrl);
+  const client = createPublicClient({
+    transport: http(rpcUrl, { timeout: 30_000, retryCount: 3 }),
+  });
+
+  const workingSet = psqlJson(args.databaseUrl, selectWorkingSetSql(args));
+  console.log(`Selected ${workingSet.length} token(s) to fetch transfers for.`);
+  if (workingSet.length === 0) return;
+  if (!args.apply) console.log("(dry-run; pass --apply to actually write)");
+
+  const totals = await tokenPool(args, client, workingSet, args.tokenConcurrency);
+  console.log(
+    `Done. processed=${totals.processed} failed=${totals.failed} transfers=${totals.totalTransfers} ponder_sync_logs_written=${totals.totalLogs}`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err.stack || err.message || err);
+  process.exit(1);
+});

--- a/scripts/backfill-derc20-transfers.mjs
+++ b/scripts/backfill-derc20-transfers.mjs
@@ -13,8 +13,22 @@ const RPC_ENV_BY_CHAIN = {
   1: ["PONDER_RPC_URL_1", "MAINNET_RPC"],
   130: ["PONDER_RPC_URL_130", "UNICHAIN_RPC"],
   143: ["PONDER_RPC_URL_143", "MONAD_RPC"],
+  4663: ["PONDER_RPC_URL_4663", "ROBINHOOD_RPC"],
   8453: ["PONDER_RPC_URL_8453", "BASE_RPC", "BASE_RPC_URL"],
   57073: ["PONDER_RPC_URL_57073", "INK_RPC"],
+};
+
+// Last-resort public endpoints for chains where one exists. Rate-limited
+// (robinhood: 10k logs per eth_getLogs, aggressive 429s) — prefer a private
+// RPC via the env vars above for large backfills.
+const PUBLIC_RPC_BY_CHAIN = {
+  4663: "https://rpc.mainnet.chain.robinhood.com",
+};
+
+// ponder_sync.factories.id of the airlock Create (DERC20 asset) factory.
+const FACTORY_ID_BY_CHAIN = {
+  8453: 640791,
+  4663: 827059,
 };
 
 function loadDotEnv(path) {
@@ -37,7 +51,7 @@ function parseArgs(argv) {
   const args = {
     apply: false,
     chainId: 8453,
-    factoryId: 640791,
+    factoryId: undefined,
     schema: "prod_1",
     pondersyncSchema: "ponder_sync",
     databaseUrl: process.env.DATABASE_URL,
@@ -78,6 +92,9 @@ function parseArgs(argv) {
       else throw new Error(`Unknown argument ${a}`);
     } else throw new Error(`Unknown argument ${a}`);
   }
+  args.factoryId ??= FACTORY_ID_BY_CHAIN[args.chainId];
+  if (!args.help && args.factoryId === undefined)
+    throw new Error(`No --factory-id and no default for chain ${args.chainId}`);
   return args;
 }
 
@@ -102,10 +119,12 @@ Transfer rows.
 
 Options:
   --chain-id <id>            EVM chain id. Default 8453.
-  --factory-id <n>           Source factory id. Default 640791.
+  --factory-id <n>           Source factory id. Default per-chain
+                             (8453 -> 640791, 4663 -> 827059).
   --schema <name>            Materialized indexer schema. Default prod_1.
   --ponder-sync-schema <s>   Sync schema name. Default ponder_sync.
-  --rpc-url <url>            RPC URL. Default \$BASE_RPC_URL etc.
+  --rpc-url <url>            RPC URL. Default \$BASE_RPC_URL etc; falls back
+                             to a public endpoint where one is known.
   --database-url <url>       Postgres URL. Default \$DATABASE_URL.
   --window-size <n>          Blocks per eth_getLogs request. Default 5000.
   --rpc-concurrency <n>      Window fetches in flight per token. Default 4.
@@ -146,6 +165,12 @@ function resolveRpcUrl(chainId, override) {
   if (override) return override;
   for (const name of RPC_ENV_BY_CHAIN[chainId] ?? []) {
     if (process.env[name]) return process.env[name];
+  }
+  if (PUBLIC_RPC_BY_CHAIN[chainId]) {
+    console.warn(
+      `No RPC env var set for chain ${chainId}; using rate-limited public endpoint ${PUBLIC_RPC_BY_CHAIN[chainId]}.`,
+    );
+    return PUBLIC_RPC_BY_CHAIN[chainId];
   }
   throw new Error(
     `No RPC URL found for chain ${chainId}. Set --rpc-url or one of ${(RPC_ENV_BY_CHAIN[chainId] ?? []).join(", ")}.`,

--- a/scripts/backfill-derc20-transfers.mjs
+++ b/scripts/backfill-derc20-transfers.mjs
@@ -148,8 +148,13 @@ function psqlJson(databaseUrl, sql) {
 function psqlReturning1(databaseUrl, sql) {
   const stdout = execFileSync(
     "psql",
-    [databaseUrl, "-X", "-A", "-t", "-v", "ON_ERROR_STOP=1", "-c", sql],
-    { encoding: "utf8", maxBuffer: 1024 * 1024 * 512 },
+    [databaseUrl, "-X", "-A", "-t", "-v", "ON_ERROR_STOP=1"],
+    {
+      input: sql,
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024 * 512,
+      stdio: ["pipe", "pipe", "inherit"],
+    },
   );
   return stdout.split("\n").filter((line) => line.trim() === "1").length;
 }

--- a/scripts/backfill-derc20-transfers.mjs
+++ b/scripts/backfill-derc20-transfers.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import process from "node:process";
 import { createPublicClient, http } from "viem";
@@ -48,6 +48,8 @@ function parseArgs(argv) {
     batchSize: 1000,
     limit: undefined,
     token: undefined,
+    checkpoint: resolve(process.cwd(), "backfill-derc20-transfers.checkpoint.json"),
+    saveIntervalMs: 5000,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -71,6 +73,8 @@ function parseArgs(argv) {
       else if (key === "batch-size") args.batchSize = Number(v);
       else if (key === "limit") args.limit = Number(v);
       else if (key === "token") args.token = v.toLowerCase();
+      else if (key === "checkpoint") args.checkpoint = resolve(v);
+      else if (key === "save-interval-ms") args.saveIntervalMs = Number(v);
       else throw new Error(`Unknown argument ${a}`);
     } else throw new Error(`Unknown argument ${a}`);
   }
@@ -109,7 +113,19 @@ Options:
   --batch-size <n>           Rows per DB INSERT batch. Default 1000.
   --limit <n>                Process at most N tokens (after filtering).
   --token <0x...>            Process exactly one token (ignores filters).
+  --checkpoint <path>        On-disk checkpoint JSON. Default
+                             ./backfill-derc20-transfers.checkpoint.json.
+                             Tracks per-token covered_to block so a restart
+                             skips windows already fetched + written.
+  --save-interval-ms <n>     Min ms between checkpoint flushes. Default 5000.
   --apply                    Actually write. Default is dry-run.
+
+Checkpoint behavior:
+  - On restart, tokens with covered_to >= head_at_start are skipped entirely.
+  - Tokens with a partial covered_to resume from covered_to + 1, regardless
+    of whether Transfer rows already exist for them (which lets us complete
+    tokens that were interrupted mid-run after their first batches landed).
+  - SIGINT triggers a final checkpoint save before exit.
 `);
 }
 
@@ -157,6 +173,83 @@ function psqlReturning1(databaseUrl, sql) {
     },
   );
   return stdout.split("\n").filter((line) => line.trim() === "1").length;
+}
+
+function loadCheckpoint(path) {
+  if (!existsSync(path)) {
+    return { version: 1, tokens: {} };
+  }
+  const raw = readFileSync(path, "utf8");
+  if (!raw.trim()) return { version: 1, tokens: {} };
+  const parsed = JSON.parse(raw);
+  if (!parsed.tokens || typeof parsed.tokens !== "object") {
+    return { version: 1, tokens: {} };
+  }
+  return parsed;
+}
+
+const checkpointState = {
+  path: null,
+  data: null,
+  dirty: false,
+  lastSave: 0,
+  saving: false,
+  intervalMs: 5000,
+};
+
+function setCheckpointState(path, data, intervalMs) {
+  checkpointState.path = path;
+  checkpointState.data = data;
+  checkpointState.intervalMs = intervalMs;
+  checkpointState.lastSave = Date.now();
+}
+
+function saveCheckpointNow() {
+  if (!checkpointState.path || !checkpointState.data) return;
+  if (checkpointState.saving) return;
+  checkpointState.saving = true;
+  try {
+    const tmp = `${checkpointState.path}.tmp`;
+    writeFileSync(tmp, JSON.stringify(checkpointState.data, null, 2));
+    renameSync(tmp, checkpointState.path);
+    checkpointState.dirty = false;
+    checkpointState.lastSave = Date.now();
+  } finally {
+    checkpointState.saving = false;
+  }
+}
+
+function maybeSaveCheckpoint() {
+  if (!checkpointState.dirty) return;
+  if (Date.now() - checkpointState.lastSave < checkpointState.intervalMs) return;
+  saveCheckpointNow();
+}
+
+function updateTokenCheckpoint(token, patch) {
+  const cur = checkpointState.data.tokens[token] ?? {};
+  checkpointState.data.tokens[token] = { ...cur, ...patch };
+  checkpointState.dirty = true;
+}
+
+function selectInProgressTokensSql(args, tokens) {
+  if (tokens.length === 0) return null;
+  const fa = `${args.pondersyncSchema}.factory_addresses`;
+  const tok = `${args.schema}.token`;
+  const list = tokens.map((t) => ql(t)).join(", ");
+  return `
+select coalesce(json_agg(q), '[]'::json) from (
+  select lower(t.address) as token,
+         t.chain_id::int as chain_id,
+         fa.block_number::text as deploy_block,
+         lower(t.pool) as pool
+  from ${tok} t
+  join ${fa} fa
+    on fa.factory_id = ${Number(args.factoryId)}
+   and fa.chain_id = t.chain_id
+   and lower(fa.address) = lower(t.address)
+  where t.chain_id = ${Number(args.chainId)}
+    and lower(t.address) in (${list})
+) q;`;
 }
 
 function selectWorkingSetSql(args) {
@@ -285,39 +378,65 @@ async function processToken(args, client, work) {
   if (deployBlock === 0n) {
     throw new Error(`Token ${work.token} has no deploy_block in factory_addresses; run airlock backfill first.`);
   }
-  const windows = makeWindows(deployBlock, head, args.windowSize);
+
+  const ckptEntry = checkpointState.data.tokens[work.token] ?? {};
+  const coveredTo = ckptEntry.covered_to ? BigInt(ckptEntry.covered_to) : null;
+  const resumeFrom = coveredTo !== null && coveredTo + 1n > deployBlock
+    ? coveredTo + 1n
+    : deployBlock;
+
+  if (resumeFrom > head) {
+    log(`already covered to ${coveredTo} (>= head ${head}); marking complete`);
+    updateTokenCheckpoint(work.token, {
+      covered_to: head.toString(),
+      head_at_complete: head.toString(),
+      completed: true,
+    });
+    saveCheckpointNow();
+    return { token: work.token, transferCount: 0, logsWritten: 0, windows: 0, resumed: true };
+  }
+
+  const windows = makeWindows(resumeFrom, head, args.windowSize);
   log(
-    `${windows.length} windows from block ${deployBlock} to ${head} (size=${args.windowSize})`,
+    `${windows.length} windows from block ${resumeFrom} to ${head} (size=${args.windowSize})` +
+      (coveredTo !== null ? ` [resuming from checkpoint covered_to=${coveredTo}]` : ""),
   );
+
+  updateTokenCheckpoint(work.token, {
+    deploy_block: deployBlock.toString(),
+    head_at_start: head.toString(),
+    completed: false,
+  });
 
   let buffer = [];
   let transferCount = 0;
   let logsWritten = 0;
   let windowsDone = 0;
   let lastReport = Date.now();
+  // Index of the most-recent window whose logs have been appended to buffer.
+  // After a full flush, every log in buffer up to and including this window
+  // is durably in the DB, so covered_to safely advances to windows[this].to.
+  let pendingWindowIndex = -1;
 
   const fetcher = (w) => fetchTransferRange(client, work.token, w.from, w.to);
 
-  const flushIfFull = () => {
+  const flushAll = () => {
     if (!args.apply) {
       buffer = [];
       return;
     }
-    while (buffer.length >= args.batchSize) {
-      const slice = buffer.splice(0, args.batchSize);
-      logsWritten += insertLogsBatch(args.databaseUrl, args.pondersyncSchema, slice);
-    }
-  };
-
-  const flushFinal = () => {
-    if (!args.apply) return;
     while (buffer.length > 0) {
       const slice = buffer.splice(0, args.batchSize);
       logsWritten += insertLogsBatch(args.databaseUrl, args.pondersyncSchema, slice);
     }
   };
 
-  for await (const { result: logs } of orderedPrefetch(
+  const advanceCheckpointTo = (toBlock) => {
+    updateTokenCheckpoint(work.token, { covered_to: toBlock.toString() });
+    maybeSaveCheckpoint();
+  };
+
+  for await (const { item: window, result: logs } of orderedPrefetch(
     windows,
     fetcher,
     args.rpcConcurrency,
@@ -339,8 +458,14 @@ async function processToken(args, client, work) {
         transactionIndex: Number(entry.transactionIndex),
       });
     }
-    flushIfFull();
     windowsDone++;
+    pendingWindowIndex = windowsDone - 1;
+
+    if (buffer.length >= args.batchSize) {
+      flushAll();
+      advanceCheckpointTo(windows[pendingWindowIndex].to);
+    }
+
     if (Date.now() - lastReport > 5000) {
       log(
         `windows ${windowsDone}/${windows.length}  transfers=${transferCount}  logs_written=${logsWritten}`,
@@ -349,7 +474,16 @@ async function processToken(args, client, work) {
     }
   }
 
-  flushFinal();
+  flushAll();
+  if (windowsDone > 0) {
+    advanceCheckpointTo(windows[windowsDone - 1].to);
+  }
+  updateTokenCheckpoint(work.token, {
+    covered_to: head.toString(),
+    head_at_complete: head.toString(),
+    completed: true,
+  });
+  saveCheckpointNow();
 
   return {
     token: work.token,
@@ -396,17 +530,76 @@ async function main() {
   if (args.help) return printHelp();
   if (!args.databaseUrl) throw new Error("Missing DATABASE_URL");
 
+  const checkpoint = loadCheckpoint(args.checkpoint);
+  setCheckpointState(args.checkpoint, checkpoint, args.saveIntervalMs);
+  console.log(`Checkpoint: ${args.checkpoint} (${Object.keys(checkpoint.tokens).length} tokens tracked)`);
+
+  process.on("SIGINT", () => {
+    console.log("\nSIGINT received — saving checkpoint and exiting.");
+    try {
+      saveCheckpointNow();
+    } catch (err) {
+      console.error(`checkpoint save failed: ${err.message || err}`);
+    }
+    process.exit(130);
+  });
+  process.on("SIGTERM", () => {
+    console.log("\nSIGTERM received — saving checkpoint and exiting.");
+    try {
+      saveCheckpointNow();
+    } catch (err) {
+      console.error(`checkpoint save failed: ${err.message || err}`);
+    }
+    process.exit(143);
+  });
+
   const rpcUrl = resolveRpcUrl(args.chainId, args.rpcUrl);
   const client = createPublicClient({
     transport: http(rpcUrl, { timeout: 30_000, retryCount: 3 }),
   });
 
-  const workingSet = psqlJson(args.databaseUrl, selectWorkingSetSql(args));
-  console.log(`Selected ${workingSet.length} token(s) to fetch transfers for.`);
-  if (workingSet.length === 0) return;
+  const sqlSet = psqlJson(args.databaseUrl, selectWorkingSetSql(args));
+
+  // Pull in tokens already in the checkpoint that aren't completed but
+  // wouldn't be re-selected by the SQL (because they already have Transfer
+  // rows from the prior partial run). Without this they'd be silently skipped.
+  const sqlTokens = new Set(sqlSet.map((w) => w.token));
+  const ckptInProgress = Object.entries(checkpoint.tokens)
+    .filter(([addr, entry]) => !entry.completed && !sqlTokens.has(addr))
+    .map(([addr]) => addr);
+
+  let mergedSet = sqlSet;
+  if (ckptInProgress.length > 0 && !args.token) {
+    const sql = selectInProgressTokensSql(args, ckptInProgress);
+    if (sql) {
+      const extra = psqlJson(args.databaseUrl, sql);
+      mergedSet = sqlSet.concat(extra);
+      console.log(
+        `Added ${extra.length} in-progress token(s) from checkpoint to the working set.`,
+      );
+    }
+  }
+
+  // Drop tokens already marked complete in the checkpoint.
+  const beforeCkptFilter = mergedSet.length;
+  mergedSet = mergedSet.filter(
+    (w) => !(checkpoint.tokens[w.token]?.completed === true),
+  );
+  const skippedCompleted = beforeCkptFilter - mergedSet.length;
+  if (skippedCompleted > 0) {
+    console.log(`Skipping ${skippedCompleted} token(s) already marked completed in checkpoint.`);
+  }
+
+  console.log(`Selected ${mergedSet.length} token(s) to fetch transfers for.`);
+  if (mergedSet.length === 0) return;
   if (!args.apply) console.log("(dry-run; pass --apply to actually write)");
 
-  const totals = await tokenPool(args, client, workingSet, args.tokenConcurrency);
+  let totals;
+  try {
+    totals = await tokenPool(args, client, mergedSet, args.tokenConcurrency);
+  } finally {
+    saveCheckpointNow();
+  }
   console.log(
     `Done. processed=${totals.processed} failed=${totals.failed} transfers=${totals.totalTransfers} ponder_sync_logs_written=${totals.totalLogs}`,
   );

--- a/scripts/backfill-derc20-transfers.mjs
+++ b/scripts/backfill-derc20-transfers.mjs
@@ -175,6 +175,20 @@ function psqlReturning1(databaseUrl, sql) {
   return stdout.split("\n").filter((line) => line.trim() === "1").length;
 }
 
+function psqlRowsTsv(databaseUrl, sql) {
+  const stdout = execFileSync(
+    "psql",
+    [databaseUrl, "-X", "-A", "-t", "-F", "\t", "-v", "ON_ERROR_STOP=1", "-c", sql],
+    { encoding: "utf8", maxBuffer: 1024 * 1024 * 1024 },
+  );
+  const out = [];
+  for (const line of stdout.split("\n")) {
+    if (!line) continue;
+    out.push(line.split("\t"));
+  }
+  return out;
+}
+
 function loadCheckpoint(path) {
   if (!existsSync(path)) {
     return { version: 1, tokens: {} };
@@ -231,69 +245,48 @@ function updateTokenCheckpoint(token, patch) {
   checkpointState.dirty = true;
 }
 
-function selectInProgressTokensSql(args, tokens) {
-  if (tokens.length === 0) return null;
+function selectAllCandidatesSql(args) {
   const fa = `${args.pondersyncSchema}.factory_addresses`;
   const tok = `${args.schema}.token`;
-  const list = tokens.map((t) => ql(t)).join(", ");
-  return `
-select coalesce(json_agg(q), '[]'::json) from (
-  select lower(t.address) as token,
-         t.chain_id::int as chain_id,
-         fa.block_number::text as deploy_block,
-         lower(t.pool) as pool
-  from ${tok} t
-  join ${fa} fa
-    on fa.factory_id = ${Number(args.factoryId)}
-   and fa.chain_id = t.chain_id
-   and lower(fa.address) = lower(t.address)
-  where t.chain_id = ${Number(args.chainId)}
-    and lower(t.address) in (${list})
-) q;`;
-}
-
-function selectWorkingSetSql(args) {
-  const fa = `${args.pondersyncSchema}.factory_addresses`;
-  const tok = `${args.schema}.token`;
-  const logs = `${args.pondersyncSchema}.logs`;
 
   if (args.token) {
     return `
-select coalesce(json_agg(q), '[]'::json) from (
-  select lower(t.address) as token,
-         t.chain_id::int as chain_id,
-         coalesce(fa.block_number, 0)::text as deploy_block,
-         lower(t.pool) as pool
-  from ${tok} t
-  left join ${fa} fa
-    on fa.factory_id = ${Number(args.factoryId)}
-   and fa.chain_id = t.chain_id
-   and lower(fa.address) = lower(t.address)
-  where lower(t.address) = ${ql(args.token)} and t.chain_id = ${Number(args.chainId)}
-) q;`;
+select lower(t.address),
+       t.chain_id::int,
+       coalesce(fa.block_number, 0)::text,
+       lower(coalesce(t.pool, ''))
+from ${tok} t
+left join ${fa} fa
+  on fa.factory_id = ${Number(args.factoryId)}
+ and fa.chain_id = t.chain_id
+ and lower(fa.address) = lower(t.address)
+where lower(t.address) = ${ql(args.token)} and t.chain_id = ${Number(args.chainId)};`;
   }
 
   const limit = args.limit ? `limit ${Number(args.limit)}` : "";
   return `
-select coalesce(json_agg(q), '[]'::json) from (
-  select lower(t.address) as token,
-         t.chain_id::int as chain_id,
-         fa.block_number::text as deploy_block,
-         lower(t.pool) as pool
-  from ${fa} fa
-  join ${tok} t
-    on lower(t.address) = lower(fa.address) and t.chain_id = fa.chain_id
-  where fa.factory_id = ${Number(args.factoryId)}
-    and fa.chain_id = ${Number(args.chainId)}
-    and not exists (
-      select 1 from ${logs} l
-      where l.chain_id = fa.chain_id
-        and lower(l.address) = lower(fa.address)
-        and l.topic0 = ${ql(TRANSFER_SELECTOR)}
-    )
-  order by fa.block_number
-  ${limit}
-) q;`;
+select lower(t.address),
+       t.chain_id::int,
+       fa.block_number::text,
+       lower(coalesce(t.pool, ''))
+from ${fa} fa
+join ${tok} t
+  on lower(t.address) = lower(fa.address) and t.chain_id = fa.chain_id
+where fa.factory_id = ${Number(args.factoryId)}
+  and fa.chain_id = ${Number(args.chainId)}
+order by fa.block_number
+${limit};`;
+}
+
+function selectExistingTokensSql(args, tokens) {
+  if (tokens.length === 0) return null;
+  const list = tokens.map((t) => ql(t)).join(", ");
+  return `
+select distinct lower(address)
+from ${args.pondersyncSchema}.logs
+where chain_id = ${Number(args.chainId)}
+  and topic0 = ${ql(TRANSFER_SELECTOR)}
+  and lower(address) in (${list});`;
 }
 
 function makeWindows(fromBlock, toBlock, size) {
@@ -558,37 +551,73 @@ async function main() {
     transport: http(rpcUrl, { timeout: 30_000, retryCount: 3 }),
   });
 
-  const sqlSet = psqlJson(args.databaseUrl, selectWorkingSetSql(args));
+  console.log("Loading candidate set (factory_addresses ∩ token)...");
+  const candidatesRaw = psqlRowsTsv(args.databaseUrl, selectAllCandidatesSql(args));
+  const candidates = [];
+  for (const [token, chainId, deployBlock, pool] of candidatesRaw) {
+    if (!token || deployBlock === "0") continue;
+    candidates.push({
+      token,
+      chain_id: Number(chainId),
+      deploy_block: deployBlock,
+      pool: pool || null,
+    });
+  }
+  console.log(`Loaded ${candidates.length} candidate token(s).`);
 
-  // Pull in tokens already in the checkpoint that aren't completed but
-  // wouldn't be re-selected by the SQL (because they already have Transfer
-  // rows from the prior partial run). Without this they'd be silently skipped.
-  const sqlTokens = new Set(sqlSet.map((w) => w.token));
-  const ckptInProgress = Object.entries(checkpoint.tokens)
-    .filter(([addr, entry]) => !entry.completed && !sqlTokens.has(addr))
-    .map(([addr]) => addr);
-
-  let mergedSet = sqlSet;
-  if (ckptInProgress.length > 0 && !args.token) {
-    const sql = selectInProgressTokensSql(args, ckptInProgress);
-    if (sql) {
-      const extra = psqlJson(args.databaseUrl, sql);
-      mergedSet = sqlSet.concat(extra);
+  // Seed checkpoint by batched existence check. Any token that already has at
+  // least one Transfer log in ponder_sync.logs was fully handled by the live
+  // indexer (Airlock Create event was received, subscription was active), so
+  // mark it completed and skip — we only need to backfill tokens with ZERO
+  // existing Transfer logs.
+  const unseeded = args.token
+    ? candidates.filter((c) => !checkpoint.tokens[c.token])
+    : candidates.filter((c) => !checkpoint.tokens[c.token]);
+  if (unseeded.length > 0) {
+    const SEED_BATCH = 2000;
+    const batches = Math.ceil(unseeded.length / SEED_BATCH);
+    console.log(
+      `Seeding checkpoint for ${unseeded.length} token(s) in ${batches} batch(es) of ${SEED_BATCH}...`,
+    );
+    let markedCompleted = 0;
+    let markedNeedBackfill = 0;
+    for (let i = 0; i < unseeded.length; i += SEED_BATCH) {
+      const slice = unseeded.slice(i, i + SEED_BATCH);
+      const addrs = slice.map((c) => c.token);
+      const sql = selectExistingTokensSql(args, addrs);
+      const rows = sql ? psqlRowsTsv(args.databaseUrl, sql) : [];
+      const existing = new Set(rows.map(([addr]) => addr));
+      for (const c of slice) {
+        if (existing.has(c.token)) {
+          updateTokenCheckpoint(c.token, {
+            completed: true,
+            reason: "preexisting-logs",
+          });
+          markedCompleted++;
+        } else {
+          updateTokenCheckpoint(c.token, {
+            deploy_block: c.deploy_block,
+            needs_backfill: true,
+          });
+          markedNeedBackfill++;
+        }
+      }
+      maybeSaveCheckpoint();
+      const batchNum = Math.floor(i / SEED_BATCH) + 1;
       console.log(
-        `Added ${extra.length} in-progress token(s) from checkpoint to the working set.`,
+        `  batch ${batchNum}/${batches}  preexisting=${markedCompleted}  needs_backfill=${markedNeedBackfill}`,
       );
     }
+    saveCheckpointNow();
+    console.log(
+      `Seeding done. ${markedCompleted} preexisting (skipped); ${markedNeedBackfill} need backfill.`,
+    );
   }
 
-  // Drop tokens already marked complete in the checkpoint.
-  const beforeCkptFilter = mergedSet.length;
-  mergedSet = mergedSet.filter(
-    (w) => !(checkpoint.tokens[w.token]?.completed === true),
+  // Working set: every candidate not marked completed.
+  const mergedSet = candidates.filter(
+    (c) => !(checkpoint.tokens[c.token]?.completed === true),
   );
-  const skippedCompleted = beforeCkptFilter - mergedSet.length;
-  if (skippedCompleted > 0) {
-    console.log(`Skipping ${skippedCompleted} token(s) already marked completed in checkpoint.`);
-  }
 
   console.log(`Selected ${mergedSet.length} token(s) to fetch transfers for.`);
   if (mergedSet.length === 0) return;

--- a/scripts/backfill-derc20-transfers.mjs
+++ b/scripts/backfill-derc20-transfers.mjs
@@ -278,16 +278,23 @@ returning 1;
 }
 
 async function processToken(args, client, work) {
+  const log = (msg) => console.log(`  [${work.token}] ${msg}`);
+
   const head = await client.getBlockNumber();
   const deployBlock = BigInt(work.deploy_block);
   if (deployBlock === 0n) {
     throw new Error(`Token ${work.token} has no deploy_block in factory_addresses; run airlock backfill first.`);
   }
   const windows = makeWindows(deployBlock, head, args.windowSize);
+  log(
+    `${windows.length} windows from block ${deployBlock} to ${head} (size=${args.windowSize})`,
+  );
 
   let buffer = [];
   let transferCount = 0;
   let logsWritten = 0;
+  let windowsDone = 0;
+  let lastReport = Date.now();
 
   const fetcher = (w) => fetchTransferRange(client, work.token, w.from, w.to);
 
@@ -315,24 +322,31 @@ async function processToken(args, client, work) {
     fetcher,
     args.rpcConcurrency,
   )) {
-    for (const log of logs) {
+    for (const entry of logs) {
       transferCount++;
       buffer.push({
-        address: lowerHex(log.address),
-        blockHash: lowerHex(log.blockHash),
-        blockNumber: BigInt(log.blockNumber),
+        address: lowerHex(entry.address),
+        blockHash: lowerHex(entry.blockHash),
+        blockNumber: BigInt(entry.blockNumber),
         chainId: args.chainId,
-        data: log.data,
-        logIndex: Number(log.logIndex),
-        topic0: lowerHex(log.topics[0]),
-        topic1: log.topics[1] ? lowerHex(log.topics[1]) : null,
-        topic2: log.topics[2] ? lowerHex(log.topics[2]) : null,
-        topic3: log.topics[3] ? lowerHex(log.topics[3]) : null,
-        transactionHash: lowerHex(log.transactionHash),
-        transactionIndex: Number(log.transactionIndex),
+        data: entry.data,
+        logIndex: Number(entry.logIndex),
+        topic0: lowerHex(entry.topics[0]),
+        topic1: entry.topics[1] ? lowerHex(entry.topics[1]) : null,
+        topic2: entry.topics[2] ? lowerHex(entry.topics[2]) : null,
+        topic3: entry.topics[3] ? lowerHex(entry.topics[3]) : null,
+        transactionHash: lowerHex(entry.transactionHash),
+        transactionIndex: Number(entry.transactionIndex),
       });
     }
     flushIfFull();
+    windowsDone++;
+    if (Date.now() - lastReport > 5000) {
+      log(
+        `windows ${windowsDone}/${windows.length}  transfers=${transferCount}  logs_written=${logsWritten}`,
+      );
+      lastReport = Date.now();
+    }
   }
 
   flushFinal();


### PR DESCRIPTION
Extends the three ponder_sync repair scripts to Robinhood chain (4663), where `factory_addresses` is missing children whose Airlock:Create was discovered in realtime but never persisted (intervals report the factory range complete, so ponder never rediscovers them — e.g. token `0xc2362aff…94ba3`, Create at block 16864619, absent from `factory_addresses` while 260k of its raw Transfer logs sit in `ponder_sync.logs`).

**What changed**

- All three scripts: chain 4663 RPC env vars (`PONDER_RPC_URL_4663` / `ROBINHOOD_RPC`) with fallback to the public endpoint `https://rpc.mainnet.chain.robinhood.com` (rate-limited; 10k-log cap per eth_getLogs), and per-chain `--factory-id` defaults (8453 → 640791, 4663 → 827059).
- `backfill-airlock-creates.mjs`: new `--event create|migrate` flag. `create` backfills the DERC20 asset factory (child = data word 0); `migrate` backfills the MigrationPool factory (child = `pool` at topic2, selector `0x2a05bb71…`), which is exposed to the same loss mechanism. Migrate has no factory-id default — look it up in `ponder_sync.factories` and pass `--factory-id`.

**Robinhood repair sequence**

1. `node scripts/backfill-airlock-creates.mjs --chain-id 4663 --start-block 367349 --apply` (32,670 creates on-chain as of 2026-07-24; compare with `select count(*) from ponder_sync.factory_addresses where chain_id=4663 and factory_id=827059`).
2. Restart the indexer so `getChildAddresses` reloads.
3. `backfill-derc20-transfers.mjs --chain-id 4663 --apply` for tokens with zero Transfer rows; for tokens with suspected partial coverage, force a full idempotent refetch with `--token <addr>`.
4. `backfill-derc20-materialize.mjs --chain-id 4663 --apply` to rebuild user/user_asset/holder_count.

Stacked on `chore/backfill-airlock-derc20`.