### PR TITLE
fix: persist factory children at discovery + robinhood balance repair tooling

### DIFF
--- a/patches/ponder@0.16.10.patch
+++ b/patches/ponder@0.16.10.patch
@@ -789,6 +789,61 @@ index 57a7d888db682479941b53e941f03c96fe910917..4e0704649aeb28a12bcbe6e24cce8ecb
                  });
                  indexingCache.clear();
                  common.logger.info({
+diff --git a/dist/esm/runtime/realtime.js b/dist/esm/runtime/realtime.js
+index 4e16042f0138f6c2839ba612e1f60e2060676fe0..60c4a559ed737cf0d85878dfd11e92d8e62da8fa 100644
+--- a/dist/esm/runtime/realtime.js
++++ b/dist/esm/runtime/realtime.js
+@@ -558,6 +558,50 @@ export async function handleRealtimeSyncEvent(event, params) {
+             params.common.metrics.ponder_sync_block.set({ chain: params.chain.name }, hexToNumber(params.syncProgress.current.number));
+             params.common.metrics.ponder_sync_block_timestamp.set({ chain: params.chain.name }, hexToNumber(params.syncProgress.current.timestamp));
+             params.unfinalizedBlocks.push(event);
++            // Persist newly discovered factory children NOW, not at finalize.
++            //
++            // Upstream only writes `factory_addresses` in the "finalize" branch
++            // below, which lags the head by ~2x finalityBlockCount. Any child
++            // discovered inside that window is lost if the process stops before
++            // the next finalize — and because finalize records intervals by
++            // block range, the child's block is later marked covered, so
++            // nothing ever re-discovers it. On restart the child is absent from
++            // the in-memory set, every log it emits stops matching, and the
++            // affected contract silently disappears from all child-filtered
++            // handlers. On a chain that launches contracts continuously this
++            // orphans a handful of contracts on EVERY restart (observed on
++            // robinhood/4663: 6 tokens lost across one afternoon of restarts,
++            // and ~91% of all children missing after weeks of deploys).
++            //
++            // Writing at discovery closes the window. Trade-off: a reorged
++            // block can leave a child row for a contract that no longer
++            // exists. That is harmless — an extra address contributes no logs,
++            // and `getChildAddresses` dedupes — whereas a MISSING child
++            // silently drops real events. Prefer over-inclusion.
++            //
++            // The finalize branch still inserts these same children; the
++            // duplicate rows are deduped on read by `getChildAddresses`.
++            if (params.chain.disableCache !== true) {
++                let hasNewChildAddresses = false;
++                for (const addresses of event.childAddresses.values()) {
++                    if (addresses.size > 0) {
++                        hasNewChildAddresses = true;
++                        break;
++                    }
++                }
++                if (hasNewChildAddresses) {
++                    const blockNumber = hexToNumber(event.block.number);
++                    const syncStore = createSyncStore({
++                        common: params.common,
++                        qb: params.database.syncQB,
++                    });
++                    await promiseAllSettledWithThrow(Array.from(event.childAddresses.entries()).map(([factory, addresses]) => syncStore.insertChildAddresses({
++                        factory,
++                        childAddresses: new Map(Array.from(addresses, (address) => [address, blockNumber])),
++                        chainId: params.chain.id,
++                    })));
++                }
++            }
+             break;
+         }
+         case "finalize": {
 diff --git a/dist/esm/sync-historical/index.js b/dist/esm/sync-historical/index.js
 index 3c0810be57bb1d6cf149485a1f34dd55540fc976..aeadc0821aa472baca4aab2883fe328fcf63ac97 100644
 --- a/dist/esm/sync-historical/index.js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   ponder@0.16.10:
-    hash: d35b4677615c2f3f72c9e8d7abff0ed7ac4d23d032ea07fcd49501c287e9ce00
+    hash: 75760ab0ed7cfd8aa7e9cc14adcc3c3c0f1935c887b7a2f20c326e8ea2d3641c
     path: patches/ponder@0.16.10.patch
 
 importers:
@@ -24,7 +24,7 @@ importers:
         version: 4.3.2
       ponder:
         specifier: 0.16.10
-        version: 0.16.10(patch_hash=d35b4677615c2f3f72c9e8d7abff0ed7ac4d23d032ea07fcd49501c287e9ce00)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3))
+        version: 0.16.10(patch_hash=75760ab0ed7cfd8aa7e9cc14adcc3c3c0f1935c887b7a2f20c326e8ea2d3641c)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3))
       viem:
         specifier: 2.30.1
         version: 2.30.1(typescript@5.9.3)
@@ -4921,7 +4921,7 @@ snapshots:
       sonic-boom: 3.8.1
       thread-stream: 2.7.0
 
-  ponder@0.16.10(patch_hash=d35b4677615c2f3f72c9e8d7abff0ed7ac4d23d032ea07fcd49501c287e9ce00)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3)):
+  ponder@0.16.10(patch_hash=75760ab0ed7cfd8aa7e9cc14adcc3c3c0f1935c887b7a2f20c326e8ea2d3641c)(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(hono@4.11.9)(typescript@5.9.3)(viem@2.30.1(typescript@5.9.3)):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@commander-js/extra-typings': 12.1.0(commander@12.1.0)

--- a/scripts/backfill-derc20-transfers.mjs
+++ b/scripts/backfill-derc20-transfers.mjs
@@ -62,6 +62,7 @@ function parseArgs(argv) {
     batchSize: 1000,
     limit: undefined,
     token: undefined,
+    force: false,
     checkpoint: resolve(process.cwd(), "backfill-derc20-transfers.checkpoint.json"),
     saveIntervalMs: 5000,
   };
@@ -70,6 +71,7 @@ function parseArgs(argv) {
     if (a === "--") continue;
     if (a === "--help" || a === "-h") args.help = true;
     else if (a === "--apply") args.apply = true;
+    else if (a === "--force") args.force = true;
     else if (a.startsWith("--")) {
       const key = a.slice(2);
       const v = argv[++i];
@@ -99,6 +101,10 @@ function parseArgs(argv) {
   args.factoryId ??= FACTORY_ID_BY_CHAIN[args.chainId];
   if (!args.help && args.factoryId === undefined)
     throw new Error(`No --factory-id and no default for chain ${args.chainId}`);
+  if (args.force && !args.token)
+    throw new Error(
+      "--force requires --token; refusing to refetch the full range for every candidate",
+    );
   return args;
 }
 
@@ -138,6 +144,11 @@ Options:
   --batch-size <n>           Rows per DB INSERT batch. Default 1000.
   --limit <n>                Process at most N tokens (after filtering).
   --token <0x...>            Process exactly one token (ignores filters).
+  --force                    With --token: refetch the token's full range from
+                             its deploy block even if Transfer rows already
+                             exist (clears its checkpoint entry). Use for gap
+                             repair — inserts are idempotent, so re-covering
+                             existing rows is safe.
   --checkpoint <path>        On-disk checkpoint JSON. Default
                              ./backfill-derc20-transfers.checkpoint.json.
                              Tracks per-token covered_to block so a restart
@@ -601,6 +612,23 @@ async function main() {
   // indexer (Airlock Create event was received, subscription was active), so
   // mark it completed and skip — we only need to backfill tokens with ZERO
   // existing Transfer logs.
+  //
+  // Caveat: "has rows" does NOT prove completeness — a token whose factory
+  // child registration was lost mid-life has rows up to the loss and a gap
+  // after it (see the robinhood chain-4663 incident). --force (with --token)
+  // clears the checkpoint entry so the full deploy->head range is refetched;
+  // inserts are idempotent so re-covering existing rows is harmless.
+  if (args.force) {
+    for (const c of candidates) {
+      checkpointState.data.tokens[c.token] = {
+        deploy_block: c.deploy_block,
+        needs_backfill: true,
+        forced: true,
+      };
+    }
+    saveCheckpointNow();
+    console.log(`--force: reset checkpoint for ${candidates.length} token(s).`);
+  }
   const unseeded = args.token
     ? candidates.filter((c) => !checkpoint.tokens[c.token])
     : candidates.filter((c) => !checkpoint.tokens[c.token]);

--- a/scripts/rebuild-transfer-balances.mjs
+++ b/scripts/rebuild-transfer-balances.mjs
@@ -1,0 +1,868 @@
+#!/usr/bin/env node
+
+// Rebuild user/user_asset/holder_count for a chain whose DERC20 Transfer logs
+// were never stored, by sweeping the chain's Transfer logs directly from RPC
+// and computing balances in flight.
+//
+// Context (robinhood chain 4663, 2026-07): ponder's realtime sync only stores
+// logs that MATCH a filter. When factory child addresses are lost from
+// ponder_sync.factory_addresses, every Transfer log for those children is
+// discarded, and because the checkpoint stays at head across restarts the
+// historical sync never re-fetches the range unfiltered. Result: ~300M
+// Transfer logs that were never persisted, and user_asset balances frozen at
+// whatever the last matched transfer was.
+//
+// Backfilling those logs into ponder_sync.logs would cost 150-200GB. This
+// script skips the raw logs entirely: it streams the chain once, accumulates
+// per (token, holder) balance deltas, stages them, and writes only the final
+// aggregated rows.
+//
+// Phases (--phase, default all):
+//   sweep      RPC -> in-memory deltas -> staging table (resumable)
+//   aggregate  staging -> aggregated balance/user tables (in-DB)
+//   write      aggregated tables -> prod schema (batched; needs --apply)
+//   counts     recompute token.holder_count / pool.holder_count
+//
+// CONSISTENCY: the write phase overwrites balances with absolute values as of
+// the sweep's end block. Live indexing applies deltas on top of whatever is in
+// the row, so a concurrent indexer would leave the row short by anything it
+// indexed between the sweep and the write. Correct procedure:
+//   1. run --phase sweep while live (long, hours)
+//   2. stop the indexer; note its checkpoint block C
+//   3. re-run --phase sweep --end-block C (short catch-up from the checkpoint)
+//   4. run --phase aggregate, then --phase write --apply, then --phase counts
+//   5. restart the indexer; it resumes at C and applies later deltas correctly
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync, renameSync } from "node:fs";
+import { resolve } from "node:path";
+import process from "node:process";
+import { createPublicClient, http } from "viem";
+
+const TRANSFER_SELECTOR =
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+const RPC_ENV_BY_CHAIN = {
+  1: ["PONDER_RPC_URL_1", "MAINNET_RPC"],
+  130: ["PONDER_RPC_URL_130", "UNICHAIN_RPC"],
+  143: ["PONDER_RPC_URL_143", "MONAD_RPC"],
+  4663: ["PONDER_RPC_URL_4663", "ROBINHOOD_RPC"],
+  8453: ["PONDER_RPC_URL_8453", "BASE_RPC", "BASE_RPC_URL"],
+  57073: ["PONDER_RPC_URL_57073", "INK_RPC"],
+};
+
+const FACTORY_ID_BY_CHAIN = {
+  8453: 640791,
+  4663: 827059,
+};
+
+const START_BLOCK_BY_CHAIN = {
+  4663: 367349,
+};
+
+function loadDotEnv(path) {
+  if (!existsSync(path)) return;
+  for (const rawLine of readFileSync(path, "utf8").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const m = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (!m) continue;
+    const [, key, rawValue] = m;
+    if (process.env[key] !== undefined) continue;
+    process.env[key] = rawValue.trim().replace(/^(['"])(.*)\1$/, "$2");
+  }
+}
+
+loadDotEnv(resolve(process.cwd(), ".env"));
+loadDotEnv(resolve(process.cwd(), ".env.local"));
+
+function parseArgs(argv) {
+  const args = {
+    apply: false,
+    phase: "all",
+    reset: false,
+    chainId: 4663,
+    factoryId: undefined,
+    schema: undefined,
+    pondersyncSchema: "ponder_sync",
+    stagingSchema: "backfill_staging",
+    databaseUrl: process.env.DATABASE_URL,
+    rpcUrl: undefined,
+    startBlock: undefined,
+    endBlock: undefined,
+    windowSize: 200,
+    rpcConcurrency: 8,
+    flushPairs: 3_000_000,
+    writeBatch: 500_000,
+    tsStride: 50,
+    checkpoint: undefined,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--") continue;
+    if (a === "--help" || a === "-h") args.help = true;
+    else if (a === "--apply") args.apply = true;
+    else if (a === "--reset") args.reset = true;
+    else if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const v = argv[++i];
+      if (v === undefined || v.startsWith("--"))
+        throw new Error(`Missing value for ${a}`);
+      if (key === "database-url") args.databaseUrl = v;
+      else if (key === "rpc-url") args.rpcUrl = v;
+      else if (key === "phase") args.phase = v;
+      else if (key === "chain-id") args.chainId = Number(v);
+      else if (key === "factory-id") args.factoryId = Number(v);
+      else if (key === "schema") args.schema = v;
+      else if (key === "ponder-sync-schema") args.pondersyncSchema = v;
+      else if (key === "staging-schema") args.stagingSchema = v;
+      else if (key === "start-block") args.startBlock = BigInt(v);
+      else if (key === "end-block") args.endBlock = BigInt(v);
+      else if (key === "window-size") args.windowSize = Number(v);
+      else if (key === "rpc-concurrency") args.rpcConcurrency = Number(v);
+      else if (key === "flush-pairs") args.flushPairs = Number(v);
+      else if (key === "write-batch") args.writeBatch = Number(v);
+      else if (key === "ts-stride") args.tsStride = Number(v);
+      else if (key === "checkpoint") args.checkpoint = resolve(v);
+      else throw new Error(`Unknown argument ${a}`);
+    } else throw new Error(`Unknown argument ${a}`);
+  }
+  if (args.help) return args;
+
+  const phases = ["all", "sweep", "aggregate", "write", "counts"];
+  if (!phases.includes(args.phase))
+    throw new Error(`--phase must be one of ${phases.join(", ")}`);
+  if (!args.databaseUrl) throw new Error("Missing DATABASE_URL");
+  if (!args.schema)
+    throw new Error(
+      "Missing required --schema (the prod schema this deployment writes, e.g. prod_2)",
+    );
+  args.factoryId ??= FACTORY_ID_BY_CHAIN[args.chainId];
+  if (args.factoryId === undefined)
+    throw new Error(`No --factory-id and no default for chain ${args.chainId}`);
+  args.checkpoint ??= resolve(
+    process.cwd(),
+    `rebuild-transfer-balances.${args.chainId}.checkpoint.json`,
+  );
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/rebuild-transfer-balances.mjs --schema prod_2 [options]
+
+Rebuilds user_asset / user / holder_count for a chain whose DERC20 Transfer
+logs were never persisted, by sweeping Transfer logs from RPC and computing
+balances in flight. Raw logs are NOT written to ponder_sync.logs.
+
+Phases:
+  --phase sweep       RPC sweep -> staging deltas (resumable via checkpoint)
+  --phase aggregate   staging deltas -> aggregated balances (in-DB)
+  --phase write       aggregated balances -> <schema> (requires --apply)
+  --phase counts      recompute token/pool holder_count (requires --apply)
+  --phase all         all of the above in order (default)
+
+Options:
+  --schema <name>            REQUIRED prod schema (e.g. prod_2).
+  --chain-id <id>            EVM chain id. Default 4663.
+  --factory-id <n>           ponder_sync factory id for the DERC20 asset
+                             factory. Default per-chain (4663 -> 827059).
+  --rpc-url <url>            RPC URL. Default \$PONDER_RPC_URL_<chainid>.
+                             Use a private endpoint; this makes ~40k requests.
+  --database-url <url>       Postgres URL. Default \$DATABASE_URL.
+  --start-block <n>          Sweep from. Default: checkpoint, else the chain's
+                             configured start block.
+  --end-block <n>            Sweep to. Default: current head.
+  --window-size <n>          Blocks per eth_getLogs. Default 200 (chain 4663
+                             averages ~20 Transfer logs/block, peaking near 45,
+                             so 200 stays under a 10k-log cap). Windows that
+                             exceed the provider's cap are split automatically.
+  --rpc-concurrency <n>      Windows in flight. Default 8.
+  --flush-pairs <n>          Flush in-memory deltas to staging once this many
+                             (token, holder) pairs are held. Default 3000000
+                             (~700MB). Run node with --max-old-space-size=4096.
+  --write-batch <n>          Rows per prod write batch. Default 500000.
+  --ts-stride <n>            Sample every Nth block header from
+                             ponder_sync.blocks to build the block->timestamp
+                             interpolator. Default 50 (<=5s error on a 10
+                             block/s chain). 1 = exact where headers exist.
+  --staging-schema <name>    Scratch schema for deltas. Default
+                             backfill_staging. Safe to drop afterwards.
+  --checkpoint <path>        Sweep checkpoint JSON. Default
+                             ./rebuild-transfer-balances.<chainid>.checkpoint.json
+  --reset                    Drop staging tables + checkpoint, then start over.
+  --apply                    Required for the write/counts phases. Sweep and
+                             aggregate only ever touch the staging schema.
+
+Consistency: the write phase sets ABSOLUTE balances as of the sweep end block,
+while live indexing applies deltas on top of existing rows. Stop the indexer
+before the write phase, sweep the small catch-up range up to its checkpoint,
+write, then restart it. See the header comment for the exact sequence.
+`);
+}
+
+function ql(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function lowerHex(value) {
+  return value == null ? null : String(value).toLowerCase();
+}
+
+function topicToAddress(topic) {
+  const hex = topic.startsWith("0x") ? topic.slice(2) : topic;
+  return `0x${hex.slice(24).toLowerCase()}`;
+}
+
+function resolveRpcUrl(chainId, override) {
+  if (override) return override;
+  for (const name of RPC_ENV_BY_CHAIN[chainId] ?? []) {
+    if (process.env[name]) return process.env[name];
+  }
+  throw new Error(
+    `No RPC URL found for chain ${chainId}. Set --rpc-url or one of ${(RPC_ENV_BY_CHAIN[chainId] ?? []).join(", ")}.`,
+  );
+}
+
+function psqlExec(databaseUrl, sql) {
+  execFileSync("psql", [databaseUrl, "-X", "-v", "ON_ERROR_STOP=1"], {
+    input: sql,
+    encoding: "utf8",
+    stdio: ["pipe", "inherit", "inherit"],
+  });
+}
+
+function psqlScalar(databaseUrl, sql) {
+  return execFileSync(
+    "psql",
+    [databaseUrl, "-X", "-A", "-t", "-v", "ON_ERROR_STOP=1", "-c", sql],
+    { encoding: "utf8", maxBuffer: 1024 * 1024 * 64 },
+  ).trim();
+}
+
+function psqlRowsTsv(databaseUrl, sql) {
+  const stdout = execFileSync(
+    "psql",
+    [databaseUrl, "-X", "-A", "-t", "-F", "\t", "-v", "ON_ERROR_STOP=1", "-c", sql],
+    { encoding: "utf8", maxBuffer: 1024 * 1024 * 1024 },
+  );
+  const out = [];
+  for (const line of stdout.split("\n")) {
+    if (!line) continue;
+    out.push(line.split("\t"));
+  }
+  return out;
+}
+
+// COPY is dramatically faster than multi-row INSERT for the staging flushes,
+// which move tens of millions of rows over the course of a full sweep.
+function psqlCopy(databaseUrl, table, columns, tsvBody) {
+  const input = `\\set ON_ERROR_STOP on\nCOPY ${table} (${columns.join(", ")}) FROM STDIN;\n${tsvBody}\\.\n`;
+  const res = spawnSync("psql", [databaseUrl, "-X", "-q", "-v", "ON_ERROR_STOP=1"], {
+    input,
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 64,
+    stdio: ["pipe", "inherit", "inherit"],
+  });
+  if (res.status !== 0)
+    throw new Error(`COPY into ${table} failed with status ${res.status}`);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// block -> timestamp
+////////////////////////////////////////////////////////////////////////////////
+
+// ponder_sync.blocks only holds headers the indexer actually fetched, so it
+// cannot answer every block. We load a strided sample and interpolate: on a
+// ~10 block/s chain a stride of 50 bounds the error at a few seconds, which is
+// well inside the meaning of created_at / last_interaction.
+function buildTimestampIndex(args) {
+  const sql = `
+select number::text || E'\\t' || timestamp::text
+from ${args.pondersyncSchema}.blocks
+where chain_id = ${Number(args.chainId)}
+  and (number % ${Math.max(1, Number(args.tsStride))}) = 0
+order by number;`;
+  const rows = psqlRowsTsv(args.databaseUrl, sql);
+  if (rows.length < 2)
+    throw new Error(
+      `Not enough block headers in ${args.pondersyncSchema}.blocks for chain ${args.chainId} to build a timestamp index`,
+    );
+  const numbers = new Float64Array(rows.length);
+  const times = new Float64Array(rows.length);
+  for (let i = 0; i < rows.length; i++) {
+    numbers[i] = Number(rows[i][0]);
+    times[i] = Number(rows[i][1]);
+  }
+  console.log(
+    `Timestamp index: ${rows.length} samples, blocks ${numbers[0]}..${numbers[numbers.length - 1]}`,
+  );
+  return { numbers, times };
+}
+
+function timestampFor(index, block) {
+  const { numbers, times } = index;
+  const n = numbers.length;
+  if (block <= numbers[0]) return Math.round(times[0]);
+  if (block >= numbers[n - 1]) return Math.round(times[n - 1]);
+  let lo = 0;
+  let hi = n - 1;
+  while (hi - lo > 1) {
+    const mid = (lo + hi) >> 1;
+    if (numbers[mid] <= block) lo = mid;
+    else hi = mid;
+  }
+  const span = numbers[hi] - numbers[lo];
+  if (span <= 0) return Math.round(times[lo]);
+  const frac = (block - numbers[lo]) / span;
+  return Math.round(times[lo] + frac * (times[hi] - times[lo]));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// staging schema
+////////////////////////////////////////////////////////////////////////////////
+
+function stagingNames(args) {
+  const s = args.stagingSchema;
+  const c = Number(args.chainId);
+  return {
+    delta: `${s}.transfer_delta_${c}`,
+    balance: `${s}.balance_final_${c}`,
+    user: `${s}.user_final_${c}`,
+  };
+}
+
+function ensureStaging(args) {
+  const t = stagingNames(args);
+  psqlExec(
+    args.databaseUrl,
+    `
+create schema if not exists ${args.stagingSchema};
+create unlogged table if not exists ${t.delta} (
+  token text not null,
+  holder text not null,
+  delta numeric not null,
+  first_ts bigint not null,
+  last_ts bigint not null
+);
+`,
+  );
+}
+
+function resetStaging(args) {
+  const t = stagingNames(args);
+  psqlExec(
+    args.databaseUrl,
+    `drop table if exists ${t.delta}; drop table if exists ${t.balance}; drop table if exists ${t.user};`,
+  );
+  if (existsSync(args.checkpoint)) {
+    writeFileSync(args.checkpoint, JSON.stringify({ version: 1 }, null, 2));
+  }
+  console.log("Reset: staging tables dropped, checkpoint cleared.");
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// checkpoint
+////////////////////////////////////////////////////////////////////////////////
+
+function loadCheckpoint(path) {
+  if (!existsSync(path)) return { version: 1 };
+  const raw = readFileSync(path, "utf8");
+  if (!raw.trim()) return { version: 1 };
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return { version: 1 };
+  }
+}
+
+function saveCheckpoint(path, data) {
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(data, null, 2));
+  renameSync(tmp, path);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// sweep
+////////////////////////////////////////////////////////////////////////////////
+
+function loadChildAddresses(args) {
+  const sql = `
+select lower(address)
+from ${args.pondersyncSchema}.factory_addresses
+where chain_id = ${Number(args.chainId)} and factory_id = ${Number(args.factoryId)};`;
+  const rows = psqlRowsTsv(args.databaseUrl, sql);
+  const set = new Set();
+  for (const [addr] of rows) if (addr) set.add(addr);
+  console.log(`Loaded ${set.size} child address(es) for factory ${args.factoryId}.`);
+  if (set.size === 0)
+    throw new Error(
+      "No child addresses found — run backfill-airlock-creates.mjs first",
+    );
+  return set;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function isTooManyLogs(err) {
+  const s = `${err?.details ?? ""} ${err?.message ?? ""}`.toLowerCase();
+  return (
+    s.includes("exceeds limit") ||
+    s.includes("too big") ||
+    s.includes("too many results") ||
+    s.includes("query returned more than") ||
+    s.includes("response size exceeded")
+  );
+}
+
+function isRateLimited(err) {
+  const s = `${err?.details ?? ""} ${err?.message ?? ""} ${err?.status ?? ""}`;
+  return s.includes("429") || s.toLowerCase().includes("too many requests");
+}
+
+// Fetch one window, splitting recursively when the provider refuses the range.
+// Returns the window's logs in block order.
+async function fetchWindow(client, from, to, depth = 0) {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await client.request({
+        method: "eth_getLogs",
+        params: [
+          {
+            topics: [TRANSFER_SELECTOR],
+            fromBlock: `0x${from.toString(16)}`,
+            toBlock: `0x${to.toString(16)}`,
+          },
+        ],
+      });
+    } catch (err) {
+      if (isTooManyLogs(err) && to > from && depth < 24) {
+        const mid = from + (to - from) / 2n;
+        const left = await fetchWindow(client, from, mid, depth + 1);
+        const right = await fetchWindow(client, mid + 1n, to, depth + 1);
+        return left.concat(right);
+      }
+      if (attempt >= 7) throw err;
+      await sleep((isRateLimited(err) ? 2000 : 500) * (attempt + 1));
+    }
+  }
+}
+
+async function* orderedPrefetch(items, fetcher, concurrency) {
+  const inflight = [];
+  let i = 0;
+  const start = (idx) => ({ item: items[idx], promise: fetcher(items[idx]) });
+  while (i < items.length && inflight.length < concurrency) {
+    inflight.push(start(i));
+    i++;
+  }
+  while (inflight.length > 0) {
+    const next = inflight.shift();
+    const result = await next.promise;
+    if (i < items.length) {
+      inflight.push(start(i));
+      i++;
+    }
+    yield { item: next.item, result };
+  }
+}
+
+function makeWindows(fromBlock, toBlock, size) {
+  const sz = BigInt(size);
+  const out = [];
+  for (let f = fromBlock; f <= toBlock; f += sz) {
+    const t = f + sz - 1n > toBlock ? toBlock : f + sz - 1n;
+    out.push({ from: f, to: t });
+  }
+  return out;
+}
+
+async function runSweep(args) {
+  ensureStaging(args);
+  const t = stagingNames(args);
+  const checkpoint = loadCheckpoint(args.checkpoint);
+  const children = loadChildAddresses(args);
+  const tsIndex = buildTimestampIndex(args);
+
+  const rpcUrl = resolveRpcUrl(args.chainId, args.rpcUrl);
+  const client = createPublicClient({
+    transport: http(rpcUrl, { timeout: 60_000, retryCount: 0 }),
+  });
+
+  const head = args.endBlock ?? (await client.getBlockNumber());
+  let startBlock = args.startBlock;
+  // Staged deltas are SUMmed by the aggregate phase, so sweeping a range that
+  // is already staged would silently double every balance in it.
+  if (
+    startBlock !== undefined &&
+    checkpoint.covered_to !== undefined &&
+    startBlock <= BigInt(checkpoint.covered_to)
+  ) {
+    throw new Error(
+      `--start-block ${startBlock} is at or below the already-swept covered_to=${checkpoint.covered_to}; ` +
+        `re-staging it would double-count those transfers. Omit --start-block to resume, or pass --reset to start over.`,
+    );
+  }
+  if (startBlock === undefined) {
+    if (checkpoint.covered_to) {
+      startBlock = BigInt(checkpoint.covered_to) + 1n;
+      console.log(`Resuming from checkpoint covered_to=${checkpoint.covered_to}`);
+    } else {
+      startBlock = BigInt(START_BLOCK_BY_CHAIN[args.chainId] ?? 0);
+    }
+  }
+  if (startBlock > head) {
+    console.log(`Nothing to sweep: start ${startBlock} > end ${head}.`);
+    return;
+  }
+
+  console.log(
+    `Sweeping Transfer logs on chain ${args.chainId}: blocks [${startBlock}, ${head}]`,
+  );
+  console.log(
+    `  window=${args.windowSize}  rpc_concurrency=${args.rpcConcurrency}  flush_pairs=${args.flushPairs}`,
+  );
+
+  // token -> holder -> [delta, firstBlock, lastBlock]
+  const acc = new Map();
+  let pairCount = 0;
+  let logsSeen = 0;
+  let logsMatched = 0;
+  let flushes = 0;
+  let rowsStaged = 0;
+  let pendingCoveredTo = startBlock - 1n;
+  let lastReport = Date.now();
+  const t0 = Date.now();
+
+  const flush = () => {
+    if (pairCount === 0) {
+      if (pendingCoveredTo >= startBlock) {
+        checkpoint.covered_to = pendingCoveredTo.toString();
+        saveCheckpoint(args.checkpoint, checkpoint);
+      }
+      return;
+    }
+    const parts = [];
+    for (const [token, holders] of acc) {
+      for (const [holder, v] of holders) {
+        parts.push(
+          `${token}\t${holder}\t${v[0].toString()}\t${timestampFor(tsIndex, v[1])}\t${timestampFor(tsIndex, v[2])}\n`,
+        );
+      }
+    }
+    psqlCopy(
+      args.databaseUrl,
+      t.delta,
+      ["token", "holder", "delta", "first_ts", "last_ts"],
+      parts.join(""),
+    );
+    rowsStaged += parts.length;
+    flushes++;
+    acc.clear();
+    pairCount = 0;
+    // Only advance the checkpoint once the staged rows are durable, so a crash
+    // re-sweeps the un-flushed tail instead of losing or double-counting it.
+    checkpoint.covered_to = pendingCoveredTo.toString();
+    saveCheckpoint(args.checkpoint, checkpoint);
+    console.log(
+      `  [flush ${flushes}] staged ${parts.length} pair-rows (total ${rowsStaged}), covered_to=${checkpoint.covered_to}`,
+    );
+  };
+
+  const windows = makeWindows(startBlock, head, args.windowSize);
+  console.log(`  windows=${windows.length}`);
+
+  const fetcher = (w) => fetchWindow(client, w.from, w.to);
+
+  let shuttingDown = false;
+  const onSigint = () => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.log("\nSIGINT — flushing staged deltas before exit...");
+    try {
+      flush();
+    } catch (err) {
+      console.error("flush on exit failed:", err?.message ?? err);
+    }
+    process.exit(130);
+  };
+  process.on("SIGINT", onSigint);
+
+  for await (const { item: window, result: logs } of orderedPrefetch(
+    windows,
+    fetcher,
+    args.rpcConcurrency,
+  )) {
+    for (const log of logs) {
+      logsSeen++;
+      // ERC-721 shares this topic0 but indexes tokenId as a 4th topic; only
+      // ERC-20 Transfers (3 topics, value in data) carry balances.
+      if (!log.topics || log.topics.length !== 3) continue;
+      if (!log.data || log.data === "0x") continue;
+      const address = lowerHex(log.address);
+      if (!children.has(address)) continue;
+
+      const from = topicToAddress(log.topics[1]);
+      const to = topicToAddress(log.topics[2]);
+      let value;
+      try {
+        value = BigInt(log.data.length > 66 ? log.data.slice(0, 66) : log.data);
+      } catch {
+        continue;
+      }
+      const block = Number(BigInt(log.blockNumber));
+      logsMatched++;
+
+      let holders = acc.get(address);
+      if (holders === undefined) {
+        holders = new Map();
+        acc.set(address, holders);
+      }
+      // Mirrors backfill-derc20-materialize.mjs: the zero address is not
+      // tracked as a holder, so a token's rows sum to its total supply.
+      if (from !== ZERO_ADDRESS) {
+        const cur = holders.get(from);
+        if (cur === undefined) {
+          holders.set(from, [-value, block, block]);
+          pairCount++;
+        } else {
+          cur[0] -= value;
+          if (block < cur[1]) cur[1] = block;
+          if (block > cur[2]) cur[2] = block;
+        }
+      }
+      if (to !== ZERO_ADDRESS) {
+        const cur = holders.get(to);
+        if (cur === undefined) {
+          holders.set(to, [value, block, block]);
+          pairCount++;
+        } else {
+          cur[0] += value;
+          if (block < cur[1]) cur[1] = block;
+          if (block > cur[2]) cur[2] = block;
+        }
+      }
+    }
+
+    pendingCoveredTo = window.to;
+    if (pairCount >= args.flushPairs) flush();
+
+    if (Date.now() - lastReport > 5000) {
+      const done = Number(window.to - startBlock + 1n);
+      const total = Number(head - startBlock + 1n);
+      const pct = ((done / total) * 100).toFixed(2);
+      const rate = done / ((Date.now() - t0) / 1000);
+      const etaMin = rate > 0 ? (total - done) / rate / 60 : 0;
+      console.log(
+        `  block=${window.to} ${pct}%  logs=${logsSeen} matched=${logsMatched} pairs=${pairCount} staged=${rowsStaged}  ${rate.toFixed(0)} blk/s  eta=${etaMin.toFixed(0)}m`,
+      );
+      lastReport = Date.now();
+    }
+  }
+
+  flush();
+  process.off("SIGINT", onSigint);
+  checkpoint.covered_to = head.toString();
+  checkpoint.swept_at = new Date().toISOString();
+  saveCheckpoint(args.checkpoint, checkpoint);
+  console.log(
+    `Sweep done. logs_seen=${logsSeen} logs_matched=${logsMatched} pair_rows_staged=${rowsStaged} flushes=${flushes}`,
+  );
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// aggregate
+////////////////////////////////////////////////////////////////////////////////
+
+function runAggregate(args) {
+  const t = stagingNames(args);
+  console.log("Aggregating staged deltas (this is a large in-DB GROUP BY)...");
+  psqlExec(
+    args.databaseUrl,
+    `
+drop table if exists ${t.balance};
+create unlogged table ${t.balance} as
+select token,
+       holder,
+       sum(delta)     as balance,
+       min(first_ts)  as created_at,
+       max(last_ts)   as last_interaction
+from ${t.delta}
+group by token, holder;
+
+alter table ${t.balance} add column rn bigint;
+update ${t.balance} set rn = s.rn
+from (select ctid, row_number() over () as rn from ${t.balance}) s
+where ${t.balance}.ctid = s.ctid;
+create index on ${t.balance} (rn);
+
+drop table if exists ${t.user};
+create unlogged table ${t.user} as
+select holder                as address,
+       min(created_at)       as created_at,
+       max(last_interaction) as last_seen_at
+from ${t.balance}
+group by holder;
+
+alter table ${t.user} add column rn bigint;
+update ${t.user} set rn = s.rn
+from (select ctid, row_number() over () as rn from ${t.user}) s
+where ${t.user}.ctid = s.ctid;
+create index on ${t.user} (rn);
+`,
+  );
+  const balances = psqlScalar(args.databaseUrl, `select count(*) from ${t.balance};`);
+  const users = psqlScalar(args.databaseUrl, `select count(*) from ${t.user};`);
+  const tokens = psqlScalar(
+    args.databaseUrl,
+    `select count(distinct token) from ${t.balance};`,
+  );
+  console.log(
+    `Aggregate done. balance rows=${balances} distinct users=${users} distinct tokens=${tokens}`,
+  );
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// write
+////////////////////////////////////////////////////////////////////////////////
+
+function runWrite(args) {
+  if (!args.apply) {
+    console.log("Dry-run: --phase write requires --apply. Nothing written.");
+    return;
+  }
+  const t = stagingNames(args);
+  const schema = args.schema;
+  const chainId = Number(args.chainId);
+
+  const maxBalanceRn = Number(
+    psqlScalar(args.databaseUrl, `select coalesce(max(rn), 0) from ${t.balance};`),
+  );
+  const maxUserRn = Number(
+    psqlScalar(args.databaseUrl, `select coalesce(max(rn), 0) from ${t.user};`),
+  );
+  const batch = Number(args.writeBatch);
+
+  console.log(
+    `Writing ${maxUserRn} user rows and ${maxBalanceRn} user_asset rows into ${schema} in batches of ${batch}...`,
+  );
+
+  // Batched so each ACCESS EXCLUSIVE lock (from DISABLE TRIGGER) is short —
+  // other indexers write these tables concurrently. Data never leaves the DB.
+  for (let lo = 1; lo <= maxUserRn; lo += batch) {
+    const hi = lo + batch - 1;
+    psqlExec(
+      args.databaseUrl,
+      `
+begin;
+alter table ${schema}."user" disable trigger user;
+insert into ${schema}."user" (address, chain_id, created_at, last_seen_at)
+select address, ${chainId}, created_at, last_seen_at
+from ${t.user} where rn between ${lo} and ${hi}
+on conflict (address, chain_id) do update set
+  last_seen_at = greatest(${schema}."user".last_seen_at, excluded.last_seen_at);
+alter table ${schema}."user" enable trigger user;
+commit;
+`,
+    );
+    console.log(`  users ${Math.min(hi, maxUserRn)}/${maxUserRn}`);
+  }
+
+  for (let lo = 1; lo <= maxBalanceRn; lo += batch) {
+    const hi = lo + batch - 1;
+    psqlExec(
+      args.databaseUrl,
+      `
+begin;
+alter table ${schema}.user_asset disable trigger user;
+insert into ${schema}.user_asset (chain_id, user_id, asset_id, balance, created_at, last_interaction)
+select ${chainId}, holder, token, balance, created_at, last_interaction
+from ${t.balance} where rn between ${lo} and ${hi}
+on conflict (user_id, asset_id, chain_id) do update set
+  balance = excluded.balance,
+  last_interaction = greatest(${schema}.user_asset.last_interaction, excluded.last_interaction);
+alter table ${schema}.user_asset enable trigger user;
+commit;
+`,
+    );
+    console.log(`  user_assets ${Math.min(hi, maxBalanceRn)}/${maxBalanceRn}`);
+  }
+  console.log("Write done.");
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// holder counts
+////////////////////////////////////////////////////////////////////////////////
+
+function runCounts(args) {
+  if (!args.apply) {
+    console.log("Dry-run: --phase counts requires --apply. Nothing written.");
+    return;
+  }
+  const schema = args.schema;
+  const chainId = Number(args.chainId);
+  console.log("Recomputing holder_count for token and pool...");
+  psqlExec(
+    args.databaseUrl,
+    `
+begin;
+alter table ${schema}.token disable trigger user;
+with counts as (
+  select asset_id, count(*)::int as n
+  from ${schema}.user_asset
+  where chain_id = ${chainId} and balance > 0
+  group by asset_id
+)
+update ${schema}.token t
+set holder_count = c.n
+from counts c
+where t.chain_id = ${chainId} and lower(t.address) = lower(c.asset_id)
+  and t.holder_count is distinct from c.n;
+alter table ${schema}.token enable trigger user;
+commit;
+
+begin;
+alter table ${schema}.pool disable trigger user;
+with counts as (
+  select asset_id, count(*)::int as n
+  from ${schema}.user_asset
+  where chain_id = ${chainId} and balance > 0
+  group by asset_id
+)
+update ${schema}.pool p
+set holder_count = c.n
+from counts c
+join ${schema}.token tk
+  on tk.chain_id = ${chainId} and lower(tk.address) = lower(c.asset_id)
+where p.chain_id = ${chainId} and lower(p.address) = lower(tk.pool)
+  and p.holder_count is distinct from c.n;
+alter table ${schema}.pool enable trigger user;
+commit;
+`,
+  );
+  console.log("Counts done.");
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) return printHelp();
+
+  if (args.reset) resetStaging(args);
+
+  const phase = args.phase;
+  if (phase === "all" || phase === "sweep") await runSweep(args);
+  if (phase === "all" || phase === "aggregate") runAggregate(args);
+  if (phase === "all" || phase === "write") runWrite(args);
+  if (phase === "all" || phase === "counts") runCounts(args);
+
+  if (phase === "all" && !args.apply)
+    console.log("\nDry-run: write/counts phases skipped. Re-run with --apply.");
+}
+
+main().catch((err) => {
+  console.error(err.stack || err.message || err);
+  process.exit(1);
+});

--- a/scripts/rebuild-transfer-balances.mjs
+++ b/scripts/rebuild-transfer-balances.mjs
@@ -862,18 +862,21 @@ function runReconcile(args) {
   const schema = args.schema;
   const chainId = Number(args.chainId);
 
-  const hasPass1 = psqlScalar(
-    args.databaseUrl,
-    `select to_regclass('${t.pass1}') is not null;`,
-  );
-  if (hasPass1 !== "t")
-    throw new Error(
-      `${t.pass1} not found — run --phase write --apply (which records it) before reconciling`,
-    );
-
   console.log("Re-aggregating with catch-up deltas...");
   runAggregate(args, true);
 
+  // Diff against what prod ACTUALLY holds, not against the pass-1 snapshot.
+  // The snapshot records what we wrote, but live indexing mutates those rows
+  // between the bulk write and this reconcile — so a pair whose balance at the
+  // catch-up block happens to equal its balance at the bulk-write block (e.g.
+  // bought and sold the same amount across the window) looks "unchanged"
+  // against the snapshot while its prod row is actually wrong.
+  //
+  // With the indexer stopped at checkpoint C and the sweep run to C, every
+  // pair's correct value IS balance_final, so any difference is an error.
+  // Pairs present in prod but absent from balance_final are left alone: they
+  // belong to tokens outside this sweep's child set (e.g. launched mid-sweep)
+  // and zeroing them would destroy correct data.
   psqlExec(
     args.databaseUrl,
     `
@@ -881,10 +884,12 @@ drop table if exists ${t.diff};
 create unlogged table ${t.diff} as
 select b.token, b.holder, b.balance, b.created_at, b.last_interaction
 from ${t.balance} b
-left join ${t.pass1} p on p.token = b.token and p.holder = b.holder
-where p.token is null
-   or p.balance is distinct from b.balance
-   or p.last_interaction is distinct from b.last_interaction;
+left join ${schema}.user_asset ua
+  on ua.chain_id = ${chainId}
+ and ua.user_id  = b.holder
+ and ua.asset_id = b.token
+where ua.user_id is null
+   or ua.balance is distinct from b.balance;
 
 alter table ${t.diff} add column rn bigint;
 update ${t.diff} set rn = s.rn
@@ -897,7 +902,7 @@ create index on ${t.diff} (rn);
   const diffCount = Number(
     psqlScalar(args.databaseUrl, `select count(*) from ${t.diff};`),
   );
-  console.log(`Pairs changed since the bulk write: ${diffCount}`);
+  console.log(`Rows in prod disagreeing with the rebuilt balances: ${diffCount}`);
   if (diffCount === 0) {
     console.log("Nothing to reconcile.");
     return;

--- a/scripts/rebuild-transfer-balances.mjs
+++ b/scripts/rebuild-transfer-balances.mjs
@@ -726,33 +726,33 @@ function runAggregate(args, quiet = false) {
     args.databaseUrl,
     `
 drop table if exists ${t.balance};
+-- rn is assigned inline. Populating it afterwards via an UPDATE joined on
+-- ctid is unsafe: ctid is not stable across an UPDATE, so rows can be left
+-- with a NULL rn. The batched writers filter on rn BETWEEN lo AND hi, which
+-- silently drops any NULL-rn row from every batch.
 create unlogged table ${t.balance} as
-select token,
-       holder,
-       sum(delta)     as balance,
-       min(first_ts)  as created_at,
-       max(last_ts)   as last_interaction
-from ${t.delta}
-group by token, holder;
-
-alter table ${t.balance} add column rn bigint;
-update ${t.balance} set rn = s.rn
-from (select ctid, row_number() over () as rn from ${t.balance}) s
-where ${t.balance}.ctid = s.ctid;
+select row_number() over () as rn, *
+from (
+  select token,
+         holder,
+         sum(delta)     as balance,
+         min(first_ts)  as created_at,
+         max(last_ts)   as last_interaction
+  from ${t.delta}
+  group by token, holder
+) q;
 create index on ${t.balance} (rn);
 
 drop table if exists ${t.user};
 create unlogged table ${t.user} as
-select holder                as address,
-       min(created_at)       as created_at,
-       max(last_interaction) as last_seen_at
-from ${t.balance}
-group by holder;
-
-alter table ${t.user} add column rn bigint;
-update ${t.user} set rn = s.rn
-from (select ctid, row_number() over () as rn from ${t.user}) s
-where ${t.user}.ctid = s.ctid;
+select row_number() over () as rn, *
+from (
+  select holder                as address,
+         min(created_at)       as created_at,
+         max(last_interaction) as last_seen_at
+  from ${t.balance}
+  group by holder
+) q;
 create index on ${t.user} (rn);
 `,
   );
@@ -882,19 +882,17 @@ function runReconcile(args) {
     `
 drop table if exists ${t.diff};
 create unlogged table ${t.diff} as
-select b.token, b.holder, b.balance, b.created_at, b.last_interaction
-from ${t.balance} b
-left join ${schema}.user_asset ua
-  on ua.chain_id = ${chainId}
- and ua.user_id  = b.holder
- and ua.asset_id = b.token
-where ua.user_id is null
-   or ua.balance is distinct from b.balance;
-
-alter table ${t.diff} add column rn bigint;
-update ${t.diff} set rn = s.rn
-from (select ctid, row_number() over () as rn from ${t.diff}) s
-where ${t.diff}.ctid = s.ctid;
+select row_number() over () as rn, *
+from (
+  select b.token, b.holder, b.balance, b.created_at, b.last_interaction
+  from ${t.balance} b
+  left join ${schema}.user_asset ua
+    on ua.chain_id = ${chainId}
+   and ua.user_id  = b.holder
+   and ua.asset_id = b.token
+  where ua.user_id is null
+     or ua.balance is distinct from b.balance
+) q;
 create index on ${t.diff} (rn);
 `,
   );
@@ -913,6 +911,13 @@ create index on ${t.diff} (rn);
   }
 
   const batch = Number(args.writeBatch);
+  const nullRn = Number(
+    psqlScalar(args.databaseUrl, `select count(*) from ${t.diff} where rn is null;`),
+  );
+  if (nullRn > 0)
+    throw new Error(
+      `${t.diff} has ${nullRn} rows with a NULL rn; the batched writer would skip them silently`,
+    );
   const maxRn = Number(
     psqlScalar(args.databaseUrl, `select coalesce(max(rn), 0) from ${t.diff};`),
   );

--- a/scripts/rebuild-transfer-balances.mjs
+++ b/scripts/rebuild-transfer-balances.mjs
@@ -21,17 +21,30 @@
 //   sweep      RPC -> in-memory deltas -> staging table (resumable)
 //   aggregate  staging -> aggregated balance/user tables (in-DB)
 //   write      aggregated tables -> prod schema (batched; needs --apply)
+//   reconcile  write only the pairs that moved since `write` (needs --apply)
 //   counts     recompute token.holder_count / pool.holder_count
 //
-// CONSISTENCY: the write phase overwrites balances with absolute values as of
-// the sweep's end block. Live indexing applies deltas on top of whatever is in
-// the row, so a concurrent indexer would leave the row short by anything it
-// indexed between the sweep and the write. Correct procedure:
-//   1. run --phase sweep while live (long, hours)
-//   2. stop the indexer; note its checkpoint block C
-//   3. re-run --phase sweep --end-block C (short catch-up from the checkpoint)
-//   4. run --phase aggregate, then --phase write --apply, then --phase counts
-//   5. restart the indexer; it resumes at C and applies later deltas correctly
+// CONSISTENCY: the write phase sets ABSOLUTE balances as of the sweep's end
+// block, while live indexing applies DELTAS on top of whatever the row holds.
+// A row written while the indexer is running therefore loses anything indexed
+// between the sweep and the write.
+//
+// The two-pass sequence keeps the indexer stopped for seconds instead of the
+// whole write. The bulk write runs live and can only be wrong for pairs that
+// traded during it; those pairs are exactly the ones the catch-up sweep sees,
+// so re-aggregating and writing just the rows whose balance moved is
+// equivalent to doing the whole write offline:
+//   1. --phase sweep                 (live, long)
+//   2. --phase aggregate             (live; verify against staging here)
+//   3. --phase write --apply         (live; bulk write + records a snapshot)
+//   4. stop the indexer; note its checkpoint block C
+//   5. --phase sweep --end-block C   (seconds; catch-up deltas)
+//   6. --phase reconcile --apply     (writes only the changed pairs)
+//   7. restart the indexer
+//   8. --phase counts --apply        (live, afterwards)
+//
+// Running steps 4-6 as a single offline write (--phase all) is also correct,
+// just slower to be stopped for.
 
 import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync, renameSync } from "node:fs";
@@ -130,7 +143,7 @@ function parseArgs(argv) {
   }
   if (args.help) return args;
 
-  const phases = ["all", "sweep", "aggregate", "write", "counts"];
+  const phases = ["all", "sweep", "aggregate", "write", "reconcile", "counts"];
   if (!phases.includes(args.phase))
     throw new Error(`--phase must be one of ${phases.join(", ")}`);
   if (!args.databaseUrl) throw new Error("Missing DATABASE_URL");
@@ -160,8 +173,21 @@ Phases:
   --phase sweep       RPC sweep -> staging deltas (resumable via checkpoint)
   --phase aggregate   staging deltas -> aggregated balances (in-DB)
   --phase write       aggregated balances -> <schema> (requires --apply)
+  --phase reconcile   re-aggregate with catch-up deltas and write ONLY the
+                      pairs whose balance moved since the last write
+                      (requires --apply)
   --phase counts      recompute token/pool holder_count (requires --apply)
-  --phase all         all of the above in order (default)
+  --phase all         sweep + aggregate + write + counts (default)
+
+Low-downtime sequence (indexer stopped only for steps 4-6):
+  1. --phase sweep                      (live, long)
+  2. --phase aggregate                  (live; verify against staging here)
+  3. --phase write --apply              (live; bulk write, records a snapshot)
+  4. stop the indexer, note checkpoint C
+  5. --phase sweep --end-block <C>      (seconds)
+  6. --phase reconcile --apply          (writes only the pairs that moved)
+  7. restart the indexer
+  8. --phase counts --apply             (live, afterwards)
 
 Options:
   --schema <name>            REQUIRED prod schema (e.g. prod_2).
@@ -277,17 +303,30 @@ function psqlCopy(databaseUrl, table, columns, tsvBody) {
 // cannot answer every block. We load a strided sample and interpolate: on a
 // ~10 block/s chain a stride of 50 bounds the error at a few seconds, which is
 // well inside the meaning of created_at / last_interaction.
-function buildTimestampIndex(args) {
-  const sql = `
+function buildTimestampIndex(args, fromBlock, toBlock) {
+  // Scoped to the range being swept: `number % stride` cannot use an index, so
+  // an unbounded scan costs a full pass over the blocks table. Bounding it by
+  // block number keeps the planner on the (chain_id, number) index, which is
+  // what makes the catch-up sweep's startup a couple of seconds instead of a
+  // couple of minutes — the difference matters because the catch-up runs
+  // inside the indexer-stopped window.
+  const pad = BigInt(Math.max(1, Number(args.tsStride)) * 8);
+  const lo = fromBlock > pad ? fromBlock - pad : 0n;
+  const hi = toBlock + pad;
+  const query = (stride) => `
 select number::text || E'\\t' || timestamp::text
 from ${args.pondersyncSchema}.blocks
 where chain_id = ${Number(args.chainId)}
-  and (number % ${Math.max(1, Number(args.tsStride))}) = 0
+  and number between ${lo} and ${hi}
+  and (number % ${Math.max(1, stride)}) = 0
 order by number;`;
-  const rows = psqlRowsTsv(args.databaseUrl, sql);
+  let rows = psqlRowsTsv(args.databaseUrl, query(Number(args.tsStride)));
+  // A short range may contain fewer than two strided samples; fall back to
+  // every header we have before giving up.
+  if (rows.length < 2) rows = psqlRowsTsv(args.databaseUrl, query(1));
   if (rows.length < 2)
     throw new Error(
-      `Not enough block headers in ${args.pondersyncSchema}.blocks for chain ${args.chainId} to build a timestamp index`,
+      `Not enough block headers in ${args.pondersyncSchema}.blocks for chain ${args.chainId} in [${lo}, ${hi}] to build a timestamp index`,
     );
   const numbers = new Float64Array(rows.length);
   const times = new Float64Array(rows.length);
@@ -330,6 +369,10 @@ function stagingNames(args) {
     delta: `${s}.transfer_delta_${c}`,
     balance: `${s}.balance_final_${c}`,
     user: `${s}.user_final_${c}`,
+    // Snapshot of what the write phase last pushed to prod, so the reconcile
+    // phase can write only the pairs that moved since.
+    pass1: `${s}.balance_pass1_${c}`,
+    diff: `${s}.balance_diff_${c}`,
   };
 }
 
@@ -483,7 +526,6 @@ async function runSweep(args) {
   const t = stagingNames(args);
   const checkpoint = loadCheckpoint(args.checkpoint);
   const children = loadChildAddresses(args);
-  const tsIndex = buildTimestampIndex(args);
 
   const rpcUrl = resolveRpcUrl(args.chainId, args.rpcUrl);
   const client = createPublicClient({
@@ -516,6 +558,7 @@ async function runSweep(args) {
     console.log(`Nothing to sweep: start ${startBlock} > end ${head}.`);
     return;
   }
+  const tsIndex = buildTimestampIndex(args, startBlock, head);
 
   console.log(
     `Sweeping Transfer logs on chain ${args.chainId}: blocks [${startBlock}, ${head}]`,
@@ -675,9 +718,10 @@ async function runSweep(args) {
 // aggregate
 ////////////////////////////////////////////////////////////////////////////////
 
-function runAggregate(args) {
+function runAggregate(args, quiet = false) {
   const t = stagingNames(args);
-  console.log("Aggregating staged deltas (this is a large in-DB GROUP BY)...");
+  if (!quiet)
+    console.log("Aggregating staged deltas (this is a large in-DB GROUP BY)...");
   psqlExec(
     args.databaseUrl,
     `
@@ -718,6 +762,7 @@ create index on ${t.user} (rn);
     args.databaseUrl,
     `select count(distinct token) from ${t.balance};`,
   );
+  if (quiet) return;
   console.log(
     `Aggregate done. balance rows=${balances} distinct users=${users} distinct tokens=${tokens}`,
   );
@@ -788,7 +833,124 @@ commit;
     );
     console.log(`  user_assets ${Math.min(hi, maxBalanceRn)}/${maxBalanceRn}`);
   }
-  console.log("Write done.");
+
+  // Record exactly what prod now holds, so a later reconcile can write only
+  // the pairs that changed instead of all of them.
+  psqlExec(
+    args.databaseUrl,
+    `
+drop table if exists ${t.pass1};
+create unlogged table ${t.pass1} as
+select token, holder, balance, created_at, last_interaction from ${t.balance};
+`,
+  );
+  console.log("Write done. Snapshot recorded for reconcile.");
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// reconcile
+////////////////////////////////////////////////////////////////////////////////
+
+// Second pass of the low-downtime write. The bulk write runs while the indexer
+// is live, which clobbers deltas it applies during that write — but only for
+// pairs that traded in the window. Those pairs are exactly the ones appearing
+// in the catch-up sweep, so re-aggregating and writing just the rows whose
+// balance moved is equivalent to the single-pass write, with a stopped window
+// measured in seconds rather than minutes.
+function runReconcile(args) {
+  const t = stagingNames(args);
+  const schema = args.schema;
+  const chainId = Number(args.chainId);
+
+  const hasPass1 = psqlScalar(
+    args.databaseUrl,
+    `select to_regclass('${t.pass1}') is not null;`,
+  );
+  if (hasPass1 !== "t")
+    throw new Error(
+      `${t.pass1} not found — run --phase write --apply (which records it) before reconciling`,
+    );
+
+  console.log("Re-aggregating with catch-up deltas...");
+  runAggregate(args, true);
+
+  psqlExec(
+    args.databaseUrl,
+    `
+drop table if exists ${t.diff};
+create unlogged table ${t.diff} as
+select b.token, b.holder, b.balance, b.created_at, b.last_interaction
+from ${t.balance} b
+left join ${t.pass1} p on p.token = b.token and p.holder = b.holder
+where p.token is null
+   or p.balance is distinct from b.balance
+   or p.last_interaction is distinct from b.last_interaction;
+
+alter table ${t.diff} add column rn bigint;
+update ${t.diff} set rn = s.rn
+from (select ctid, row_number() over () as rn from ${t.diff}) s
+where ${t.diff}.ctid = s.ctid;
+create index on ${t.diff} (rn);
+`,
+  );
+
+  const diffCount = Number(
+    psqlScalar(args.databaseUrl, `select count(*) from ${t.diff};`),
+  );
+  console.log(`Pairs changed since the bulk write: ${diffCount}`);
+  if (diffCount === 0) {
+    console.log("Nothing to reconcile.");
+    return;
+  }
+  if (!args.apply) {
+    console.log("Dry-run: --phase reconcile requires --apply. Nothing written.");
+    return;
+  }
+
+  const batch = Number(args.writeBatch);
+  const maxRn = Number(
+    psqlScalar(args.databaseUrl, `select coalesce(max(rn), 0) from ${t.diff};`),
+  );
+  for (let lo = 1; lo <= maxRn; lo += batch) {
+    const hi = lo + batch - 1;
+    psqlExec(
+      args.databaseUrl,
+      `
+begin;
+alter table ${schema}."user" disable trigger user;
+insert into ${schema}."user" (address, chain_id, created_at, last_seen_at)
+select holder, ${chainId}, min(created_at), max(last_interaction)
+from ${t.diff} where rn between ${lo} and ${hi}
+group by holder
+on conflict (address, chain_id) do update set
+  last_seen_at = greatest(${schema}."user".last_seen_at, excluded.last_seen_at);
+alter table ${schema}."user" enable trigger user;
+
+alter table ${schema}.user_asset disable trigger user;
+insert into ${schema}.user_asset (chain_id, user_id, asset_id, balance, created_at, last_interaction)
+select ${chainId}, holder, token, balance, created_at, last_interaction
+from ${t.diff} where rn between ${lo} and ${hi}
+on conflict (user_id, asset_id, chain_id) do update set
+  balance = excluded.balance,
+  last_interaction = greatest(${schema}.user_asset.last_interaction, excluded.last_interaction);
+alter table ${schema}.user_asset enable trigger user;
+commit;
+`,
+    );
+    console.log(`  reconciled ${Math.min(hi, maxRn)}/${maxRn}`);
+  }
+
+  // Refresh the snapshot so a repeated reconcile is a no-op rather than a
+  // rewrite of the same rows.
+  psqlExec(
+    args.databaseUrl,
+    `
+drop table if exists ${t.pass1};
+create unlogged table ${t.pass1} as
+select token, holder, balance, created_at, last_interaction from ${t.balance};
+`,
+  );
+  console.log("Reconcile done.");
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -856,6 +1018,7 @@ async function main() {
   if (phase === "all" || phase === "sweep") await runSweep(args);
   if (phase === "all" || phase === "aggregate") runAggregate(args);
   if (phase === "all" || phase === "write") runWrite(args);
+  if (phase === "reconcile") runReconcile(args);
   if (phase === "all" || phase === "counts") runCounts(args);
 
   if (phase === "all" && !args.apply)


### PR DESCRIPTION
Fixes the root cause of the robinhood (chain 4663) `user_asset` incident, plus the tooling used to repair the ~300M Transfer logs it lost.

## Root cause: factory children are only persisted at finalize

Upstream ponder writes `ponder_sync.factory_addresses` **only** in the `"finalize"` branch of `handleRealtimeSyncEvent`, which lags the head by ~2x `finalityBlockCount`. Any child discovered inside that window is lost if the process stops before the next finalize — and because finalize records intervals by block range, the child's block is later marked covered, so nothing re-discovers it. On restart the child is missing from the in-memory set, every log it emits stops matching, and the contract silently vanishes from all child-filtered handlers.

On a chain launching contracts continuously this orphans a few contracts on **every restart**. Measured on 4663: 6 tokens lost across one afternoon of restarts, and ~91% of all children (31,952 of 35,226) missing after weeks of deploys. Swap rows kept landing (static PoolManager address) while `DERC20:Transfer` was dropped for the same transactions, which is what made it look like a per-user bug.

`patches/ponder@0.16.10.patch` now persists children at discovery. Trade-off, documented inline: a reorged block can leave a row for a contract that no longer exists, which is harmless (an extra address contributes no logs, and `getChildAddresses` dedupes) whereas a missing child drops real events. Over-inclusion is the safe direction. The finalize insert is left in place; duplicate rows are deduped on read.

## Repair tooling

- **`scripts/rebuild-transfer-balances.mjs`** (new). Backfilling the missing logs into `ponder_sync.logs` would have cost 150-200GB, so this sweeps Transfer logs from RPC and computes balances in flight instead: one unfiltered chain sweep, in-memory `(token, holder)` delta accumulation, staged to a scratch schema, aggregated in-DB, written as absolute balances. ~40k RPC calls versus ~50M for a per-token approach. Phases (`sweep`/`aggregate`/`write`/`reconcile`/`counts`) are individually runnable and the sweep is resumable.

  Two-pass write keeps the indexer stopped for seconds rather than the whole write: the bulk write runs live, then a short catch-up sweep plus `reconcile` fixes only the rows that disagree with prod.

- **`--force` on `backfill-derc20-transfers.mjs`**. The checkpoint seeding treats "has any Transfer row" as "fully handled", which is wrong for a token whose child registration was lost mid-life. `--force` (requires `--token`) refetches its full range; inserts are idempotent on the PK.

## Verification

Ran end-to-end against throwaway Postgres instances plus live chain data, reproducing the real failure modes: the sweep rebuilt the known-broken token's balance to the exact on-chain value (`20169468244776737005348`), a deliberately corrupted row was repaired by `reconcile`, and convergence reaches exactly 0 mismatches with `--write-batch 7` (many batches, which is what exposed the `rn` bug below). `tsc` clean, vitest 65/65.

Applied to production: `prod_2` now matches the rebuild on all 579,987 pairs, with 0 negative balances outside the zero address.

## Notes for reviewers

- Two bugs were found and fixed while running this live, both in the new script: `reconcile` diffed against its own snapshot instead of actual prod rows (missing pairs whose balance was equal at both endpoints but corrupted in between), and the `rn` batching column was populated via `UPDATE ... FROM (SELECT ctid, row_number() ...)` — `ctid` isn't stable across an UPDATE, so NULL-`rn` rows were silently skipped by every write batch. `rn` is now assigned inline with a guard.
- Operational sequence matters and is documented in the script header: stop the indexer, *then* read `_ponder_checkpoint`, sweep to exactly that block, reconcile, verify 0 mismatches, restart. Writing absolute balances while the indexer is ahead of your sweep end permanently drops the deltas in between.
- `sum(user_asset.balance) = token.total_supply` is not a valid invariant: burns park tokens at `balanceOf(0x0)` without reducing `totalSupply`, and the indexer excludes the zero address as a holder. Use "no negative balances" plus spot-checks against on-chain `balanceOf`.
- Worth adding separately: a monitor comparing on-chain factory Create counts against `factory_addresses` per factory, and a standing negative-balance check per chain. This class of bug is invisible without them.
