### PR TITLE
fix(backfill): require explicit --schema, no prod_1 default

### DIFF
--- a/scripts/backfill-airlock-creates.mjs
+++ b/scripts/backfill-airlock-creates.mjs
@@ -92,7 +92,7 @@ function parseArgs(argv) {
     batchSize: 1000,
     rpcConcurrency: 4,
     pondersyncSchema: "ponder_sync",
-    schema: "prod_1",
+    schema: undefined,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -155,7 +155,8 @@ Options:
   --rpc-concurrency <n>      Window fetches in flight. Default 4.
   --ponder-sync-schema <s>   Sync schema name. Default ponder_sync.
   --schema <name>            Materialized schema, used to detect gaps when
-                             --start-block is omitted. Default prod_1.
+                             --start-block is omitted. Required in that case
+                             (e.g. prod_2); unused with --start-block.
   --apply                    Actually write. Default is dry-run.
 
 Default --start-block:
@@ -405,6 +406,10 @@ async function main() {
   let startBlock = args.startBlock;
   let startReason = "explicit --start-block";
   if (startBlock === undefined) {
+    if (args.event === "create" && !args.schema)
+      throw new Error(
+        "Missing required --schema (the prod schema this deployment writes, e.g. prod_2); needed for the earliest-gap heuristic when --start-block is omitted",
+      );
     // The earliest-gap heuristic scans <schema>.token for DERC20 rows, which
     // only maps to children of the Create factory.
     const earliestGap =

--- a/scripts/backfill-derc20-materialize.mjs
+++ b/scripts/backfill-derc20-materialize.mjs
@@ -53,7 +53,7 @@ function parseArgs(argv) {
     apply: false,
     chainId: 8453,
     factoryId: undefined,
-    schema: "prod_1",
+    schema: undefined,
     pondersyncSchema: "ponder_sync",
     databaseUrl: process.env.DATABASE_URL,
     rpcUrl: undefined,
@@ -89,6 +89,10 @@ function parseArgs(argv) {
       else throw new Error(`Unknown argument ${a}`);
     } else throw new Error(`Unknown argument ${a}`);
   }
+  if (!args.help && !args.schema)
+    throw new Error(
+      "Missing required --schema (the prod schema this deployment writes, e.g. prod_2)",
+    );
   args.factoryId ??= FACTORY_ID_BY_CHAIN[args.chainId];
   if (!args.help && args.factoryId === undefined)
     throw new Error(`No --factory-id and no default for chain ${args.chainId}`);
@@ -119,7 +123,9 @@ Options:
   --chain-id <id>            EVM chain id. Default 8453.
   --factory-id <n>           Source factory id. Default per-chain
                              (8453 -> 640791, 4663 -> 827059).
-  --schema <name>            Materialized indexer schema. Default prod_1.
+  --schema <name>            Materialized indexer schema. REQUIRED
+                             (e.g. prod_2); no default to avoid writing
+                             the wrong deployment.
   --ponder-sync-schema <s>   Sync schema name. Default ponder_sync.
   --rpc-url <url>            RPC URL. Default \$BASE_RPC_URL etc; falls back
                              to a public endpoint where one is known.

--- a/scripts/backfill-derc20-transfers.mjs
+++ b/scripts/backfill-derc20-transfers.mjs
@@ -52,7 +52,7 @@ function parseArgs(argv) {
     apply: false,
     chainId: 8453,
     factoryId: undefined,
-    schema: "prod_1",
+    schema: undefined,
     pondersyncSchema: "ponder_sync",
     databaseUrl: process.env.DATABASE_URL,
     rpcUrl: undefined,
@@ -92,6 +92,10 @@ function parseArgs(argv) {
       else throw new Error(`Unknown argument ${a}`);
     } else throw new Error(`Unknown argument ${a}`);
   }
+  if (!args.help && !args.schema)
+    throw new Error(
+      "Missing required --schema (the prod schema this deployment writes, e.g. prod_2)",
+    );
   args.factoryId ??= FACTORY_ID_BY_CHAIN[args.chainId];
   if (!args.help && args.factoryId === undefined)
     throw new Error(`No --factory-id and no default for chain ${args.chainId}`);
@@ -121,7 +125,9 @@ Options:
   --chain-id <id>            EVM chain id. Default 8453.
   --factory-id <n>           Source factory id. Default per-chain
                              (8453 -> 640791, 4663 -> 827059).
-  --schema <name>            Materialized indexer schema. Default prod_1.
+  --schema <name>            Materialized indexer schema. REQUIRED
+                             (e.g. prod_2); no default to avoid writing
+                             the wrong deployment.
   --ponder-sync-schema <s>   Sync schema name. Default ponder_sync.
   --rpc-url <url>            RPC URL. Default \$BASE_RPC_URL etc; falls back
                              to a public endpoint where one is known.


### PR DESCRIPTION
The three ponder_sync repair scripts defaulted `--schema` to `prod_1`, which silently targets the wrong deployment when the active schema is something else (this bit the robinhood repair today: the materialize sweep wrote into the stale `prod_1` schema, and token lookups came back empty because `prod_1.token` predates the affected tokens).

- `backfill-derc20-transfers.mjs` / `backfill-derc20-materialize.mjs`: `--schema` is now required and fails loudly when omitted.
- `backfill-airlock-creates.mjs`: only reads the prod schema for the earliest-gap start-block heuristic, so `--schema` is required exactly when `--start-block` is omitted (for the `create` event); unused otherwise.

Verified: all three fail with a clear error when the schema is needed and missing, and the creates script still runs schema-free with an explicit `--start-block` (dry-run against robinhood found the expected 2 creates at block 16864619).