### PR TITLE
fix: zora creator coin holder counts

### DIFF
--- a/docs/features/holder-counts.md
+++ b/docs/features/holder-counts.md
@@ -1,0 +1,109 @@
+# Holder counts
+
+How many distinct wallets hold a token, maintained incrementally as transfers
+are indexed.
+
+## Scope
+
+- `token.holderCount` — the authoritative count for an asset.
+- `pool.holderCount` — a mirror of the token's count, denormalized onto the pool
+  row so explore/integrator queries can filter and sort (`pool_holder_count_idx`,
+  `pool_chain_quote_holders_idx`) without joining `token`.
+- Maintained by the two ERC20-style transfer handlers: `DERC20:Transfer` and
+  `ZoraCreatorCoinV4:CoinTransfer`.
+
+Not in scope:
+
+- `asset.holderCount` — present in the schema, initialized to `0`, and never
+  written by any handler. Do not read it.
+- `poolHourBucket.holderCount` / other bucket snapshots.
+- Content coins (`ZoraCoinV4`) — those handlers are commented out.
+
+## Invariants
+
+1. **`token.holderCount` is authoritative; `pool.holderCount` mirrors it.**
+   Every write sets both rows to the same value. The pool count is never derived
+   from its own previous value.
+2. A wallet is a holder when its balance is `> 0`. The zero address is never a
+   holder, so mints only add and burns only remove.
+3. The count includes contract addresses (pool manager, hook, the coin itself) —
+   whatever holds a positive balance. The backfill counts the same way, so live
+   and backfilled rows agree.
+4. Counts never go negative.
+
+Invariant 1 is the one that matters. A pool row is created *after* its token's
+first transfers: a Zora creator coin mints its supply inside its initializer,
+and the factory emits `CreatorCoinCreated` (which inserts the pool row) later in
+the same transaction. A pool counter that accumulated its own deltas would start
+life already behind the token and could never catch up — that is the bug this
+design exists to prevent.
+
+## Control flow
+
+### `ZoraCreatorCoinV4:CoinTransfer` (`src/indexer/indexer-zora.ts`)
+
+1. `db.find(token, ...)`. On a miss — which is the normal case for the mint
+   transfers in the creation transaction, since they precede
+   `CreatorCoinCreated` — the token is created by `upsertTokenWithPool` with
+   `poolAddress: null`.
+2. `batchUpsertUsersAndAssets` (`shared/entities/user-optimized.ts`) reads the
+   previous `userAsset` balances, writes the new absolute balances carried by
+   the event, and returns a `holderCountDelta` from
+   `computeHolderCountDelta` (`shared/entities/holder-count.ts`).
+3. When the delta is non-zero, `batchUpdateHolderCounts` writes
+   `nextHolderCount(tokenHolderCount, delta)` to `token`, then the same value to
+   `pool` when the token has a pool row. When `token.pool` is still `null`
+   (step 1), only the token is written — the pool picks the count up at creation.
+
+### `ZoraFactory:CreatorCoinCreated` (`src/indexer/indexer-zora.ts`)
+
+`insertZoraPoolV4Optimized` (`shared/entities/zora/pool.ts`) seeds the new pool's
+`holderCount` from the token row rather than starting at `0`, so a coin that is
+created and never traded still reports its mint holders.
+
+`ZoraCreatorCoinV4:LiquidityMigrated` carries the count across to the new pool
+row by spreading the old pool entity into the update.
+
+### `DERC20:Transfer` (`src/indexer/indexer-shared.ts`)
+
+Computes the delta from the `userAsset` balances it already loaded and writes
+`tokenData.holderCount + delta` to both `token` and `pool` — the same
+token-authoritative rule, inlined.
+
+## Files
+
+| File | Role |
+| --- | --- |
+| `src/indexer/shared/entities/holder-count.ts` | `computeHolderCountDelta`, `nextHolderCount` — the pure rules, unit tested |
+| `src/indexer/shared/entities/user-optimized.ts` | `batchUpsertUsersAndAssets` (balances + delta), `batchUpdateHolderCounts` (token + pool writes) |
+| `src/indexer/shared/entities/zora/pool.ts` | `insertZoraPoolV4Optimized` — seeds `holderCount` from the token at pool creation |
+| `src/indexer/indexer-zora.ts` | `ZoraCreatorCoinV4:CoinTransfer`, `ZoraFactory:CreatorCoinCreated` |
+| `src/indexer/indexer-shared.ts` | `DERC20:Transfer` |
+| `ponder.schema.ts` | `token.holderCount`, `pool.holderCount` and their indices |
+| `scripts/backfill-zora-creator-holders.mjs` | Recomputes creator coin counts from indexed `CoinTransfer` logs |
+
+## Backfill
+
+`scripts/backfill-zora-creator-holders.mjs` recomputes counts for existing rows.
+It reads `CoinTransfer` logs from `ponder_sync.logs` — no re-sync needed — and
+derives balances from the absolute post-transfer balances the event carries, so
+it does not depend on seeing every log.
+
+```bash
+# dry run: prints stored vs computed per coin
+node scripts/backfill-zora-creator-holders.mjs --schema prod_1
+
+# write holder_count on token + pool
+node scripts/backfill-zora-creator-holders.mjs --schema prod_1 --apply
+
+# also repair user / user_asset so future deltas start from correct balances
+node scripts/backfill-zora-creator-holders.mjs --schema prod_1 --with-balances --apply
+```
+
+Verify afterwards:
+
+```sql
+SELECT t.address, t.holder_count AS token_hc, p.holder_count AS pool_hc
+FROM token t JOIN pool p ON p.address = t.pool AND p.chain_id = t.chain_id
+WHERE t.is_creator_coin AND t.holder_count <> p.holder_count;
+```

--- a/scripts/backfill-zora-creator-holders.mjs
+++ b/scripts/backfill-zora-creator-holders.mjs
@@ -1,0 +1,583 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import process from "node:process";
+import { createPublicClient, http } from "viem";
+
+// CoinTransfer(address indexed sender, address indexed recipient,
+//              uint256 amount, uint256 senderBalance, uint256 recipientBalance)
+const COIN_TRANSFER_SELECTOR =
+  "0xa20126263d779da517a295859c8332765f45a215da1c42acac1b9e458a69a144";
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+const RPC_ENV_BY_CHAIN = {
+  1: ["PONDER_RPC_URL_1", "MAINNET_RPC"],
+  130: ["PONDER_RPC_URL_130", "UNICHAIN_RPC"],
+  143: ["PONDER_RPC_URL_143", "MONAD_RPC"],
+  8453: ["PONDER_RPC_URL_8453", "BASE_RPC", "BASE_RPC_URL"],
+  57073: ["PONDER_RPC_URL_57073", "INK_RPC"],
+};
+
+function loadDotEnv(path) {
+  if (!existsSync(path)) return;
+  for (const rawLine of readFileSync(path, "utf8").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const m = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (!m) continue;
+    const [, key, rawValue] = m;
+    if (process.env[key] !== undefined) continue;
+    process.env[key] = rawValue.trim().replace(/^(['"])(.*)\1$/, "$2");
+  }
+}
+
+loadDotEnv(resolve(process.cwd(), ".env"));
+loadDotEnv(resolve(process.cwd(), ".env.local"));
+
+function parseArgs(argv) {
+  const args = {
+    apply: false,
+    chainId: 8453,
+    schema: "prod_1",
+    pondersyncSchema: "ponder_sync",
+    databaseUrl: process.env.DATABASE_URL,
+    rpcUrl: undefined,
+    tokenConcurrency: 4,
+    rpcConcurrency: 8,
+    batchSize: 500,
+    limit: undefined,
+    token: undefined,
+    onlyZero: false,
+    withBalances: false,
+    skipUserUpsert: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--") continue;
+    if (a === "--help" || a === "-h") args.help = true;
+    else if (a === "--apply") args.apply = true;
+    else if (a === "--only-zero") args.onlyZero = true;
+    else if (a === "--with-balances") args.withBalances = true;
+    else if (a === "--skip-user-upsert") args.skipUserUpsert = true;
+    else if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const v = argv[++i];
+      if (v === undefined || v.startsWith("--"))
+        throw new Error(`Missing value for ${a}`);
+      if (key === "database-url") args.databaseUrl = v;
+      else if (key === "rpc-url") args.rpcUrl = v;
+      else if (key === "chain-id") args.chainId = Number(v);
+      else if (key === "schema") args.schema = v;
+      else if (key === "ponder-sync-schema") args.pondersyncSchema = v;
+      else if (key === "token-concurrency") args.tokenConcurrency = Number(v);
+      else if (key === "rpc-concurrency") args.rpcConcurrency = Number(v);
+      else if (key === "batch-size") args.batchSize = Number(v);
+      else if (key === "limit") args.limit = Number(v);
+      else if (key === "token") args.token = v.toLowerCase();
+      else throw new Error(`Unknown argument ${a}`);
+    } else throw new Error(`Unknown argument ${a}`);
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/backfill-zora-creator-holders.mjs [options]
+
+Recomputes holder_count for Zora creator coins from the CoinTransfer logs
+already present in ponder_sync.logs. For each creator coin token, this script:
+
+  1. Selects every CoinTransfer row for the coin in (block_number, log_index)
+     order.
+  2. Derives each address's current balance. CoinTransfer carries absolute
+     post-transfer balances for both sides, so the balance is read straight off
+     the last log an address appears in — no delta replay, and a missing log
+     window cannot skew the result.
+  3. UPDATEs holder_count on prod_<schema>.token and, when the token is linked
+     to a pool, on prod_<schema>.pool. Both rows get the same count: token is
+     authoritative and pool mirrors it.
+
+With --with-balances it also UPSERTs prod_<schema>.user_asset (and
+prod_<schema>.user) so the live handler's subsequent deltas start from correct
+per-wallet balances. Block timestamps come from ponder_sync.blocks, falling back
+to RPC for blocks the sync store does not have.
+
+Holders are counted exactly as the live indexer counts them: every address with
+a positive balance, including contracts such as the pool manager and the coin
+itself. The zero address is never counted.
+
+Options:
+  --chain-id <id>            EVM chain id. Default 8453.
+  --schema <name>            Materialized indexer schema. Default prod_1.
+  --ponder-sync-schema <s>   Sync schema name. Default ponder_sync.
+  --rpc-url <url>            RPC URL. Default \$BASE_RPC_URL etc. Only needed
+                             with --with-balances.
+  --database-url <url>       Postgres URL. Default \$DATABASE_URL.
+  --token-concurrency <n>    Tokens processed in parallel. Default 4.
+  --rpc-concurrency <n>      eth_getBlockByNumber calls in flight per token.
+                             Default 8.
+  --batch-size <n>           Rows per DB INSERT batch. Default 500.
+  --limit <n>                Process at most N tokens (after filtering).
+  --token <0x...>            Process exactly one token (ignores filters).
+  --only-zero                Only tokens whose token.holder_count is currently 0.
+  --with-balances            Also upsert user / user_asset rows.
+  --skip-user-upsert         With --with-balances, skip the user table
+                             (user_asset and holder_count still get written).
+  --apply                    Actually write. Default is dry-run.
+
+Dry-run prints the computed count next to the stored one so the drift is
+visible before anything is written.
+`);
+}
+
+function ql(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function topicToAddress(topic) {
+  const hex = topic.startsWith("0x") ? topic.slice(2) : topic;
+  return `0x${hex.slice(24).toLowerCase()}`;
+}
+
+/** Reads the nth 32-byte word of a log data blob as a bigint. */
+function dataWord(data, index) {
+  const hex = data.startsWith("0x") ? data.slice(2) : data;
+  const word = hex.slice(index * 64, (index + 1) * 64);
+  if (word.length < 64) throw new Error(`CoinTransfer data too short: ${data}`);
+  return BigInt(`0x${word}`);
+}
+
+function resolveRpcUrl(chainId, override) {
+  if (override) return override;
+  for (const name of RPC_ENV_BY_CHAIN[chainId] ?? []) {
+    if (process.env[name]) return process.env[name];
+  }
+  throw new Error(
+    `No RPC URL found for chain ${chainId}. Set --rpc-url or one of ${(RPC_ENV_BY_CHAIN[chainId] ?? []).join(", ")}.`,
+  );
+}
+
+function psqlJson(databaseUrl, sql) {
+  const out = execFileSync(
+    "psql",
+    [databaseUrl, "-X", "-A", "-t", "-v", "ON_ERROR_STOP=1", "-c", sql],
+    { encoding: "utf8", maxBuffer: 1024 * 1024 * 512 },
+  ).trim();
+  return JSON.parse(out || "[]");
+}
+
+function psqlReturning1(databaseUrl, sql) {
+  const stdout = execFileSync(
+    "psql",
+    [databaseUrl, "-X", "-A", "-t", "-v", "ON_ERROR_STOP=1"],
+    {
+      input: sql,
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024 * 512,
+      stdio: ["pipe", "pipe", "inherit"],
+    },
+  );
+  return stdout.split("\n").filter((line) => line.trim() === "1").length;
+}
+
+function psqlExec(databaseUrl, sql) {
+  execFileSync("psql", [databaseUrl, "-X", "-q", "-v", "ON_ERROR_STOP=1"], {
+    input: sql,
+    encoding: "utf8",
+    stdio: ["pipe", "inherit", "inherit"],
+  });
+}
+
+function psqlRowsTsv(databaseUrl, sql, minColumns) {
+  const stdout = execFileSync(
+    "psql",
+    [databaseUrl, "-X", "-A", "-t", "-v", "ON_ERROR_STOP=1", "-c", sql],
+    { encoding: "utf8", maxBuffer: 1024 * 1024 * 1024 },
+  );
+  const rows = [];
+  for (const line of stdout.split("\n")) {
+    if (!line) continue;
+    const parts = line.split("\t");
+    if (parts.length < minColumns) continue;
+    rows.push(parts);
+  }
+  return rows;
+}
+
+function selectWorkingSetSql(args) {
+  const tok = `${args.schema}.token`;
+
+  const filters = [
+    `t.chain_id = ${Number(args.chainId)}`,
+    "t.is_creator_coin = true",
+  ];
+  if (args.token) filters.push(`lower(t.address) = ${ql(args.token)}`);
+  else if (args.onlyZero) filters.push("t.holder_count = 0");
+
+  const limit = !args.token && args.limit ? `limit ${Number(args.limit)}` : "";
+
+  return `
+select coalesce(json_agg(q), '[]'::json) from (
+  select lower(t.address) as token,
+         t.chain_id::int as chain_id,
+         lower(t.pool) as pool,
+         t.holder_count::int as stored_holder_count
+  from ${tok} t
+  where ${filters.join("\n    and ")}
+  order by t.first_seen_at
+  ${limit}
+) q;`;
+}
+
+function selectTransfersSql(pondersyncSchema, chainId, tokenAddress) {
+  return `
+select block_number::text || E'\\t' || log_index::text || E'\\t' || topic1 || E'\\t' || topic2 || E'\\t' || data
+from ${pondersyncSchema}.logs
+where chain_id = ${Number(chainId)}
+  and lower(address) = ${ql(tokenAddress)}
+  and topic0 = ${ql(COIN_TRANSFER_SELECTOR)}
+order by block_number, log_index;`;
+}
+
+function selectBlockTimestampsSql(pondersyncSchema, chainId, blockNumbers) {
+  const list = blockNumbers.map((b) => `${b.toString()}`).join(",");
+  return `
+select number::text || E'\\t' || timestamp::text
+from ${pondersyncSchema}.blocks
+where chain_id = ${Number(chainId)}
+  and number in (${list});`;
+}
+
+async function* orderedPrefetch(items, fetcher, concurrency) {
+  const inflight = [];
+  let i = 0;
+  const start = (idx) => ({ item: items[idx], promise: fetcher(items[idx]) });
+  while (i < items.length && inflight.length < concurrency) {
+    inflight.push(start(i));
+    i++;
+  }
+  while (inflight.length > 0) {
+    const next = inflight.shift();
+    const result = await next.promise;
+    if (i < items.length) {
+      inflight.push(start(i));
+      i++;
+    }
+    yield { item: next.item, result };
+  }
+}
+
+async function fetchBlockTimestamp(client, blockNumber, attempts = 4) {
+  let lastErr;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      const block = await client.request({
+        method: "eth_getBlockByNumber",
+        params: [`0x${BigInt(blockNumber).toString(16)}`, false],
+      });
+      if (!block) throw new Error(`block ${blockNumber} not found`);
+      return BigInt(block.timestamp);
+    } catch (err) {
+      lastErr = err;
+      await new Promise((r) => setTimeout(r, 200 * 2 ** attempt));
+    }
+  }
+  throw lastErr;
+}
+
+/**
+ * Lazily built so a run whose blocks are all present in ponder_sync.blocks
+ * needs no RPC URL at all.
+ */
+function makeClientFactory(args) {
+  let client;
+  return () => {
+    if (!client) {
+      client = createPublicClient({
+        transport: http(resolveRpcUrl(args.chainId, args.rpcUrl), {
+          timeout: 30_000,
+          retryCount: 3,
+        }),
+      });
+    }
+    return client;
+  };
+}
+
+async function fetchBlockTimestamps(args, getClient, blockNumbers) {
+  const map = new Map();
+  const unique = [...new Set(blockNumbers.map((b) => b.toString()))];
+  if (unique.length === 0) return map;
+
+  for (const [number, timestamp] of psqlRowsTsv(
+    args.databaseUrl,
+    selectBlockTimestampsSql(args.pondersyncSchema, args.chainId, unique),
+    2,
+  )) {
+    map.set(number, BigInt(timestamp));
+  }
+
+  const missing = unique.filter((n) => !map.has(n));
+  if (missing.length === 0) return map;
+
+  const client = getClient();
+  const fetcher = (bn) => fetchBlockTimestamp(client, bn);
+  for await (const { item, result } of orderedPrefetch(
+    missing.map((s) => BigInt(s)),
+    fetcher,
+    args.rpcConcurrency,
+  )) {
+    map.set(item.toString(), result);
+  }
+  return map;
+}
+
+/**
+ * CoinTransfer reports absolute post-transfer balances for both sides, so the
+ * current balance of an address is whatever the last log it appears in said.
+ */
+function deriveBalances(transfers) {
+  const balances = new Map();
+  const firstSeen = new Map();
+  const lastInteraction = new Map();
+
+  for (const [blockNumber, , topic1, topic2, data] of transfers) {
+    const sender = topicToAddress(topic1);
+    const recipient = topicToAddress(topic2);
+    const senderBalance = dataWord(data, 1);
+    const recipientBalance = dataWord(data, 2);
+
+    for (const [address, balance] of [
+      [sender, senderBalance],
+      [recipient, recipientBalance],
+    ]) {
+      if (address === ZERO_ADDRESS) continue;
+      balances.set(address, balance);
+      lastInteraction.set(address, blockNumber);
+      if (!firstSeen.has(address)) firstSeen.set(address, blockNumber);
+    }
+  }
+
+  return { balances, firstSeen, lastInteraction };
+}
+
+function chunk(array, size) {
+  const out = [];
+  for (let i = 0; i < array.length; i += size) out.push(array.slice(i, i + size));
+  return out;
+}
+
+function writeUserAssetBatch(databaseUrl, schema, rows) {
+  if (rows.length === 0) return 0;
+  const values = rows
+    .map(
+      (r) =>
+        `(${Number(r.chainId)}, ${ql(r.userId)}, ${ql(r.assetId)}, ${r.balance.toString()}, ${r.createdAt.toString()}, ${r.lastInteraction.toString()})`,
+    )
+    .join(",\n");
+  const sql = `
+begin;
+alter table ${schema}.user_asset disable trigger user;
+insert into ${schema}.user_asset (chain_id, user_id, asset_id, balance, created_at, last_interaction)
+values
+${values}
+on conflict (user_id, asset_id, chain_id) do update set
+  balance = excluded.balance,
+  last_interaction = greatest(${schema}.user_asset.last_interaction, excluded.last_interaction)
+returning 1;
+alter table ${schema}.user_asset enable trigger user;
+commit;
+`;
+  return psqlReturning1(databaseUrl, sql);
+}
+
+function writeUsersBatch(databaseUrl, schema, rows) {
+  if (rows.length === 0) return 0;
+  const values = rows
+    .map(
+      (r) =>
+        `(${ql(r.address)}, ${Number(r.chainId)}, ${r.createdAt.toString()}, ${r.lastSeenAt.toString()})`,
+    )
+    .join(",\n");
+  const sql = `
+begin;
+alter table ${schema}."user" disable trigger user;
+insert into ${schema}."user" (address, chain_id, created_at, last_seen_at)
+values
+${values}
+on conflict (address, chain_id) do update set
+  last_seen_at = greatest(${schema}."user".last_seen_at, excluded.last_seen_at)
+returning 1;
+alter table ${schema}."user" enable trigger user;
+commit;
+`;
+  return psqlReturning1(databaseUrl, sql);
+}
+
+function setHolderCounts(databaseUrl, schema, chainId, tokenAddress, poolAddress, holderCount) {
+  const parts = [
+    "begin;",
+    `alter table ${schema}.token disable trigger user;`,
+    `update ${schema}.token set holder_count = ${Number(holderCount)} where lower(address) = ${ql(tokenAddress)} and chain_id = ${Number(chainId)};`,
+    `alter table ${schema}.token enable trigger user;`,
+  ];
+  if (poolAddress && poolAddress !== ZERO_ADDRESS) {
+    parts.push(
+      `alter table ${schema}.pool disable trigger user;`,
+      `update ${schema}.pool set holder_count = ${Number(holderCount)} where lower(address) = ${ql(poolAddress)} and chain_id = ${Number(chainId)};`,
+      `alter table ${schema}.pool enable trigger user;`,
+    );
+  }
+  parts.push("commit;");
+  psqlExec(databaseUrl, parts.join("\n"));
+}
+
+async function buildPlanForToken(args, getClient, work) {
+  const transfers = psqlRowsTsv(
+    args.databaseUrl,
+    selectTransfersSql(args.pondersyncSchema, args.chainId, work.token),
+    5,
+  );
+
+  const { balances, firstSeen, lastInteraction } = deriveBalances(transfers);
+  const holderCount = [...balances.values()].filter((b) => b > 0n).length;
+
+  let blockTimestamps = new Map();
+  if (args.apply && args.withBalances && balances.size > 0) {
+    blockTimestamps = await fetchBlockTimestamps(args, getClient, [
+      ...firstSeen.values(),
+      ...lastInteraction.values(),
+    ]);
+  }
+
+  return {
+    work,
+    transferCount: transfers.length,
+    balances,
+    firstSeen,
+    lastInteraction,
+    blockTimestamps,
+    holderCount,
+  };
+}
+
+function applyPlan(args, plan) {
+  const { work, balances, firstSeen, lastInteraction, blockTimestamps, holderCount } = plan;
+
+  if (!args.apply) {
+    return { ...plan, usersWritten: 0, userAssetsWritten: 0 };
+  }
+
+  let usersWritten = 0;
+  let userAssetsWritten = 0;
+
+  if (args.withBalances) {
+    const userRows = [];
+    const userAssetRows = [];
+    for (const [address, balance] of balances.entries()) {
+      const createdAt = blockTimestamps.get(String(firstSeen.get(address))) ?? 0n;
+      const lastTs =
+        blockTimestamps.get(String(lastInteraction.get(address))) ?? createdAt;
+      userRows.push({
+        address,
+        chainId: args.chainId,
+        createdAt,
+        lastSeenAt: lastTs,
+      });
+      userAssetRows.push({
+        chainId: args.chainId,
+        userId: address,
+        assetId: work.token,
+        balance,
+        createdAt,
+        lastInteraction: lastTs,
+      });
+    }
+
+    if (!args.skipUserUpsert) {
+      for (const slice of chunk(userRows, args.batchSize)) {
+        usersWritten += writeUsersBatch(args.databaseUrl, args.schema, slice);
+      }
+    }
+    for (const slice of chunk(userAssetRows, args.batchSize)) {
+      userAssetsWritten += writeUserAssetBatch(args.databaseUrl, args.schema, slice);
+    }
+  }
+
+  setHolderCounts(
+    args.databaseUrl,
+    args.schema,
+    args.chainId,
+    work.token,
+    work.pool,
+    holderCount,
+  );
+
+  return { ...plan, usersWritten, userAssetsWritten };
+}
+
+async function tokenPipeline(args, getClient, workingSet) {
+  const builder = (work) => buildPlanForToken(args, getClient, work);
+
+  let processed = 0;
+  let failed = 0;
+  let drifted = 0;
+  const totals = { transfers: 0, holders: 0, userAssets: 0, users: 0 };
+
+  for await (const { result: plan } of orderedPrefetch(
+    workingSet,
+    builder,
+    args.tokenConcurrency,
+  )) {
+    try {
+      const start = Date.now();
+      const res = applyPlan(args, plan);
+      processed++;
+      totals.transfers += res.transferCount;
+      totals.holders += res.holderCount;
+      totals.userAssets += res.userAssetsWritten;
+      totals.users += res.usersWritten;
+      const stored = plan.work.stored_holder_count;
+      if (stored !== res.holderCount) drifted++;
+      console.log(
+        `${plan.work.token}  transfers=${res.transferCount}  stored=${stored}  computed=${res.holderCount}  user_assets=${res.userAssetsWritten}  ${Date.now() - start}ms  (${processed}/${workingSet.length})`,
+      );
+    } catch (err) {
+      failed++;
+      console.error(`${plan.work.token} FAILED: ${err.message || err}`);
+    }
+  }
+
+  return { processed, failed, drifted, totals };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) return printHelp();
+  if (!args.databaseUrl) throw new Error("Missing DATABASE_URL");
+
+  // Only --with-balances needs block timestamps, and only for blocks that
+  // ponder_sync.blocks is missing — so the RPC client is built on first use.
+  const getClient = makeClientFactory(args);
+
+  const workingSet = psqlJson(args.databaseUrl, selectWorkingSetSql(args));
+  console.log(`Selected ${workingSet.length} creator coin(s).`);
+  if (workingSet.length === 0) return;
+  if (!args.apply) console.log("(dry-run; pass --apply to actually write)");
+
+  const { processed, failed, drifted, totals } = await tokenPipeline(
+    args,
+    getClient,
+    workingSet,
+  );
+  console.log(
+    `Done. processed=${processed} failed=${failed} drifted=${drifted} transfers=${totals.transfers} holders=${totals.holders} user_assets=${totals.userAssets} users=${totals.users}`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err.stack || err.message || err);
+  process.exit(1);
+});

--- a/src/indexer/shared/entities/holder-count.test.ts
+++ b/src/indexer/shared/entities/holder-count.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+import { computeHolderCountDelta, nextHolderCount } from "./holder-count";
+
+const ZERO = "0x0000000000000000000000000000000000000000";
+const ALICE = "0x1111111111111111111111111111111111111111";
+const BOB = "0x2222222222222222222222222222222222222222";
+
+const delta = (params: Partial<Parameters<typeof computeHolderCountDelta>[0]>) =>
+  computeHolderCountDelta({
+    senderAddress: ALICE,
+    recipientAddress: BOB,
+    senderPreviousBalance: 0n,
+    senderBalance: 0n,
+    recipientPreviousBalance: 0n,
+    recipientBalance: 0n,
+    ...params,
+  });
+
+describe("computeHolderCountDelta", () => {
+  it("counts a mint to a new address as a gained holder", () => {
+    expect(
+      delta({
+        senderAddress: ZERO,
+        recipientPreviousBalance: 0n,
+        recipientBalance: 1000n,
+      }),
+    ).toBe(1);
+  });
+
+  it("does not count a mint to an existing holder", () => {
+    expect(
+      delta({
+        senderAddress: ZERO,
+        recipientPreviousBalance: 500n,
+        recipientBalance: 1500n,
+      }),
+    ).toBe(0);
+  });
+
+  it("never counts the zero address as a holder on a mint", () => {
+    // The zero address' balance is meaningless; it must not be treated as an exit.
+    expect(
+      delta({
+        senderAddress: ZERO,
+        senderPreviousBalance: 1000n,
+        senderBalance: 0n,
+        recipientPreviousBalance: 0n,
+        recipientBalance: 1000n,
+      }),
+    ).toBe(1);
+  });
+
+  it("counts a full burn as a lost holder", () => {
+    expect(
+      delta({
+        recipientAddress: ZERO,
+        senderPreviousBalance: 1000n,
+        senderBalance: 0n,
+      }),
+    ).toBe(-1);
+  });
+
+  it("does not count a partial burn", () => {
+    expect(
+      delta({
+        recipientAddress: ZERO,
+        senderPreviousBalance: 1000n,
+        senderBalance: 400n,
+      }),
+    ).toBe(0);
+  });
+
+  it("never counts the zero address as a gained holder on a burn", () => {
+    expect(
+      delta({
+        recipientAddress: ZERO,
+        senderPreviousBalance: 1000n,
+        senderBalance: 400n,
+        recipientPreviousBalance: 0n,
+        recipientBalance: 1000n,
+      }),
+    ).toBe(0);
+  });
+
+  it("counts a transfer to a new address as a gained holder", () => {
+    expect(
+      delta({
+        senderPreviousBalance: 1000n,
+        senderBalance: 400n,
+        recipientPreviousBalance: 0n,
+        recipientBalance: 600n,
+      }),
+    ).toBe(1);
+  });
+
+  it("nets to zero when the sender exits and the recipient is new", () => {
+    expect(
+      delta({
+        senderPreviousBalance: 1000n,
+        senderBalance: 0n,
+        recipientPreviousBalance: 0n,
+        recipientBalance: 1000n,
+      }),
+    ).toBe(-1 + 1);
+  });
+
+  it("counts a full transfer between existing holders as no change", () => {
+    expect(
+      delta({
+        senderPreviousBalance: 1000n,
+        senderBalance: 400n,
+        recipientPreviousBalance: 200n,
+        recipientBalance: 800n,
+      }),
+    ).toBe(0);
+  });
+
+  it("counts the sender emptying out as a lost holder", () => {
+    expect(
+      delta({
+        senderPreviousBalance: 1000n,
+        senderBalance: 0n,
+        recipientPreviousBalance: 200n,
+        recipientBalance: 1200n,
+      }),
+    ).toBe(-1);
+  });
+
+  it("ignores a zero-value transfer between existing holders", () => {
+    expect(
+      delta({
+        senderPreviousBalance: 1000n,
+        senderBalance: 1000n,
+        recipientPreviousBalance: 200n,
+        recipientBalance: 200n,
+      }),
+    ).toBe(0);
+  });
+
+  it("ignores a zero-value transfer to an address that stays empty", () => {
+    expect(
+      delta({
+        senderPreviousBalance: 1000n,
+        senderBalance: 1000n,
+        recipientPreviousBalance: 0n,
+        recipientBalance: 0n,
+      }),
+    ).toBe(0);
+  });
+
+  it("matches on the zero address regardless of casing", () => {
+    expect(
+      delta({
+        senderAddress: "0x0000000000000000000000000000000000000000".toUpperCase(),
+        senderPreviousBalance: 1000n,
+        senderBalance: 0n,
+        recipientBalance: 1000n,
+      }),
+    ).toBe(1);
+  });
+});
+
+describe("nextHolderCount", () => {
+  it("applies the delta to the current count", () => {
+    expect(nextHolderCount(5, 1)).toBe(6);
+    expect(nextHolderCount(5, -1)).toBe(4);
+    expect(nextHolderCount(5, 0)).toBe(5);
+  });
+
+  it("clamps at zero so an under-counted row never goes negative", () => {
+    expect(nextHolderCount(0, -1)).toBe(0);
+    expect(nextHolderCount(1, -3)).toBe(0);
+  });
+});

--- a/src/indexer/shared/entities/holder-count.ts
+++ b/src/indexer/shared/entities/holder-count.ts
@@ -1,0 +1,62 @@
+/**
+ * Holder-count bookkeeping shared by the ERC20-style transfer handlers.
+ *
+ * `token.holderCount` is the authoritative count for an asset; `pool.holderCount`
+ * mirrors it so explore queries can filter and sort on the pool row without a
+ * join. The pool count must always be derived from the token count, never from
+ * the pool's own previous value: a coin mints its supply (and gains its first
+ * holders) before its pool row exists, so a self-relative pool counter starts
+ * life behind and can never catch up.
+ */
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+export interface HolderCountDeltaParams {
+  senderAddress: string;
+  recipientAddress: string;
+  /** Sender balance before the transfer. */
+  senderPreviousBalance: bigint;
+  /** Sender balance after the transfer. */
+  senderBalance: bigint;
+  /** Recipient balance before the transfer. */
+  recipientPreviousBalance: bigint;
+  /** Recipient balance after the transfer. */
+  recipientBalance: bigint;
+}
+
+/**
+ * Holder count only moves when a wallet crosses 0 <-> positive. The zero address
+ * is never a holder, so mints only ever add and burns only ever remove.
+ */
+export const computeHolderCountDelta = ({
+  senderAddress,
+  recipientAddress,
+  senderPreviousBalance,
+  senderBalance,
+  recipientPreviousBalance,
+  recipientBalance,
+}: HolderCountDeltaParams): number => {
+  const isMint = senderAddress.toLowerCase() === ZERO_ADDRESS;
+  const isBurn = recipientAddress.toLowerCase() === ZERO_ADDRESS;
+
+  let delta = 0;
+
+  if (!isBurn && recipientPreviousBalance === 0n && recipientBalance > 0n) {
+    delta += 1;
+  }
+
+  if (!isMint && senderPreviousBalance > 0n && senderBalance === 0n) {
+    delta -= 1;
+  }
+
+  return delta;
+};
+
+/**
+ * Applies a delta to the authoritative token count. Clamped at zero so a row
+ * that starts out under-counted (rows written before this bookkeeping was
+ * correct, pending a backfill) degrades to 0 rather than to a negative count
+ * that would poison `order by holder_count`.
+ */
+export const nextHolderCount = (current: number, delta: number): number =>
+  Math.max(0, current + delta);

--- a/src/indexer/shared/entities/user-optimized.test.ts
+++ b/src/indexer/shared/entities/user-optimized.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import { pool, token } from "ponder:schema";
+import { batchUpdateHolderCounts } from "./user-optimized";
+
+const CHAIN_ID = 8453;
+const TOKEN = "0x1111111111111111111111111111111111111111";
+const POOL = "0x2222222222222222222222222222222222222222";
+const ZERO = "0x0000000000000000000000000000000000000000";
+
+interface UpdateCall {
+  table: unknown;
+  key: Record<string, unknown>;
+  values: Record<string, unknown>;
+}
+
+const makeContext = ({ poolRow }: { poolRow: { holderCount: number } | null }) => {
+  const updates: UpdateCall[] = [];
+  const finds: { table: unknown; key: Record<string, unknown> }[] = [];
+
+  const context = {
+    chain: { id: CHAIN_ID },
+    db: {
+      find: async (table: unknown, key: Record<string, unknown>) => {
+        finds.push({ table, key });
+        return table === pool ? poolRow : null;
+      },
+      update: (table: unknown, key: Record<string, unknown>) => ({
+        set: async (values: Record<string, unknown>) => {
+          updates.push({ table, key, values });
+        },
+      }),
+    },
+  };
+
+  return { context, updates, finds };
+};
+
+const updateFor = (updates: UpdateCall[], table: unknown) =>
+  updates.filter((u) => u.table === table);
+
+describe("batchUpdateHolderCounts", () => {
+  it("writes the same token-derived count to token and pool", async () => {
+    const { context, updates } = makeContext({ poolRow: { holderCount: 0 } });
+
+    await batchUpdateHolderCounts({
+      tokenAddress: TOKEN,
+      poolAddress: POOL,
+      holderCountDelta: 1,
+      currentTokenHolderCount: 12,
+      context: context as any,
+    });
+
+    expect(updateFor(updates, token)).toHaveLength(1);
+    expect(updateFor(updates, token)[0]!.values).toEqual({ holderCount: 13 });
+    expect(updateFor(updates, pool)).toHaveLength(1);
+    expect(updateFor(updates, pool)[0]!.values).toEqual({ holderCount: 13 });
+  });
+
+  it("heals a pool row that was created after the token already had holders", async () => {
+    // The regression: pool rows for Zora creator coins are inserted at 0 while
+    // the token already counts the mint holders. Deriving from the pool's own
+    // value would write 1 here and stay permanently behind.
+    const { context, updates } = makeContext({ poolRow: { holderCount: 0 } });
+
+    await batchUpdateHolderCounts({
+      tokenAddress: TOKEN,
+      poolAddress: POOL,
+      holderCountDelta: 1,
+      currentTokenHolderCount: 40,
+      context: context as any,
+    });
+
+    expect(updateFor(updates, pool)[0]!.values).toEqual({ holderCount: 41 });
+  });
+
+  it("applies a negative delta to both rows", async () => {
+    const { context, updates } = makeContext({ poolRow: { holderCount: 9 } });
+
+    await batchUpdateHolderCounts({
+      tokenAddress: TOKEN,
+      poolAddress: POOL,
+      holderCountDelta: -1,
+      currentTokenHolderCount: 9,
+      context: context as any,
+    });
+
+    expect(updateFor(updates, token)[0]!.values).toEqual({ holderCount: 8 });
+    expect(updateFor(updates, pool)[0]!.values).toEqual({ holderCount: 8 });
+  });
+
+  it("never writes a negative count", async () => {
+    const { context, updates } = makeContext({ poolRow: { holderCount: 0 } });
+
+    await batchUpdateHolderCounts({
+      tokenAddress: TOKEN,
+      poolAddress: POOL,
+      holderCountDelta: -1,
+      currentTokenHolderCount: 0,
+      context: context as any,
+    });
+
+    expect(updateFor(updates, token)[0]!.values).toEqual({ holderCount: 0 });
+    expect(updateFor(updates, pool)[0]!.values).toEqual({ holderCount: 0 });
+  });
+
+  it("writes nothing when the delta is zero", async () => {
+    const { context, updates, finds } = makeContext({ poolRow: { holderCount: 3 } });
+
+    await batchUpdateHolderCounts({
+      tokenAddress: TOKEN,
+      poolAddress: POOL,
+      holderCountDelta: 0,
+      currentTokenHolderCount: 3,
+      context: context as any,
+    });
+
+    expect(updates).toHaveLength(0);
+    expect(finds).toHaveLength(0);
+  });
+
+  it("still updates the token when the coin has no pool row yet", async () => {
+    const { context, updates } = makeContext({ poolRow: null });
+
+    await batchUpdateHolderCounts({
+      tokenAddress: TOKEN,
+      poolAddress: POOL,
+      holderCountDelta: 1,
+      currentTokenHolderCount: 4,
+      context: context as any,
+    });
+
+    expect(updateFor(updates, token)[0]!.values).toEqual({ holderCount: 5 });
+    expect(updateFor(updates, pool)).toHaveLength(0);
+  });
+
+  it("skips the pool lookup when the token has no pool linked", async () => {
+    const { context, updates, finds } = makeContext({ poolRow: { holderCount: 0 } });
+
+    await batchUpdateHolderCounts({
+      tokenAddress: TOKEN,
+      poolAddress: null,
+      holderCountDelta: 1,
+      currentTokenHolderCount: 4,
+      context: context as any,
+    });
+
+    expect(updateFor(updates, token)[0]!.values).toEqual({ holderCount: 5 });
+    expect(finds).toHaveLength(0);
+  });
+
+  it("skips the pool lookup for a zero-address pool", async () => {
+    const { context, finds } = makeContext({ poolRow: { holderCount: 0 } });
+
+    await batchUpdateHolderCounts({
+      tokenAddress: TOKEN,
+      poolAddress: ZERO,
+      holderCountDelta: 1,
+      currentTokenHolderCount: 4,
+      context: context as any,
+    });
+
+    expect(finds).toHaveLength(0);
+  });
+
+  it("lowercases addresses on every write", async () => {
+    const { context, updates, finds } = makeContext({ poolRow: { holderCount: 0 } });
+
+    await batchUpdateHolderCounts({
+      tokenAddress: TOKEN.toUpperCase() as `0x${string}`,
+      poolAddress: POOL.toUpperCase() as `0x${string}`,
+      holderCountDelta: 1,
+      currentTokenHolderCount: 1,
+      context: context as any,
+    });
+
+    expect(updateFor(updates, token)[0]!.key).toEqual({
+      address: TOKEN,
+      chainId: CHAIN_ID,
+    });
+    expect(finds[0]!.key).toEqual({ address: POOL, chainId: CHAIN_ID });
+    expect(updateFor(updates, pool)[0]!.key).toEqual({
+      address: POOL,
+      chainId: CHAIN_ID,
+    });
+  });
+});

--- a/src/indexer/shared/entities/user-optimized.ts
+++ b/src/indexer/shared/entities/user-optimized.ts
@@ -1,6 +1,7 @@
 import { Context } from "ponder:registry";
 import { user, userAsset } from "ponder:schema";
-import { Address } from "viem";
+import { Address, zeroAddress } from "viem";
+import { computeHolderCountDelta, nextHolderCount } from "./holder-count";
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000" as `0x${string}`;
 
@@ -84,33 +85,14 @@ export const batchUpsertUsersAndAssets = async ({
     chainId: chain.id,
   }) : null;
   
-  let holderCountDelta = 0;
-  
-  if (isMint && recipientBalance > 0n) {
-    const recipientPrevBalance = existingRecipientAsset?.balance ?? 0n;
-    if (recipientPrevBalance === 0n) {
-      holderCountDelta += 1;
-    }
-  }
-
-  else if (isBurn && senderBalance === 0n) {
-    const senderPrevBalance = existingSenderAsset?.balance ?? 0n;
-    if (senderPrevBalance > 0n) {
-      holderCountDelta -= 1;
-    }
-  }
-
-  else if (!isMint && !isBurn) {
-    const senderPrevBalance = existingSenderAsset?.balance ?? 0n;
-    const recipientPrevBalance = existingRecipientAsset?.balance ?? 0n;
-    
-    if (recipientPrevBalance === 0n && recipientBalance > 0n) {
-      holderCountDelta += 1;
-    }
-    if (senderPrevBalance > 0n && senderBalance === 0n) {
-      holderCountDelta -= 1;
-    }
-  }
+  const holderCountDelta = computeHolderCountDelta({
+    senderAddress: senderLower,
+    recipientAddress: recipientLower,
+    senderPreviousBalance: existingSenderAsset?.balance ?? 0n,
+    senderBalance,
+    recipientPreviousBalance: existingRecipientAsset?.balance ?? 0n,
+    recipientBalance,
+  });
 
   // Batch upsert user assets (skip zero address)
   let senderAsset: typeof userAsset.$inferSelect | null = null;
@@ -168,7 +150,10 @@ export const batchUpsertUsersAndAssets = async ({
 };
 
 /**
- * Batch update holder counts for multiple entities
+ * Batch update holder counts for multiple entities.
+ *
+ * `token` is authoritative and `pool` mirrors it — see `holder-count.ts` for why
+ * the pool count is never derived from its own previous value.
  */
 export const batchUpdateHolderCounts = async ({
   tokenAddress,
@@ -189,26 +174,31 @@ export const batchUpdateHolderCounts = async ({
     return;
   }
 
+  const holderCount = nextHolderCount(currentTokenHolderCount, holderCountDelta);
+
   // Update token holder count first (must succeed independently)
   await db.update(token, {
     address: tokenAddress.toLowerCase() as `0x${string}`,
     chainId: chain.id,
   }).set({
-    holderCount: currentTokenHolderCount + holderCountDelta,
+    holderCount,
   });
 
-  // Update pool holder count separately using the pool's own current value
-  if (poolAddress) {
+  // Mirror the authoritative token count onto the pool. Writing the token-derived
+  // value (rather than poolEntity.holderCount + delta) also self-heals pool rows
+  // created after the token already had holders.
+  if (poolAddress && poolAddress.toLowerCase() !== zeroAddress) {
+    const address = poolAddress.toLowerCase() as `0x${string}`;
     const poolEntity = await db.find(pool, {
-      address: poolAddress.toLowerCase() as `0x${string}`,
+      address,
       chainId: chain.id,
     });
     if (poolEntity) {
       await db.update(pool, {
-        address: poolAddress.toLowerCase() as `0x${string}`,
+        address,
         chainId: chain.id,
       }).set({
-        holderCount: poolEntity.holderCount + holderCountDelta,
+        holderCount,
       });
     }
   }

--- a/src/indexer/shared/entities/zora/pool.ts
+++ b/src/indexer/shared/entities/zora/pool.ts
@@ -1,7 +1,7 @@
 import { PoolKey } from "@app/types";
 import { MarketDataService, PriceService } from "@app/core";
 import { Context } from "ponder:registry";
-import { pool } from "ponder:schema";
+import { pool, token } from "ponder:schema";
 import { Address, zeroAddress } from "viem";
 import { ZoraV4HookABI } from "@app/abis/ZoraV4HookABI";
 import { StateViewABI } from "@app/abis";
@@ -160,7 +160,16 @@ export const insertZoraPoolV4Optimized = async ({
     marketCapUsd,
     poolAddress: address
   })
-  
+
+  // The coin mints its supply — and so gains its first holders — before the
+  // factory emits the event that creates this pool row, so those transfers land
+  // on the token while `token.pool` is still null. Seed from the token instead
+  // of starting at 0, otherwise the pool can never catch up.
+  const baseTokenEntity = await db.find(token, {
+    address: baseToken.toLowerCase() as `0x${string}`,
+    chainId,
+  });
+
   const isQuoteEth = quoteInfo.quoteToken === QuoteToken.Eth;
   
   // Insert new pool with all data at once
@@ -195,7 +204,7 @@ export const insertZoraPoolV4Optimized = async ({
     integrator: zeroAddress,
     isContentCoin,
     isCreatorCoin,
-    holderCount: 0,
+    holderCount: baseTokenEntity?.holderCount ?? 0,
     lastSwapTimestamp: timestamp,
     lastRefreshed: timestamp,
     poolKey: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
   resolve: {
     alias: {
       '@app': path.resolve(__dirname, './src'),
+      // Ponder resolves this virtual module at build time; map it so entity
+      // modules that import table definitions can be unit tested.
+      'ponder:schema': path.resolve(__dirname, './ponder.schema.ts'),
     },
   },
 });


### PR DESCRIPTION
Zora creator coins report `holder_count = 0` on `pool` (and, for existing rows, on `token`).

## Why

`pool.holderCount` was maintained as an independent counter (`poolEntity.holderCount + delta`) that starts at 0 when the pool row is inserted. For a creator coin the pool row is created *after* the token's first transfers: the coin mints its supply inside its initializer, and `ZoraFactory:CreatorCoinCreated` — which inserts the pool row — is emitted later in the same transaction.

So during those mint transfers `db.find(token, ...)` misses, the handler creates the token via `upsertTokenWithPool({ poolAddress: null })`, and `batchUpdateHolderCounts` gets `poolAddress: null` and skips the pool entirely. `insertZoraPoolV4Optimized` then inserts the pool with a hardcoded `holderCount: 0`. A coin whose only transfers are the creation ones sits at 0 forever; one that goes on to trade counts up from 0, and drifts back toward 0 as creation-time holders exit (their `-1` is subtracted from a base that never included them).

`DERC20:Transfer` never had this problem because it writes `tokenData.holderCount + delta` to the pool — it re-syncs the pool to the authoritative token count on every holder change, so a bad start heals itself.

## What changed

- `batchUpdateHolderCounts` writes the token-derived count to both `token` and `pool`, matching the DERC20 path. Pool rows now self-heal on the next holder change. Also skips the pool lookup for a zero-address pool, as DERC20 already did.
- `insertZoraPoolV4Optimized` seeds `holderCount` from the token row instead of `0`, so a coin that is created and never traded still reports its mint holders. Both event orderings are covered.
- New `holder-count.ts` holds the rules as pure functions — `computeHolderCountDelta` (replaces the three inline mint/burn/transfer branches, behavior-equivalent) and `nextHolderCount` (applies a delta, clamped at 0 so rows that are under-counted pending the backfill can't go negative and poison `order by holder_count`).
- 24 tests covering the delta rules and the token→pool propagation, including the regression itself. Testing `user-optimized.ts` needed a `ponder:schema` alias in `vitest.config.ts`, since it value-imports the table definitions.
- `docs/features/holder-counts.md` documents the invariant: `token` is authoritative, `pool` mirrors it, and the pool count is never derived from its own previous value.

`asset.holderCount` is untouched — it is initialized to 0 and never written by any handler, on any path. It should not be read.

## Backfill

`scripts/backfill-zora-creator-holders.mjs` repairs existing rows. It reads `CoinTransfer` logs already present in `ponder_sync.logs`, so no re-sync is needed, and it needs no RPC unless you ask it to rewrite balances. `CoinTransfer` carries absolute post-transfer balances for both sides, so each address's balance is read off the last log it appears in rather than replayed from deltas — a gap in the log history cannot skew the result.

```bash
node scripts/backfill-zora-creator-holders.mjs --schema prod_1                     # dry-run: stored vs computed per coin
node scripts/backfill-zora-creator-holders.mjs --schema prod_1 --apply             # token + pool holder_count
node scripts/backfill-zora-creator-holders.mjs --schema prod_1 --with-balances --apply
```

`--with-balances` also upserts `user_asset` / `user`. That matters where those rows are missing: the live handler derives its deltas from them, so without it existing holders get recounted as new ones. Block timestamps come from `ponder_sync.blocks`, falling back to RPC only for blocks the sync store lacks. Other flags: `--only-zero`, `--token`, `--limit`, `--chain-id`, `--skip-user-upsert`.

Holders are counted exactly as the live indexer counts them — every address with a positive balance, including contracts such as the pool manager and the coin itself — so backfilled and live rows agree.
